### PR TITLE
feat(e2e): add tests for seo url

### DIFF
--- a/apps/e2e-tests/tests/checkForSeoUrl.spec.ts
+++ b/apps/e2e-tests/tests/checkForSeoUrl.spec.ts
@@ -23,7 +23,7 @@ test.describe.only("Check for seo-url requests", () => {
     await page.waitForLoadState("networkidle");
     await expect(SeoUrlRequest).toBe(false);
     await page
-      .locator("getByRole('link', { name: 'Summer Trends', exact: true })")
+      .getByRole("link", { name: "Summer Trends", exact: true })
       .click();
     await page.waitForLoadState("networkidle");
     await expect(SeoUrlRequest).toBe(false);

--- a/apps/e2e-tests/tests/checkForSeoUrl.spec.ts
+++ b/apps/e2e-tests/tests/checkForSeoUrl.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect, request } from "@playwright/test";
+import { HomePage } from "../page-objects/HomePage";
+
+test.describe.only("Check for seo-url requests", () => {
+  let homePage: HomePage;
+
+  // Before Hook
+  test.beforeEach(async ({ page }) => {
+    homePage = new HomePage(page);
+    await homePage.visitMainPage();
+  });
+
+  test("Check for seo-url requests", async ({ page }) => {
+    await homePage.visitMainPage();
+    await page.waitForLoadState("networkidle");
+    await expect(page.waitForRequest("**/store-api/seo-url")).toThrowError();
+    await homePage.openCartPage();
+    await page.waitForLoadState("networkidle");
+    await expect(page.waitForRequest("**/store-api/seo-url")).toThrowError();
+  });
+});

--- a/apps/e2e-tests/tests/checkForSeoUrl.spec.ts
+++ b/apps/e2e-tests/tests/checkForSeoUrl.spec.ts
@@ -10,7 +10,7 @@ test.describe.only("Check for seo-url requests", () => {
     await homePage.visitMainPage();
   });
 
-  test("Check for seo-url requests", async ({ page }) => {
+  test("should not show any seo-url requests during internal navigation", async ({ page }) => {
     let SeoUrlRequest = false;
     page.on("request", (request) => {
       if (request.url().includes("seo-url")) SeoUrlRequest = true;

--- a/apps/e2e-tests/tests/checkForSeoUrl.spec.ts
+++ b/apps/e2e-tests/tests/checkForSeoUrl.spec.ts
@@ -22,7 +22,9 @@ test.describe.only("Check for seo-url requests", () => {
     await homePage.openCartPage();
     await page.waitForLoadState("networkidle");
     await expect(SeoUrlRequest).toBe(false);
-    await page.goto("/Summer-Trends/");
+    await page
+      .locator("getByRole('link', { name: 'Summer Trends', exact: true })")
+      .click();
     await page.waitForLoadState("networkidle");
     await expect(SeoUrlRequest).toBe(false);
   });

--- a/apps/e2e-tests/tests/checkForSeoUrl.spec.ts
+++ b/apps/e2e-tests/tests/checkForSeoUrl.spec.ts
@@ -11,11 +11,19 @@ test.describe.only("Check for seo-url requests", () => {
   });
 
   test("Check for seo-url requests", async ({ page }) => {
+    let SeoUrlRequest = false;
+    page.on("request", (request) => {
+      if (request.url().includes("seo-url")) SeoUrlRequest = true;
+    });
+
     await homePage.visitMainPage();
     await page.waitForLoadState("networkidle");
-    await expect(page.waitForRequest("**/store-api/seo-url")).toThrowError();
+    await expect(SeoUrlRequest).toBe(false);
     await homePage.openCartPage();
     await page.waitForLoadState("networkidle");
-    await expect(page.waitForRequest("**/store-api/seo-url")).toThrowError();
+    await expect(SeoUrlRequest).toBe(false);
+    await page.goto("/Summer-Trends/");
+    await page.waitForLoadState("networkidle");
+    await expect(SeoUrlRequest).toBe(false);
   });
 });


### PR DESCRIPTION
### Description

<!-- Describe the changes you did and which issue you're closing
 example: closes #230
-->

### Type of change

Related #311 - test for checking `seo-url` during internal navigation