### PR TITLE
feat: audit check improvements

### DIFF
--- a/.github/workflows/audit-check.yml
+++ b/.github/workflows/audit-check.yml
@@ -1,0 +1,39 @@
+name: Audit check
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 8 * * *"
+  push:
+    branches: ["main"]
+    paths:
+      - "pnpm-lock.yaml"
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "pnpm-lock.yaml"
+
+jobs:
+  init:
+    name: Check audit
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - run: corepack enable
+      - run: pnpm --version
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "pnpm"
+          cache-dependency-path: "**/pnpm-lock.yaml"
+      - name: Audit
+        run: pnpm audit

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -67,10 +67,6 @@ jobs:
       - name: Lint
         run: pnpm lint
 
-      - name: Audit
-        if: (${{ success() }} || ${{ failure() }})
-        run: pnpm audit
-
   test:
     name: Test
     timeout-minutes: 15


### PR DESCRIPTION
### Description

<!-- Describe the changes you did and which issue you're closing
 example: closes #230
-->

New GH action to check audit when invoked:
- manually
- every day at 8:30
- when lockfile is changed on a branch or incoming PR

Additionally, the old check has been removed, so not every PR is checked with the audit. Thanks to this if PRs haven't changed any dependencies should not be blocked by the `audit` command.