### PR TITLE
fix: use translated name property for listing properties filter label

### DIFF
--- a/packages/cms-base/components/listing-filters/SwFilterProperties.vue
+++ b/packages/cms-base/components/listing-filters/SwFilterProperties.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ListingFilter } from "@shopware-pwa/types";
 import { inject, ref } from "vue";
+import { getTranslatedProperty } from "@shopware-pwa/helpers-next";
 
 defineProps<{
   filter: ListingFilter;
@@ -91,7 +92,7 @@ onClickOutside(dropdownElement, () => (isFilterVisible.value = false));
               class="h-4 w-4 border-gray-300 rounded text-indigo-600 focus:ring-indigo-500"
             />
             <div>
-              {{ option.name }}
+              {{ getTranslatedProperty(option, 'name') }}
             </div>
           </label>
         </div>

--- a/templates/vue-demo-store/components/listing-filters/ListingFiltersProperties.vue
+++ b/templates/vue-demo-store/components/listing-filters/ListingFiltersProperties.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ListingFilter } from "@shopware-pwa/types";
+import { getTranslatedProperty } from "@shopware-pwa/helpers-next";
 
 const { getCurrentFilters } = useListing({
   listingType: "productSearchListing",
@@ -78,7 +79,7 @@ onClickOutside(dropdownElement, () => (isOpen.value = false));
             :for="`filter-mobile-${filter.code}-${option.id}`"
             class="ml-3 min-w-0 flex-1 text-gray-500"
           >
-            {{ option.name }}
+            {{ getTranslatedProperty(option, 'name') }}
           </label>
         </div>
       </div>


### PR DESCRIPTION
I had no text shown for my product properties in the listing filter. Using the translated helper fixed the issue.