### PR TITLE
fix(demo): mobile view homepage

### DIFF
--- a/packages/cms-base/components/SwListingProductPrice.vue
+++ b/packages/cms-base/components/SwListingProductPrice.vue
@@ -42,6 +42,9 @@ const regulationPrice = computed(() => price.value?.regulationPrice?.price);
       class="text-l text-gray-900 basis-2/6 justify-end line-through"
       :value="price?.listPrice?.price"
     />
+    <template v-if="!isListPrice">
+      <div class="h-6"><!-- placeholder --></div>
+    </template>
     <SwSharedPrice
       class="text-xl text-gray-900 basis-2/6 justify-end"
       v-if="displayFromVariants"
@@ -57,8 +60,8 @@ const regulationPrice = computed(() => price.value?.regulationPrice?.price);
       class="text-gray-900 basis-2/6"
       :class="{
         'text-red-600 font-bold': isListPrice,
-        'justify-start text-xl': regulationPrice || !displayFromVariants,
-        'justify-end text-l': !regulationPrice,
+        'justify-end text-xl':
+          regulationPrice || !regulationPrice || !displayFromVariants,
       }"
       :value="unitPrice"
     >
@@ -68,9 +71,14 @@ const regulationPrice = computed(() => price.value?.regulationPrice?.price);
         }}</span></template
       >
     </SwSharedPrice>
-    <div class="text-xs flex text-gray-500" v-if="regulationPrice">
-      {{ translations.listing.previously }}
-      <SharedPrice class="ml-1" :value="regulationPrice" />
-    </div>
+    <template v-if="regulationPrice">
+      <div class="text-xs flex text-gray-500">
+        {{ translations.listing.previously }}
+        <SharedPrice class="ml-1" :value="regulationPrice" />
+      </div>
+    </template>
+    <template v-if="!regulationPrice">
+      <div class="h-4"><!-- placeholder --></div>
+    </template>
   </div>
 </template>

--- a/packages/cms-base/components/SwProductCard.vue
+++ b/packages/cms-base/components/SwProductCard.vue
@@ -155,30 +155,30 @@ const srcPath = computed(() => {
       <client-only>
         <div
           v-if="isInWishlist"
-          class="h-7 w-7 i-carbon-favorite-filled c-red-500"
+          class="h-9 w-9 i-carbon-favorite-filled c-red-500"
           data-testid="product-box-wishlist-icon-in"
         ></div>
         <div
           v-else
-          class="h-7 w-7 i-carbon-favorite"
+          class="h-9 w-9 i-carbon-favorite c-black"
           data-testid="product-box-wishlist-icon-not-in"
         ></div>
         <template #placeholder>
-          <div class="h-7 w-7 i-carbon-favorite"></div>
+          <div class="h-9 w-9 i-carbon-favorite"></div>
         </template>
       </client-only>
     </button>
-    <div class="min-h-20px px-2">
-      <span
+    <div class="h-8 mx-4 my-2">
+      <p
         v-for="option in product?.options"
         :key="option.id"
-        class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10"
+        class="items-center px-1 py-0 line-clamp-2 rounded-md bg-gray-50 ring-1 ring-inset ring-gray-500/10 text-xs font-medium text-gray-600"
       >
         {{ (option as PropertyGroupOption).group.name }}:
         {{ (option as PropertyGroupOption).name }}
-      </span>
+      </p>
     </div>
-    <div class="px-4 pb-4">
+    <div class="px-4 pb-4 h-52 md:h-32">
       <RouterLink
         class="line-clamp-2"
         :to="getProductRoute(product)"
@@ -190,7 +190,7 @@ const srcPath = computed(() => {
           {{ getProductName({ product }) }}
         </h5>
       </RouterLink>
-      <div class="flex items-center justify-between">
+      <div class="md:flex items-center justify-between">
         <div class="">
           <SwListingProductPrice
             :product="product"
@@ -203,7 +203,7 @@ const srcPath = computed(() => {
           v-if="!fromPrice"
           type="button"
           @click="addToCartProxy"
-          class="justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 transform transition duration-400 md:hover:scale-120 flex"
+          class="justify-center w-full md:w-auto my-8 md-m-0 py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 transform transition duration-400 md:hover:scale-120 flex"
           :class="{
             'text-white bg-blue-500 hover:bg-blue-600': !isInCart,
             'text-gray-500 bg-gray-100': isInCart,
@@ -216,12 +216,12 @@ const srcPath = computed(() => {
             {{ count }}
           </div>
         </button>
-        <RouterLink
-          v-else
-          :to="getProductRoute(product)"
-          class="justify-center py-2 px-3 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-black hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 transform transition duration-400 hover:scale-120"
-        >
-          <span data-testid="product-box-product-show-details"> Details </span>
+        <RouterLink v-else :to="getProductRoute(product)" class="">
+          <button
+            class="justify-center w-full md:w-auto my-8 md-m-0 py-2 px-3 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-black hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 transform transition duration-400 hover:scale-120"
+          >
+            <span data-testid="product-box-product-show-details">Details</span>
+          </button>
         </RouterLink>
       </div>
     </div>

--- a/packages/cms-base/components/SwSlider.vue
+++ b/packages/cms-base/components/SwSlider.vue
@@ -273,7 +273,7 @@ defineExpose({
             height: displayModeValue === 'standard' ? 'min-content' : '100%',
           }"
         >
-          <component :is="child as any" class="w-[300px]" />
+          <component :is="child as any" />
         </div>
       </div>
     </div>

--- a/packages/cms-base/components/public/cms/block/CmsBlockProductThreeColumn.vue
+++ b/packages/cms-base/components/public/cms/block/CmsBlockProductThreeColumn.vue
@@ -13,7 +13,7 @@ const centerContent = getSlotContent("center");
 </script>
 
 <template>
-  <div class="grid md:grid-cols-3 gap-10 mx-auto">
+  <div class="grid md:grid-cols-3 gap-10 place-items-center">
     <CmsGenericElement :content="leftContent" class="w-full" />
     <CmsGenericElement :content="centerContent" class="w-full" />
     <CmsGenericElement :content="rightContent" class="w-full" />

--- a/packages/cms-base/components/public/cms/block/CmsBlockTextTwoColumn.vue
+++ b/packages/cms-base/components/public/cms/block/CmsBlockTextTwoColumn.vue
@@ -12,7 +12,9 @@ const rightContent = getSlotContent("right");
 </script>
 
 <template>
-  <article class="cms-block-text-two-column flex gap-20">
+  <article
+    class="cms-block-text-two-column flex justify-center gap-5 md:gap-20"
+  >
     <CmsGenericElement
       :content="leftContent"
       class="w-1/2 cms-block-text-two-column__text"

--- a/packages/cms-base/components/public/cms/element/CmsElementImageSlider.vue
+++ b/packages/cms-base/components/public/cms/element/CmsElementImageSlider.vue
@@ -11,7 +11,8 @@ const props = defineProps<{
 const items = computed(() => props.content.data.sliderItems);
 </script>
 <template>
-  <div class="cms-element-image-slider">
+  <!-- need some with here for small views that the slider can calculate the correct items with -->
+  <div class="cms-element-image-slider w-[92vw] sm:w-[94vw] md:w-auto">
     <SwSlider :config="props.content.config">
       <CmsElementImage
         v-for="image of items"


### PR DESCRIPTION
### Description

closes: #205

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

### Screenshots (if applicable)

Current Image Slider:
![grafik](https://github.com/shopware/frontends/assets/3763023/316ce1e6-7b94-45bc-90d4-c3f5b21966d9)

Fixed Image Slider:
![grafik](https://github.com/shopware/frontends/assets/3763023/55dd224e-a54d-41d7-8652-d873259ec278)

Current Product Slider:
![grafik](https://github.com/shopware/frontends/assets/3763023/08ed280e-5e7e-4161-898d-c53c4f9fdec3)

Fixed Product Slider:
![grafik](https://github.com/shopware/frontends/assets/3763023/e183016b-2f93-4642-b4d3-a05c8e9f91dd)

Current three column items:
![grafik](https://github.com/shopware/frontends/assets/3763023/78b11452-6e3b-4270-aa94-29c607850e95)

Fixed three column items:
![grafik](https://github.com/shopware/frontends/assets/3763023/92d27c4e-169b-4369-b4eb-22e7da9bf047)

Current two column items:
![grafik](https://github.com/shopware/frontends/assets/3763023/b1b4e22d-e0e5-421f-a918-e20f88ce06aa)

Fixed two column items:
![grafik](https://github.com/shopware/frontends/assets/3763023/d8d2efeb-c9a0-4fe8-9ed6-a03c71f2c827)

### Additional context

* I also improved the product card (and prices) with placeholders so that the cards (height) look the same also when they have different content. I am sure there will be some more work to do when other content is added.
* I made the wishlist icon bigger because google lighthouse was claiming about that it is too small.
