### PR TITLE
chore: dependency changelog script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "postversion": "pnpm run versionReadme",
     "versionReadme": "pnpx ts-node scripts/addChangelogBodyToReadmeFile.ts",
     "taze": "taze major -wr",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "generateDependencyChangelog": "esno ./scripts/generateDependencyChangelog.ts"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4240,7 +4240,7 @@ packages:
       '@nuxt/kit': 3.6.1
       '@nuxt/schema': 3.6.1
       execa: 7.1.1
-      nuxt: 3.6.1(@types/node@20.3.2)(eslint@8.43.0)(typescript@5.1.6)
+      nuxt: 3.6.1(@types/node@20.3.2)(eslint@8.43.0)(typescript@5.1.6)(vue-tsc@1.8.3)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -4309,7 +4309,7 @@ packages:
       launch-editor: 2.6.0
       local-pkg: 0.4.3
       magicast: 0.2.9
-      nuxt: 3.6.1(@types/node@20.3.2)(eslint@8.43.0)(typescript@5.1.6)
+      nuxt: 3.6.1(@types/node@20.3.2)(eslint@8.43.0)(typescript@5.1.6)(vue-tsc@1.8.3)
       nypm: 0.2.1
       pacote: 15.2.0
       pathe: 1.1.1
@@ -14892,99 +14892,6 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
-
-  /nuxt@3.6.1(@types/node@20.3.2)(eslint@8.43.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-IznN+nogCvDuI3IpjXSphdcGBTEeAdpG1iv01inXMWUAeViXhx6FpfPJ2BjQ1WBuahwcUkV2xmMhB3gsv3SLhw==}
-    engines: {node: ^14.18.0 || >=16.10.0}
-    hasBin: true
-    peerDependencies:
-      '@parcel/watcher': ^2.1.0
-      '@types/node': ^14.18.0 || >=16.10.0
-    peerDependenciesMeta:
-      '@parcel/watcher':
-        optional: true
-    dependencies:
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 3.6.1
-      '@nuxt/schema': 3.6.1
-      '@nuxt/telemetry': 2.2.0
-      '@nuxt/ui-templates': 1.2.0
-      '@nuxt/vite-builder': 3.6.1(@types/node@20.3.2)(eslint@8.43.0)(typescript@5.1.6)(vue-tsc@1.8.3)(vue@3.3.4)
-      '@types/node': 20.3.2
-      '@unhead/ssr': 1.1.28
-      '@unhead/vue': 1.1.28(vue@3.3.4)
-      '@vue/shared': 3.3.4
-      acorn: 8.9.0
-      c12: 1.4.2
-      chokidar: 3.5.3
-      cookie-es: 1.0.0
-      defu: 6.1.2
-      destr: 2.0.0
-      devalue: 4.3.2
-      esbuild: 0.18.9
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      fs-extra: 11.1.1
-      globby: 13.2.0
-      h3: 1.7.0
-      hookable: 5.5.3
-      jiti: 1.18.2
-      klona: 2.0.6
-      knitwork: 1.0.0
-      local-pkg: 0.4.3
-      magic-string: 0.30.0
-      mlly: 1.4.0
-      nitropack: 2.5.1
-      nuxi: 3.6.1
-      nypm: 0.2.1
-      ofetch: 1.1.1
-      ohash: 1.1.2
-      pathe: 1.1.1
-      perfect-debounce: 1.0.0
-      prompts: 2.4.2
-      scule: 1.0.0
-      strip-literal: 1.0.1
-      ufo: 1.1.2
-      ultrahtml: 1.2.0
-      uncrypto: 0.1.3
-      unctx: 2.3.1
-      unenv: 1.5.1
-      unimport: 3.0.11(rollup@3.25.2)
-      unplugin: 1.3.1
-      unplugin-vue-router: 0.6.4(vue-router@4.2.2)(vue@3.3.4)
-      untyped: 1.3.2
-      vue: 3.3.4
-      vue-bundle-renderer: 1.0.3
-      vue-devtools-stub: 0.1.0
-      vue-router: 4.2.2(vue@3.3.4)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/kv'
-      - debug
-      - encoding
-      - eslint
-      - less
-      - meow
-      - optionator
-      - rollup
-      - sass
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - typescript
-      - vls
-      - vti
-      - vue-tsc
-    dev: true
 
   /nuxt@3.6.1(@types/node@20.3.2)(eslint@8.43.0)(typescript@5.1.6)(vue-tsc@1.8.3):
     resolution: {integrity: sha512-IznN+nogCvDuI3IpjXSphdcGBTEeAdpG1iv01inXMWUAeViXhx6FpfPJ2BjQ1WBuahwcUkV2xmMhB3gsv3SLhw==}

--- a/scripts/generateDependencyChangelog.ts
+++ b/scripts/generateDependencyChangelog.ts
@@ -1,0 +1,121 @@
+import type { PackageJSON } from "@changesets/types";
+import { getPackages } from "@manypkg/get-packages";
+import { getChangedFilesSince } from "@changesets/git";
+import spawn from "spawndamnit";
+import writeChangeset from "@changesets/write";
+
+async function getJsonFileBaseVersion(
+  filename: string,
+  cwd: string
+): Promise<PackageJSON> {
+  const { stdout, code } = await spawn("git", ["show", `HEAD:./${filename}`], {
+    cwd,
+  });
+
+  const packageJSON = JSON.parse(stdout.toString());
+  return packageJSON;
+}
+
+function createLineDescription(
+  name: string,
+  type: "dependency" | "peerDependency",
+  from: string | undefined,
+  to: string | undefined
+): string {
+  if (from && to) {
+    return ` - Changed ${type} _${name}_ from **${from}** to **${to}**`;
+  }
+  if (from) {
+    return ` - Removed ${type} _${name}_`;
+  }
+  return ` - Added ${type} _${name}_ with version **${to}**`;
+}
+
+async function run() {
+  const repoInfo = await getPackages(__dirname);
+  const rootDir = repoInfo.root.dir;
+  let dependenciesChanged = false;
+
+  const packages = repoInfo.packages.map((pkg) => {
+    const relativeDir = pkg.dir.replace(rootDir + "/", "") + "/package.json";
+
+    return {
+      ...pkg,
+      relativeDir,
+    };
+  });
+
+  const changedFiles = await getChangedFilesSince({
+    cwd: rootDir,
+    ref: "main",
+  });
+
+  const updatedPackages = packages.filter((pkg) => {
+    return changedFiles.includes(pkg.relativeDir);
+  });
+
+  for (const pkg of updatedPackages) {
+    const updatedEntries: string[] = [];
+    const baseVersion = await getJsonFileBaseVersion(pkg.relativeDir, rootDir);
+    // find dependencies which changed and list them
+    const baseDependencies = baseVersion.dependencies || {};
+    const basePeerDependencies = baseVersion.peerDependencies || {};
+    const currentDependencies = pkg.packageJson.dependencies || {};
+    const currentPeerDependencies = pkg.packageJson.peerDependencies || {};
+
+    const allDependenciesChanged = Object.keys(baseDependencies)
+      .concat(Object.keys(currentDependencies))
+      .reduce((acc, key) => {
+        acc.includes(key) ? acc : acc.push(key);
+        return acc;
+      }, [] as string[]);
+    allDependenciesChanged.forEach((dep) => {
+      if (baseDependencies[dep] !== currentDependencies[dep]) {
+        updatedEntries.push(
+          createLineDescription(
+            dep,
+            "dependency",
+            baseDependencies[dep],
+            currentDependencies[dep]
+          )
+        );
+      }
+    });
+    const allPeerDependenciesChanged = Object.keys(basePeerDependencies)
+      .concat(Object.keys(currentPeerDependencies))
+      .reduce((acc, key) => {
+        acc.includes(key) ? acc : acc.push(key);
+        return acc;
+      }, [] as string[]);
+    allPeerDependenciesChanged.forEach((dep) => {
+      if (basePeerDependencies[dep] !== currentPeerDependencies[dep]) {
+        updatedEntries.push(
+          createLineDescription(
+            dep,
+            "peerDependency",
+            basePeerDependencies[dep],
+            currentPeerDependencies[dep]
+          )
+        );
+      }
+    });
+
+    if (updatedEntries.length) {
+      dependenciesChanged = true;
+      const id = await writeChangeset(
+        {
+          summary: `Dependency changes:\n${updatedEntries.join("\n")}`,
+          releases: [{ name: pkg.packageJson.name, type: "patch" }],
+        },
+        rootDir
+      );
+      console.log("Saved dependency changeset: ", id);
+    }
+  }
+
+  if (!dependenciesChanged) {
+    console.log("No dependency changes found");
+  }
+}
+
+run();


### PR DESCRIPTION
### Description

<!-- Describe the changes you did and which issue you're closing
 example: closes #230
-->

Script creates pretty changeset describing dependencies and peerDependencies changes in the package.
Example:

```md
---
"eslint-config-shopware": patch
---

Dependency changes:

- Changed dependency _@typescript-eslint/eslint-plugin_ from **^5.60.1** to **^5.61.0**
- Changed dependency _@typescript-eslint/parser_ from **^5.60.1** to **^5.61.0**
- Changed dependency _eslint_ from **^8.43.0** to **^8.44.0**
```

Which will produce something like this, especially nice to see previous entries to notice the change:
![image](https://github.com/shopware/frontends/assets/13100280/007e254a-6bac-4703-ad72-34bb03b64ad7)


TODO:
- [ ] integrate it after normal `changeset` command to be running automatically