### PR TITLE
fix(nuxt3-module): remove package.json parser

### DIFF
--- a/.changeset/khaki-seas-sin.md
+++ b/.changeset/khaki-seas-sin.md
@@ -1,0 +1,5 @@
+---
+"@shopware-pwa/nuxt3-module": patch
+---
+
+Package.json parser removed

--- a/packages/nuxt3-module/build.config.ts
+++ b/packages/nuxt3-module/build.config.ts
@@ -7,10 +7,5 @@ export default defineBuildConfig({
     cjsBridge: true,
   },
   declaration: true,
-  externals: [
-    "@nuxt/schema",
-    "@nuxt/kit",
-    "@shopware-pwa/composables-next",
-    "package-json-parser",
-  ],
+  externals: ["@nuxt/schema", "@nuxt/kit", "@shopware-pwa/composables-next"],
 });

--- a/packages/nuxt3-module/package.json
+++ b/packages/nuxt3-module/package.json
@@ -48,7 +48,6 @@
     "@nuxt/devtools": "^0.4.6",
     "@nuxt/schema": "^3.4.3",
     "eslint-config-shopware": "workspace:*",
-    "package-json-parser": "^2.2.0",
     "tsconfig": "workspace:*",
     "typescript": "^5.0.4",
     "unbuild": "^1.2.1"

--- a/packages/nuxt3-module/src/utils.ts
+++ b/packages/nuxt3-module/src/utils.ts
@@ -2,7 +2,6 @@ import { Nuxt } from "@nuxt/schema";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "node:url";
 import { promises as fs, constants as FS_CONSTANTS } from "node:fs";
-import packageJson from "package-json-parser";
 
 type DEPENDENCY = "@shopware-pwa/api-client" | "@shopware-pwa/composables-next";
 
@@ -16,15 +15,18 @@ export async function isDependencyInstalledLocally(
 ) {
   try {
     const projectPackageJsonPath = resolve(rootDir, "package.json");
-    const packageJsonDefinition = packageJson.json(projectPackageJsonPath);
+    const packageJson = JSON.parse(
+      await fs.readFile(projectPackageJsonPath, "utf8")
+    );
+
     if (
-      packageJsonDefinition?.dependencies?.[dependency] ||
-      packageJsonDefinition?.devDependencies?.[dependency]
+      packageJson?.dependencies?.[dependency] ||
+      packageJson?.devDependencies?.[dependency]
     ) {
       return true;
     }
   } catch (error) {
-    console.error("nuxt3-module: unable to check local dependencies");
+    console.error("nuxt3-module: unable to check local dependencies", error);
   }
   return false;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -593,9 +593,6 @@ importers:
       eslint-config-shopware:
         specifier: workspace:*
         version: link:../eslint-config-shopware
-      package-json-parser:
-        specifier: ^2.2.0
-        version: 2.2.0
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -5618,7 +5615,7 @@ packages:
   /@types/node-fetch@2.6.3:
     resolution: {integrity: sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==}
     dependencies:
-      '@types/node': 14.18.33
+      '@types/node': 18.16.9
       form-data: 3.0.1
     dev: true
 
@@ -14512,12 +14509,6 @@ packages:
       degenerator: 3.0.4
       ip: 1.1.8
       netmask: 2.0.2
-    dev: true
-
-  /package-json-parser@2.2.0:
-    resolution: {integrity: sha512-yrLg4z/NeyIYTGjH/QFQBmobZUF1FkuxdJy09j7l4PiPEjkxbtRNk1dl88jRvKgW5DGaqQ3azClJNqmQNzPZyg==}
-    dependencies:
-      type-fest: 0.21.3
     dev: true
 
   /pacote@15.1.3:


### PR DESCRIPTION
### Description

removes a dependency responsible for parsing/reading a package.json. the library was replaced by simple fs read function + JSON.parse.

### Type of change

<!--
  Please select the relevant option.
  Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. Read more: https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
