### PR TITLE
feat(demo): path from main nav to breadcrumb

### DIFF
--- a/packages/composables/src/index.ts
+++ b/packages/composables/src/index.ts
@@ -57,6 +57,7 @@ export * from "./useNavigationSearch";
 export * from "./useWishlist";
 export * from "./useProductWishlist";
 export * from "./useBreadcrumbs";
+export * from "./useBreadcrumbsMainNavigation";
 
 export function resolveCmsComponent(content: CmsSection | CmsBlock | CmsSlot) {
   const componentName = content.type;

--- a/packages/composables/src/useBreadcrumbs.ts
+++ b/packages/composables/src/useBreadcrumbs.ts
@@ -25,9 +25,9 @@ export type UseBreadcrumbsReturn = {
 
 /**
  * Composable for breadcrumbs management.
- * Read the [guide](https://frontends.shopware.com/getting-started/breadcrumbs.html#building-breadcrumbs-for-cms-pages).
+ * Read the [guide](https://frontends.shopware.com/getting-started/page-elements/breadcrumbs.html#building-breadcrumbs-for-cms-pages).
  *
- * It's recommended to use [getCategoryBreadcrumbs](https://frontends.shopware.com/packages/helpers/getCategoryBreadcrumbs) for category breadcrumbs.
+ * It's recommended to use [getCategoryBreadcrumbs](https://github.com/shopware/frontends/blob/main/packages/helpers/src/category/getCategoryBreadcrumbs.ts) for category breadcrumbs.
  *
  * @public
  * @category CMS (Shopping Experiences)

--- a/packages/composables/src/useBreadcrumbsMainNavigation.ts
+++ b/packages/composables/src/useBreadcrumbsMainNavigation.ts
@@ -1,0 +1,114 @@
+import { ComputedRef, computed, isProxy, toRaw } from "vue";
+import { _useContext } from "./internal/_useContext";
+import { StoreNavigationElement } from "@shopware-pwa/types";
+import { Breadcrumb } from "./useBreadcrumbs";
+
+export function useBreadcrumbsMainNavigation(
+  mainNavigation: ComputedRef<StoreNavigationElement[]>,
+  newBreadcrumbs?: Breadcrumb[]
+) {
+  const start = Date.now();
+  // Store for breadcrumbs
+  const _breadcrumbs = _useContext<Breadcrumb[]>("swBreadcrumb", {
+    replace: newBreadcrumbs,
+  });
+
+  /**
+   * Clear breadcrumbs store
+   */
+  const clearBreadcrumbs = () => {
+    _breadcrumbs.value = [];
+  };
+
+  /**
+   * Created breadcrumbs with main-navigation data store
+   */
+  const createdBreadcrumbs = () => {
+    _breadcrumbs.value = [];
+  };
+
+  let breadcrumbRaw = null;
+  if (isProxy(_breadcrumbs.value)) {
+    breadcrumbRaw = toRaw(_breadcrumbs.value);
+  }
+
+  let navigationRaw = null;
+  if (isProxy(mainNavigation.value)) {
+    navigationRaw = toRaw(mainNavigation.value) as StoreNavigationElement[];
+  }
+
+  if (breadcrumbRaw && navigationRaw) {
+    const matchingNodes = findMatchingNodes(breadcrumbRaw, navigationRaw);
+    if (matchingNodes.length > 0) {
+      createdBreadcrumbs.value = extendBreadcrumbWithSeoPath(
+        breadcrumbRaw,
+        matchingNodes
+      );
+    }
+  }
+
+  const end = Date.now();
+  console.log(`Execution time: ${end - start} ms`);
+
+  return {
+    clearBreadcrumbs,
+    breadcrumbs: computed(() => createdBreadcrumbs.value),
+  };
+}
+
+function findMatchingNodes(
+  breadcrumb: Breadcrumb[],
+  nodes: StoreNavigationElement[]
+): StoreNavigationElement[] {
+  const matchingNodes: StoreNavigationElement[] = [];
+  if (breadcrumb.length === 0 || nodes.length === 0) {
+    return matchingNodes;
+  }
+
+  const [currentCrumb, ...remainingCrumbs] = breadcrumb;
+
+  for (const node of nodes) {
+    if (node.name === currentCrumb.name) {
+      matchingNodes.push(node);
+      if (remainingCrumbs.length === 0) {
+        matchingNodes.push(node);
+      } else {
+        if (!node.children) {
+          continue;
+        }
+        const childMatchingNodes = findMatchingNodes(
+          remainingCrumbs,
+          node.children
+        );
+        if (!childMatchingNodes) {
+          continue;
+        }
+        matchingNodes.push(...childMatchingNodes);
+      }
+    }
+  }
+
+  return matchingNodes;
+}
+
+function extendBreadcrumbWithSeoPath(
+  breadcrumb: Breadcrumb[],
+  matchingNodes: StoreNavigationElement[]
+): Breadcrumb[] {
+  const extendedBreadcrumb: Breadcrumb[] = [...breadcrumb];
+
+  for (let i = 0; i < extendedBreadcrumb.length; i++) {
+    const breadcrumbItem = extendedBreadcrumb[i];
+    for (const matchingNode of matchingNodes) {
+      if (
+        matchingNode.name === breadcrumbItem.name &&
+        matchingNode.seoUrls?.[0]?.seoPathInfo
+      ) {
+        breadcrumbItem.path = "/" + matchingNode.seoUrls?.[0]?.seoPathInfo;
+        break;
+      }
+    }
+  }
+
+  return extendedBreadcrumb;
+}

--- a/packages/composables/src/useBreadcrumbsMainNavigation.ts
+++ b/packages/composables/src/useBreadcrumbsMainNavigation.ts
@@ -7,7 +7,6 @@ export function useBreadcrumbsMainNavigation(
   mainNavigation: ComputedRef<StoreNavigationElement[]>,
   newBreadcrumbs?: Breadcrumb[]
 ) {
-  const start = Date.now();
   // Store for breadcrumbs
   const _breadcrumbs = _useContext<Breadcrumb[]>("swBreadcrumb", {
     replace: newBreadcrumbs,
@@ -47,9 +46,6 @@ export function useBreadcrumbsMainNavigation(
     }
   }
 
-  const end = Date.now();
-  console.log(`Execution time: ${end - start} ms`);
-
   return {
     clearBreadcrumbs,
     breadcrumbs: computed(() => createdBreadcrumbs.value),
@@ -69,10 +65,10 @@ function findMatchingNodes(
 
   for (const node of nodes) {
     if (node.name === currentCrumb.name) {
-      matchingNodes.push(node);
       if (remainingCrumbs.length === 0) {
         matchingNodes.push(node);
       } else {
+        matchingNodes.push(node);
         if (!node.children) {
           continue;
         }
@@ -104,6 +100,7 @@ function extendBreadcrumbWithSeoPath(
         matchingNode.name === breadcrumbItem.name &&
         matchingNode.seoUrls?.[0]?.seoPathInfo
       ) {
+        // @ToDo: How to know which seoPathInfo is the main one to push?
         breadcrumbItem.path = "/" + matchingNode.seoUrls?.[0]?.seoPathInfo;
         break;
       }

--- a/templates/vue-demo-store/components/FrontendDetailPage.vue
+++ b/templates/vue-demo-store/components/FrontendDetailPage.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { useProductSearch } from "@shopware-pwa/composables-next";
 import { getCategoryBreadcrumbs } from "@shopware-pwa/helpers-next";
+import {
+  UseNavigationReturn,
+  useBreadcrumbsMainNavigation,
+} from "@shopware-pwa/composables-next";
 
 const props = defineProps<{
   navigationId: string;
@@ -18,13 +22,17 @@ const { data: productResponse } = await useAsyncData(
   }
 );
 
+const mainNavigation = inject(
+  "swNavigation-main-navigation"
+) as ComputedRef<UseNavigationReturn>;
+
 const breadcrumbs = getCategoryBreadcrumbs(
   productResponse.value?.product.seoCategory,
   {
     startIndex: 2,
   }
 );
-useBreadcrumbs(breadcrumbs);
+useBreadcrumbsMainNavigation(mainNavigation, breadcrumbs);
 
 const { product } = useProduct(
   productResponse.value?.product,

--- a/templates/vue-demo-store/components/FrontendNavigationPage.vue
+++ b/templates/vue-demo-store/components/FrontendNavigationPage.vue
@@ -4,6 +4,10 @@ import { useCategorySearch } from "@shopware-pwa/composables-next";
 import { Ref } from "vue";
 import { getCategoryBreadcrumbs } from "@shopware-pwa/helpers-next";
 import { useCmsHead } from "@/composables/useCmsHead";
+import {
+  UseNavigationReturn,
+  useBreadcrumbsMainNavigation,
+} from "@shopware-pwa/composables-next";
 
 const props = defineProps<{
   navigationId: string;
@@ -25,10 +29,14 @@ const { data: categoryResponse } = await useAsyncData(
   }
 );
 
+const mainNavigation = inject(
+  "swNavigation-main-navigation"
+) as ComputedRef<UseNavigationReturn>;
+
 const breadcrumbs = getCategoryBreadcrumbs(categoryResponse.value, {
   startIndex: 2,
 });
-useBreadcrumbs(breadcrumbs);
+useBreadcrumbsMainNavigation(mainNavigation, breadcrumbs);
 
 const { category } = useCategory(categoryResponse as Ref<Category>);
 useCmsHead(category, { mainShopTitle: "Shopware Frontends Demo Store" });


### PR DESCRIPTION
### Description

This new composable is searching for the `seoPathInfo` inside the main navigation tree. And if the breadcrumb name and the category name is matching it will add the path to the breadcrumb object. This is just a workaround until the core returns also the path from the breadcrumb store API call. 

### Type of change

- [X] New feature (non-breaking change which adds functionality)

### Screenshots (if applicable)

![image](https://github.com/shopware/frontends/assets/3763023/bfbc89e5-8637-40e6-9b59-2371afa13e2e)

### Additional context

Only changed in:
- FrontendDetailPage
- FrontendNavigationPage

:warning: I always take the first soePathInfo from seoURLs object. :warning: 

I am also fine with it when this PR will not get merged. 
It was a nice learning (experiment) for me. :pray: 
