### PR TITLE
feat: improve images performance and product card design

### DIFF
--- a/.changeset/mighty-dogs-attack.md
+++ b/.changeset/mighty-dogs-attack.md
@@ -1,0 +1,6 @@
+---
+"vue-demo-store": minor
+"@shopware-pwa/cms-base": minor
+---
+
+Images for CMS elements and Product cart are now optimised for displayed size. This is decreasing weight of the whole page. Also small thumbnail of the image is shown.

--- a/.changeset/nasty-elephants-drop.md
+++ b/.changeset/nasty-elephants-drop.md
@@ -1,0 +1,6 @@
+---
+"vue-demo-store": minor
+"@shopware-pwa/cms-base": minor
+---
+
+Product Card design has changed.

--- a/packages/cms-base/components/SwListingProductPrice.vue
+++ b/packages/cms-base/components/SwListingProductPrice.vue
@@ -16,27 +16,31 @@ const regulationPrice = computed(() => price.value?.regulationPrice?.price);
   <div :id="product.id">
     <SharedPrice
       v-if="isListPrice"
-      class="text-xs text-gray-900 basis-2/6 justify-end line-through"
+      class="text-l text-gray-900 basis-2/6 justify-end line-through"
       :value="price?.listPrice?.price"
     />
     <SharedPrice
-      class="text-sm text-gray-900 basis-2/6 justify-end"
+      class="text-xl text-gray-900 basis-2/6 justify-end"
       v-if="displayFromVariants"
       :value="displayFromVariants"
     >
       <template #beforePrice
-        ><span v-if="displayFromVariants">variants from</span></template
+        ><span v-if="displayFromVariants" class="text-sm">from</span></template
       >
     </SharedPrice>
     <SharedPrice
-      class="text-sm text-gray-900 basis-2/6 justify-end"
+      class="text-gray-900 basis-2/6"
       :class="{
-        'text-red': isListPrice,
+        'text-red-600 font-bold': isListPrice,
+        'justify-start text-xl': regulationPrice || !displayFromVariants,
+        'justify-end text-l': !regulationPrice,
       }"
       :value="unitPrice"
     >
       <template #beforePrice
-        ><span v-if="displayFrom || displayFromVariants">to</span></template
+        ><span v-if="displayFrom || displayFromVariants" class="text-sm"
+          >to</span
+        ></template
       >
     </SharedPrice>
     <div class="text-xs flex text-gray-500" v-if="regulationPrice">

--- a/packages/cms-base/components/SwProductCard.vue
+++ b/packages/cms-base/components/SwProductCard.vue
@@ -1,15 +1,10 @@
 <script setup lang="ts">
 import { RouterLink } from "vue-router";
-import {
-  BoxLayout,
-  DisplayMode,
-  useProductPrice,
-} from "@shopware-pwa/composables-next";
+import { BoxLayout, DisplayMode } from "@shopware-pwa/composables-next";
 import {
   getProductName,
   getProductThumbnailUrl,
   getProductUrl,
-  getTranslatedProperty,
   getProductFromPrice,
 } from "@shopware-pwa/helpers-next";
 import {
@@ -74,11 +69,25 @@ const fromPrice = getProductFromPrice(props.product);
 const ratingAverage: Ref<number> = computed(() =>
   props.product.ratingAverage ? Math.round(props.product.ratingAverage) : 0
 );
+
+const imageElement = ref(null);
+const { height } = useElementSize(imageElement);
+
+const DEFAULT_THUMBNAIL_SIZE = 10;
+function roundUp(num: number) {
+  return num ? Math.ceil(num / 100) * 100 : DEFAULT_THUMBNAIL_SIZE;
+}
+
+const srcPath = computed(() => {
+  return `${getProductThumbnailUrl(product.value)}?&height=${roundUp(
+    height.value
+  )}&fit=crop`;
+});
 </script>
 
 <template>
   <div
-    class="sw-product-card group relative max-w-full inline-block p-4"
+    class="sw-product-card group relative max-w-full inline-block max-w-sm bg-white border border-gray-200 rounded-md shadow transform transition duration-300 hover:scale-101"
     data-testid="product-box"
   >
     <div
@@ -87,10 +96,12 @@ const ratingAverage: Ref<number> = computed(() =>
         layoutType === 'image' ? 'h-80' : 'h-60',
       ]"
     >
-      <RouterLink :to="getProductUrl(product)">
+      <RouterLink :to="getProductUrl(product)" class="overflow-hidden">
         <img
-          :src="getProductThumbnailUrl(product)"
+          ref="imageElement"
+          :src="srcPath"
           :alt="getProductName({ product }) || ''"
+          class="transform transition duration-400 hover:scale-120"
           :class="{
             'w-full h-full': true,
             'object-cover':
@@ -108,7 +119,7 @@ const ratingAverage: Ref<number> = computed(() =>
       aria-label="Add to wishlist"
       type="button"
       @click="toggleWishlistProduct"
-      class="absolute top-2 right-2"
+      class="absolute top-2 right-2 hover:animate-count-infinite hover:animate-heart-beat"
       data-testid="product-box-toggle-wishlist-button"
     >
       <client-only>
@@ -127,75 +138,54 @@ const ratingAverage: Ref<number> = computed(() =>
         </template>
       </client-only>
     </button>
-    <div class="mt-4 flex flex-col justify-between flex-1">
-      <div>
-        <h3 class="text-base font-bold text-gray-700">
-          <RouterLink
-            class="line-clamp-2 h-12"
-            :to="getProductUrl(product)"
-            data-testid="product-box-product-name-link"
-          >
-            {{ getProductName({ product }) }}
-          </RouterLink>
-        </h3>
-        <div
-          v-if="layoutType === 'standard'"
-          class="line-clamp-4 mt-2 text-sm text-gray-500 h-20 overflow-hidden"
-          v-html="getTranslatedProperty(product, 'description')"
-          data-testid="product-box-product-description"
-        />
-        <div class="mt-2 flex gap-2 flex-wrap">
-          <span
-            v-for="option in product?.options"
-            :key="(option as PropertyGroupOption).id"
-            class="bg-gray-400 text-sm text-white rounded py-1 px-2"
-            data-testid="product-box-product-options"
-          >
-            {{ (option as PropertyGroupOption).group.name }}:
-            {{ (option as PropertyGroupOption).name }}
-          </span>
-        </div>
-      </div>
-      <div class="flex flex-col mt-3 justify-between">
-        <SwListingProductPrice
-          :product="product"
-          class="ml-auto"
-          data-testid="product-box-product-price"
-        />
-        <div
-          v-if="!isProductListing"
-          class="sw-product-rating inline-flex"
-          data-testid="product-box-product-rating"
-        >
-          <div
-            v-for="value in ratingAverage"
-            class="w-5 h-5 i-carbon-star-filled"
-          ></div>
-          <div
-            v-for="value in 5 - ratingAverage"
-            class="w-5 h-5 i-carbon-star"
-          ></div>
-        </div>
-      </div>
-    </div>
-    <div class="mt-3">
-      <button
-        v-if="!fromPrice"
-        type="button"
-        @click="addToCartProxy"
-        class="mt-3 w-full justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
-        data-testid="add-to-cart-button"
+    <div class="min-h-20px px-2">
+      <span
+        v-for="option in product?.options"
+        :key="option.id"
+        class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10"
       >
-        🛍 Add to cart
-      </button>
-      <RouterLink v-else :to="getProductUrl(product)">
-        <button
-          class="mt-3 w-full justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-black hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
-          data-testid="product-box-product-show-details"
+        {{ (option as PropertyGroupOption).group.name }}:
+        {{ (option as PropertyGroupOption).name }}
+      </span>
+    </div>
+    <div class="px-4 pb-4">
+      <RouterLink
+        class="line-clamp-2"
+        :to="getProductUrl(product)"
+        data-testid="product-box-product-name-link"
+      >
+        <h5
+          class="text-xl font-semibold tracking-tight text-gray-900 dark:text-white min-h-60px"
         >
-          Details
-        </button>
+          {{ getProductName({ product }) }}
+        </h5>
       </RouterLink>
+      <div class="flex items-center justify-between">
+        <div class="">
+          <SwListingProductPrice
+            :product="product"
+            class="ml-auto"
+            data-testid="product-box-product-price"
+          />
+        </div>
+
+        <button
+          v-if="!fromPrice"
+          type="button"
+          @click="addToCartProxy"
+          class="justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-500 hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 transform transition duration-400 md:hover:scale-120"
+          data-testid="add-to-cart-button"
+        >
+          Add to cart
+        </button>
+        <RouterLink
+          v-else
+          :to="getProductUrl(product)"
+          class="justify-center py-2 px-3 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-black hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 transform transition duration-400 hover:scale-120"
+        >
+          <span data-testid="product-box-product-show-details"> Details </span>
+        </RouterLink>
+      </div>
     </div>
   </div>
 </template>

--- a/packages/cms-base/components/SwSlider.vue
+++ b/packages/cms-base/components/SwSlider.vue
@@ -236,13 +236,17 @@ defineExpose({
   <div
     ref="slider"
     :class="{
-      'relative overflow-hidden': true,
+      'relative overflow-hidden h-full': true,
       'px-10': navigationArrowsValue === 'outside',
       'pb-15': navigationDotsValue === 'outside',
       'opacity-0': !isReady,
     }"
   >
-    <div class="overflow-hidden" ref="imageSlider" :style="imageSliderStyle">
+    <div
+      class="overflow-hidden h-full"
+      ref="imageSlider"
+      :style="imageSliderStyle"
+    >
       <div
         ref="imageSliderTrack"
         :class="{
@@ -269,7 +273,7 @@ defineExpose({
             height: displayModeValue === 'standard' ? 'min-content' : '100%',
           }"
         >
-          <component :is="child" />
+          <component :is="child" class="w-[300px]" />
         </div>
       </div>
     </div>

--- a/packages/cms-base/components/public/cms/CmsPage.vue
+++ b/packages/cms-base/components/public/cms/CmsPage.vue
@@ -34,7 +34,7 @@ const DynamicRender = () => {
       content: componentObject.section,
       class: {
         [cssClasses ?? ""]: true,
-        "max-w-screen-xl mx-auto": layoutStyles?.sizingMode === "boxed",
+        "max-w-screen-2xl mx-auto": layoutStyles?.sizingMode === "boxed",
       },
       style: {
         backgroundColor: layoutStyles?.backgroundColor,

--- a/packages/cms-base/components/public/cms/block/CmsBlockProductThreeColumn.vue
+++ b/packages/cms-base/components/public/cms/block/CmsBlockProductThreeColumn.vue
@@ -14,8 +14,8 @@ const centerContent = getSlotContent("center");
 
 <template>
   <div class="grid md:grid-cols-3 gap-10 mx-auto">
-    <CmsGenericElement :content="leftContent" class="md:pr-4 w-full" />
-    <CmsGenericElement :content="centerContent" class="md:pr-4 w-full" />
+    <CmsGenericElement :content="leftContent" class="w-full" />
+    <CmsGenericElement :content="centerContent" class="w-full" />
     <CmsGenericElement :content="rightContent" class="w-full" />
   </div>
 </template>

--- a/packages/cms-base/components/public/cms/element/CmsElementCrossSelling.vue
+++ b/packages/cms-base/components/public/cms/element/CmsElementCrossSelling.vue
@@ -80,7 +80,7 @@ const toggleTab = (index: number) => {
       >
         <SwProductCard
           v-for="product of crossSellCollections[currentTabIndex].products"
-          class="h-[600px]"
+          class="w-[300px]"
           :key="product.id"
           :product="product"
           :layoutType="getConfigValue('boxLayout')"

--- a/packages/cms-base/components/public/cms/element/CmsElementImage.vue
+++ b/packages/cms-base/components/public/cms/element/CmsElementImage.vue
@@ -16,24 +16,41 @@ const {
   imageAttrs,
   imageLink,
 } = useCmsElementImage(props.content);
+
+const DEFAULT_THUMBNAIL_SIZE = 10;
+const imageElement = ref(null);
+const { width, height } = useElementSize(imageElement);
+
+function roundUp(num: number) {
+  return num ? Math.ceil(num / 100) * 100 : DEFAULT_THUMBNAIL_SIZE;
+}
+
+const srcPath = computed(() => {
+  const biggestParam =
+    width.value > height.value
+      ? `width=${roundUp(width.value)}`
+      : `height=${roundUp(height.value)}`;
+  return `${imageAttrs.value.src}?${biggestParam}&fit=crop,smart`;
+});
 </script>
 <template>
   <!-- TODO: using a tag only works with externalLink, need to improve this element to deal with both internalLink & externalLink -->
   <component
     v-if="imageAttrs.src"
-    class="cms-element-image relative"
+    class="cms-element-image relative h-full w-full"
     :is="imageLink.url ? 'a' : 'div'"
     :style="containerStyle"
     v-bind="imageContainerAttrs"
   >
     <img
+      ref="imageElement"
       :class="{
         'h-full w-full': true,
         'absolute inset-0': ['cover', 'stretch'].includes(displayMode),
         'object-cover': displayMode === 'cover',
       }"
-      v-bind="imageAttrs"
       alt="Image link"
+      :src="srcPath"
     />
   </component>
 </template>

--- a/packages/cms-base/components/public/cms/element/CmsElementProductListing.vue
+++ b/packages/cms-base/components/public/cms/element/CmsElementProductListing.vue
@@ -38,13 +38,13 @@ setInitialListing(props?.content?.data?.listing);
   <div class="bg-white">
     <div class="max-w-2xl mx-auto lg:max-w-full">
       <div v-if="getElements.length" class="mt-6">
-        <div class="flex-1 flex-col justify-around">
+        <div class="flex flex-wrap justify-center sm:justify-between">
           <SwProductCard
             v-for="product in getElements"
             :key="product.id"
             :product="product"
             :isProductListing="isProductListing"
-            class="sm:w-6/12 lg:w-3/12 md:max-w-xs"
+            class="w-full sm:w-3/7 lg:w-2/7 mb-8"
           />
         </div>
         <div class="mt-10">

--- a/templates/vue-demo-store/components/layout/LayoutHeader.vue
+++ b/templates/vue-demo-store/components/layout/LayoutHeader.vue
@@ -44,7 +44,7 @@ const sidebarController = useModal();
               to="/wishlist"
             >
               <div
-                class="w-7 h-7 i-carbon-favorite text-gray-600 hover:text-brand-primary"
+                class="w-7 h-7 i-carbon-favorite text-gray-600 hover:text-brand-primary hover:animate-count-infinite hover:animate-heart-beat"
               />
               <span
                 v-if="wishlistCount > 0"

--- a/templates/vue-demo-store/components/product/ProductGallery.vue
+++ b/templates/vue-demo-store/components/product/ProductGallery.vue
@@ -14,7 +14,7 @@ watch(
     content.value = {
       config: {
         minHeight: {
-          value: "300px",
+          value: "600px",
           source: "static",
         },
         navigationArrows: {

--- a/templates/vue-demo-store/components/product/ProductSuggestSearch.vue
+++ b/templates/vue-demo-store/components/product/ProductSuggestSearch.vue
@@ -9,6 +9,24 @@ const props = defineProps<{ product: Product }>();
 
 const { product } = toRefs(props);
 const { unitPrice, displayFrom } = useProductPrice(product);
+
+const DEFAULT_THUMBNAIL_SIZE = 10;
+const imageElement = ref(null);
+const { width, height } = useElementSize(imageElement);
+
+function roundUp(num: number) {
+  return num ? Math.ceil(num / 100) * 100 : DEFAULT_THUMBNAIL_SIZE;
+}
+
+const srcPath = computed(() => {
+  const biggestParam =
+    width.value > height.value
+      ? `width=${roundUp(width.value)}`
+      : `height=${roundUp(height.value)}`;
+  return `${getSmallestThumbnailUrl(
+    product.value.cover.media
+  )}?${biggestParam}&fit=crop,smart`;
+});
 </script>
 <template>
   <div
@@ -16,8 +34,9 @@ const { unitPrice, displayFrom } = useProductPrice(product);
   >
     <div class="rounded-md border-1 border-gray-200 overflow-hidden flex-none">
       <img
+        ref="imageElement"
         data-testid="layout-search-suggest-image"
-        :src="getSmallestThumbnailUrl(product.cover.media)"
+        :src="srcPath"
         class="h-8 w-8 object-cover"
         alt="Product image"
       />


### PR DESCRIPTION
### Description

<!-- Describe the changes you did and which issue you're closing
 example: closes #230
-->
merge after: #179, as prices are not showing correctly without it

- improved images loaded from cloud, mostly in cms, images are rounded up to 100px, so we're not loading new images after minima resize
- simplified card design
- added some animations for
  - cart hover (small scale)
  - add to cart hover
  - wishlist icon hover


#### Sidenote
The code responsible for getting proper image sizes is not abstracted to some shared composable. It's easier to overwrite single components this way and change/remove functionality. We can think about this in future though.

### Type of change

<!--
  Please select the relevant option.
  Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. Read more: https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->
Before:
![image](https://user-images.githubusercontent.com/13100280/234814216-914a5625-a7e6-45b8-8a17-3f4c3d3871a8.png)

After:
![image](https://user-images.githubusercontent.com/13100280/234814315-5a196c3b-6a63-4ae3-b9f4-4a842e2660b7.png)


Variants:
Before:
![image](https://user-images.githubusercontent.com/13100280/234814601-3eff40bf-f711-4c2c-8e6d-568ca29067e7.png)
After:
![image](https://user-images.githubusercontent.com/13100280/234814719-99098d0e-025c-49d8-8efa-d28f07c981ed.png)

Advanced pricing `/CMS/Commerce-element/`:
Before:
![image](https://user-images.githubusercontent.com/13100280/234815412-73f1687b-94ac-4937-bc84-a3c29510f121.png)

After:
![image](https://user-images.githubusercontent.com/13100280/234815586-450e43a6-b9d7-4ba6-bd3b-a7a485c2e6c7.png)

Sale:
Before:
![image](https://user-images.githubusercontent.com/13100280/234815711-18b3856c-e504-4ea9-9132-ea157ffc7dc6.png)


After:
![image](https://user-images.githubusercontent.com/13100280/234815824-faa2e93e-6d25-4bd4-a8a7-4da2d5f32325.png)

