### PR TITLE
feat(demo): improve cms block on mobile

### DIFF
--- a/packages/cms-base/components/public/cms/block/CmsBlockImageTextCover.vue
+++ b/packages/cms-base/components/public/cms/block/CmsBlockImageTextCover.vue
@@ -11,7 +11,7 @@ const leftContent = getSlotContent("left");
 const rightContent = getSlotContent("right");
 </script>
 <template>
-  <article class="grid md:grid-cols-2 gap-10">
+  <article class="md:grid md:grid-cols-2 gap-10">
     <CmsGenericElement
       :content="leftContent"
       class="cms-block-image-text-cover__image"


### PR DESCRIPTION
This will display the 2 column block on mobile in rows underneath (you can then see all the content).

At the moment this is cut in our demo store at this page: 
https://frontends-demo.vercel.app/Summer-Trends/Ice-Cream-Trends/