### PR TITLE
fix: redirect to the specific variant page

### DIFF
--- a/.changeset/pretty-snakes-travel.md
+++ b/.changeset/pretty-snakes-travel.md
@@ -1,0 +1,6 @@
+---
+"vue-demo-store": patch
+"@shopware-pwa/cms-base": patch
+---
+
+Redirect to the corresponding URL on variant change in PDP

--- a/packages/cms-base/components/SwVariantConfigurator.vue
+++ b/packages/cms-base/components/SwVariantConfigurator.vue
@@ -9,7 +9,7 @@ const props = withDefaults(
     allowRedirect?: boolean;
   }>(),
   {
-    allowRedirect: false,
+    allowRedirect: true,
   }
 );
 
@@ -53,6 +53,7 @@ const onHandleChange = async () => {
   );
   // const selectedOptionsVariantPath = variantFound?.seoUrls?.[0]?.seoPathInfo;
   const selectedOptionsVariantPath = getProductRoute(variantFound);
+  console.warn("onchange", props.allowRedirect, selectedOptionsVariantPath);
   if (props.allowRedirect && selectedOptionsVariantPath) {
     try {
       router.push(selectedOptionsVariantPath);

--- a/templates/vue-demo-store/components/product/ProductVariantConfigurator.vue
+++ b/templates/vue-demo-store/components/product/ProductVariantConfigurator.vue
@@ -7,7 +7,7 @@ const props = withDefaults(
     allowRedirect?: boolean;
   }>(),
   {
-    allowRedirect: false,
+    allowRedirect: true,
   }
 );
 


### PR DESCRIPTION
### Description

Enables "redirect to variant's URL" on variant's change instead of assigning the product object in PDP.

fixes:
- gallery change
- price change

### Type of change

<!--
  Please select the relevant option.
  Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. Read more: https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
