### PR TITLE
fix(demo): remove tmp fix useMeta

### DIFF
--- a/templates/vue-demo-store/composables/useMeta.ts
+++ b/templates/vue-demo-store/composables/useMeta.ts
@@ -1,6 +1,0 @@
-/**
- * TODO: Temp fix until new VueUse published:
- * - https://github.com/vueuse/vueuse/pull/2449
- * - https://github.com/vueuse/vueuse/actions/workflows/publish.yml
- */
-export const useMeta = useHead;

--- a/templates/vue-demo-store/nuxt.config.ts
+++ b/templates/vue-demo-store/nuxt.config.ts
@@ -11,14 +11,6 @@ export default defineNuxtConfig({
       },
     },
   },
-  alias: {
-    /**
-     * TODO: Temp fix until new VueUse published:
-     * - https://github.com/vueuse/vueuse/pull/2449
-     * - https://github.com/vueuse/vueuse/actions/workflows/publish.yml
-     */
-    useMeta: "~/composables/useMeta",
-  },
   /**
    * Commented because of the StackBlitz error
    * Issue: https://github.com/shopware/frontends/issues/88


### PR DESCRIPTION
### Description

Removes a temporary fix that was needed for useMeta because of [this issue](https://github.com/vueuse/vueuse/pull/2449).

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

### Additional context

Tested different pages and was looking at the meta tags in head.
Looks fine after removing these files.
