### PR TITLE
fix(cms-base): CMS apply error on missing UnoCSS

### DIFF
--- a/.changeset/chilled-moles-grab.md
+++ b/.changeset/chilled-moles-grab.md
@@ -1,0 +1,5 @@
+---
+"@shopware-pwa/cms-base": patch
+---
+
+Fixed CMS apply error on missing UnoCSS

--- a/packages/cms-base/components/public/cms/block/CmsBlockImageHighlightRow.vue
+++ b/packages/cms-base/components/public/cms/block/CmsBlockImageHighlightRow.vue
@@ -21,6 +21,6 @@ const centerContent = getSlotContent("center");
 
 <style scoped>
 .cms-block-image-highlight-row .cms-element-image {
-  @apply border-12 border-white;
+  @apply border-[12px] border-white;
 }
 </style>

--- a/packages/cms-base/components/public/cms/block/CmsBlockProductHeading.vue
+++ b/packages/cms-base/components/public/cms/block/CmsBlockProductHeading.vue
@@ -20,6 +20,6 @@ const rightContent = getSlotContent("right");
 
 <style scoped>
 .cms-block-product-heading .cms-element-image {
-  @apply max-w-30 max-h-30;
+  @apply max-w-[7.5rem] max-h-[7.5rem];
 }
 </style>


### PR DESCRIPTION
### Description

<!-- Describe the changes you did and which issue you're closing
 example: closes #230
-->

If you don't use UnoCSS with the "cms-base" package, you will get a critical error message and won't be able to use the package.
The changes provided fix this issue.

### Type of change

<!--
  Please select the relevant option.
  Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. Read more: https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots (if applicable)

![image](https://github.com/shopware/frontends/assets/72447403/5f6e9e89-bdf0-4ce0-96b8-80b57a333e02)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->

This changes also fix #305.
