### PR TITLE
fix: ship api types with the package

### DIFF
--- a/.changeset/pink-donuts-join.md
+++ b/.changeset/pink-donuts-join.md
@@ -1,0 +1,5 @@
+---
+"@shopware/api-client": patch
+---
+
+ship api-types with package

--- a/packages/api-client-next/package.json
+++ b/packages/api-client-next/package.json
@@ -20,7 +20,8 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "api-types"
   ],
   "exports": {
     "import": "./dist/index.mjs"


### PR DESCRIPTION
### Description

<!-- Describe the changes you did and which issue you're closing
 example: closes #230
-->
fix for api-types not included in npm package
