### PR TITLE
fix(demo): update useAuthGuard, redirects

### DIFF
--- a/templates/vue-demo-store/components/account/AccountMenu.vue
+++ b/templates/vue-demo-store/components/account/AccountMenu.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { SharedModal } from "~~/components/shared/SharedModal.vue";
-const { isLoggedIn, logout, user, refreshUser } = useUser();
+const { isLoggedIn, logout, user } = useUser();
 const isAccountMenuOpen = ref(false);
 const modal = inject<SharedModal>("modal") as SharedModal;
 

--- a/templates/vue-demo-store/composables/useAuthGuard.ts
+++ b/templates/vue-demo-store/composables/useAuthGuard.ts
@@ -1,8 +1,9 @@
 /**
  * Guard for checking if the user is authenticated.
- * By default it redirects to homepage, but you can pass destination as an argument or edit this composable to suit your needs.
+ * The check is done on the client side only. If the user is not logged in, the user is redirected to the homepage.
+ * If the user is not logged in and a destination is provided, the user is redirected to the destination.
  */
-export function useAuthGuardRedirection(params?: { to: "string" }) {
+export function useAuthGuardRedirection(params?: { to: string }) {
   const { isLoggedIn } = useUser();
   const router = useRouter();
   const { pushInfo } = useNotifications();
@@ -10,9 +11,15 @@ export function useAuthGuardRedirection(params?: { to: "string" }) {
   watch(
     isLoggedIn,
     (isLoggedIn) => {
-      if (!isLoggedIn) {
-        router.push(params?.to || "/");
-        pushInfo(`You're logged out.`);
+      if (process.client && !isLoggedIn) {
+        if (!params?.to) {
+          router.push({ path: "/" });
+          pushInfo(`Login is required to access this page. You are redirected to the homepage.`);
+        }
+        if (params?.to) {
+          router.push({ path: params.to });
+          pushInfo(`You are redirected to ${params.to}.`);
+        }
       }
     },
     {

--- a/templates/vue-demo-store/layouts/account.vue
+++ b/templates/vue-demo-store/layouts/account.vue
@@ -5,7 +5,11 @@ export default {
 </script>
 
 <script setup lang="ts">
-useAuthGuardRedirection();
+const route = useRoute()
+const to = route.query.to as string;
+const params = {to: to}
+
+useAuthGuardRedirection(params);
 
 // Navigation for Account page
 const { loadNavigationElements } = useNavigation();

--- a/templates/vue-demo-store/pages/login.vue
+++ b/templates/vue-demo-store/pages/login.vue
@@ -2,11 +2,13 @@
 const { push } = useRouter();
 const { logout, isLoggedIn } = useUser();
 
-const navigateTo = (path = "/") => push(path);
+const redirectAfterLogin = (path = "/") => push(path);
 
 onBeforeMount(async () => {
-  if (isLoggedIn.value) {
-    await logout();
+  if (process.client && isLoggedIn.value) { // redirect to account page if user is logged in
+    navigateTo({ path: "/account" });
+  } else {
+    await logout(); // if you do a hard reload on the login page, you will be logged out
   }
 });
 
@@ -26,7 +28,7 @@ export default {
 
 <template>
   <div class="login-wrapper">
-    <AccountLoginForm @success="navigateTo('/')">
+    <AccountLoginForm @success="redirectAfterLogin('/')">
       <div class="flex items-center justify-end">
         <div class="text-sm">
           <NuxtLink

--- a/templates/vue-demo-store/pages/login.vue
+++ b/templates/vue-demo-store/pages/login.vue
@@ -2,7 +2,7 @@
 const { push } = useRouter();
 const { logout, isLoggedIn } = useUser();
 
-const redirectAfterLogin = (path = "/") => push(path);
+const redirectAfterLogin = (path = "/account") => push(path);
 
 onBeforeMount(async () => {
   if (process.client && isLoggedIn.value) { // redirect to account page if user is logged in
@@ -28,7 +28,7 @@ export default {
 
 <template>
   <div class="login-wrapper">
-    <AccountLoginForm @success="redirectAfterLogin('/')">
+    <AccountLoginForm @success="redirectAfterLogin('/account')">
       <div class="flex items-center justify-end">
         <div class="text-sm">
           <NuxtLink

--- a/templates/vue-demo-store/pages/register.vue
+++ b/templates/vue-demo-store/pages/register.vue
@@ -11,11 +11,15 @@ import { ClientApiError } from "@shopware-pwa/types";
 
 const { getSalutations } = useSalutations();
 const { getCountries } = useCountries();
-const { register } = useUser();
+const { register, isLoggedIn } = useUser();
 const { pushError } = useNotifications();
 
 const router = useRouter();
 const loading = ref<boolean>();
+
+if (process.client && isLoggedIn.value) { // redirect to account page if user is logged in
+  navigateTo({ path: "/account" });
+}
 
 const state = reactive({
   salutationId: "",


### PR DESCRIPTION
Changes

- If you logged in and try to reach the login page you are redirected to account
- If you logged in and try to reach the register page you are redirected to account
- After log in from login page you are redirected to account instead of homepage
- Params can be used for account page in combination with useAuthGuardRedirection
- useAuthGuardRedirection will only execute if the routing is on client side (on server side the value of isLoggedIn is not correct)