### PR TITLE
Implement optional browser endpoint for the api client

### DIFF
--- a/packages/api-client/src/apiService.ts
+++ b/packages/api-client/src/apiService.ts
@@ -42,8 +42,8 @@ export function _createInstance(initialConfig: ClientSettings = {}) {
   const apiService: AxiosInstance = axios.create();
 
   function reloadConfiguration() {
-    apiService.defaults.baseURL = clientConfig.endpoint;
-    apiService.defaults.browserBaseURL = clientConfig.browserEndpoint;
+    const browserBaseUrl = clientConfig.browserEndpoint ?? clientConfig.endpoint;
+    apiService.defaults.baseURL = process.client ? browserBaseUrl :  clientConfig.endpoint;
 
     if (clientConfig.timeout) {
       apiService.defaults.timeout =

--- a/packages/api-client/src/apiService.ts
+++ b/packages/api-client/src/apiService.ts
@@ -43,6 +43,8 @@ export function _createInstance(initialConfig: ClientSettings = {}) {
 
   function reloadConfiguration() {
     apiService.defaults.baseURL = clientConfig.endpoint;
+    apiService.defaults.browserBaseURL = clientConfig.browserEndpoint;
+
     if (clientConfig.timeout) {
       apiService.defaults.timeout =
         (typeof clientConfig.timeout === "number" && clientConfig.timeout) ||

--- a/packages/api-client/src/services/customerService.ts
+++ b/packages/api-client/src/services/customerService.ts
@@ -306,7 +306,7 @@ export async function resetPassword(
   contextInstance: ShopwareApiInstance = defaultInstance
 ): Promise<void> {
   if (params && !params.storefrontUrl) {
-    params.storefrontUrl = contextInstance.config.endpoint;
+    params.storefrontUrl = contextInstance.config.browserEndpoint ?? contextInstance.config.endpoint;
   }
 
   await contextInstance.invoke.post(getCustomerResetPasswordEndpoint(), params);

--- a/packages/api-client/src/services/customerService.ts
+++ b/packages/api-client/src/services/customerService.ts
@@ -306,7 +306,8 @@ export async function resetPassword(
   contextInstance: ShopwareApiInstance = defaultInstance
 ): Promise<void> {
   if (params && !params.storefrontUrl) {
-    params.storefrontUrl = contextInstance.config.browserEndpoint ?? contextInstance.config.endpoint;
+    const browserEndpoint = contextInstance.config.browserEndpoint ?? contextInstance.config.endpoint;
+    params.storefrontUrl = process.client ? browserEndpoint : contextInstance.config.endpoint;;
   }
 
   await contextInstance.invoke.post(getCustomerResetPasswordEndpoint(), params);

--- a/packages/api-client/src/settings.ts
+++ b/packages/api-client/src/settings.ts
@@ -7,6 +7,10 @@ export type ClientSettings = {
    */
   endpoint?: string;
   /**
+   * shopware URL for the browser if the differs from the base endpoint URL
+   */
+  browserEndpoint?: string;
+  /**
    * id specific for each sales channel
    */
   accessToken?: string;
@@ -30,6 +34,7 @@ export type ClientSettings = {
 
 export const defaultConfig: ClientSettings = {
   endpoint: "https://pwa-demo-api.shopware.com/prev/",
+  browserEndpoint: "https://pwa-demo-api.shopware.com/prev/",
   accessToken: "SWSC40-LJTNO6COUEN7CJMXKLA",
   contextToken: "",
   languageId: "",

--- a/packages/nuxt3-module/plugin.ts
+++ b/packages/nuxt3-module/plugin.ts
@@ -23,6 +23,7 @@ const ShopwarePlugin = {
 
     const instance = createInstance({
       endpoint: "<%= options.shopwareEndpoint %>",
+      browserEndpoint: "<%= options.shopwareBrowserEndpoint %>",
       accessToken: "<%= options.shopwareAccessToken %>",
       timeout: "<%= options.shopwareApiClient.timeout %>",
       auth: {


### PR DESCRIPTION
Axios supports a browser base url which should be also configurable via the plugin settings.