### PR TITLE
fix(api-client): query param arrays

### DIFF
--- a/.changeset/chilly-shirts-exercise.md
+++ b/.changeset/chilly-shirts-exercise.md
@@ -1,0 +1,6 @@
+---
+"@shopware/api-client": patch
+---
+
+Query param arrays. This fixes the way how query params are serialized. Previously, array query params were serialized as `?ids=1&ids=2`, now they are serialized as `?ids[]=1&ids[]=2`. This is the proper way of serialization in the Shopware API.
+The definition of the endpoints hasn't changed, so you don't need to change anything in your code.

--- a/packages/api-client-next/src/index.ts
+++ b/packages/api-client-next/src/index.ts
@@ -169,7 +169,13 @@ export function transformPathToQuery<T extends Record<string, unknown>>(
   });
   const query: Record<string, unknown> = {};
   queryParamNames.forEach((paramName) => {
-    query[paramName] = params[paramName];
+    // API takes array params as `paramName[]`, so multiple params have shape ?paramName[]=1&paramName[]=2
+    // to improve DX we do not require user to add [] to param name, we do it here
+    let queryParamName = paramName;
+    if (Array.isArray(params[paramName]) && !queryParamName.includes("[]")) {
+      queryParamName += "[]";
+    }
+    query[queryParamName] = params[paramName];
   });
 
   const returnOptions = {

--- a/packages/api-client-next/src/transformPathToQuery.test.ts
+++ b/packages/api-client-next/src/transformPathToQuery.test.ts
@@ -2,15 +2,16 @@ import { describe, expect, it } from "vitest";
 import { transformPathToQuery } from ".";
 
 describe("transform path to query request", () => {
-  it("should transform query to request", async () => {
-    const [path, params] = transformPathToQuery(
-      "readCart get /checkout/cart?name",
-      {
-        name: "myId123",
-      },
-    );
-    expect(path).toEqual("/checkout/cart");
-    expect(params).toMatchInlineSnapshot(`
+  describe("transforming query parameters", () => {
+    it("should transform query to request", async () => {
+      const [path, params] = transformPathToQuery(
+        "readCart get /checkout/cart?name",
+        {
+          name: "myId123",
+        },
+      );
+      expect(path).toEqual("/checkout/cart");
+      expect(params).toMatchInlineSnapshot(`
       {
         "headers": {},
         "method": "GET",
@@ -19,6 +20,51 @@ describe("transform path to query request", () => {
         },
       }
     `);
+    });
+
+    it("should add [] to query name if it's an array", () => {
+      const [path, params] = transformPathToQuery(
+        "removeLineItem delete /checkout/cart/line-item?ids",
+        {
+          ids: ["myId123", "myId456"],
+        },
+      );
+      expect(path).toEqual("/checkout/cart/line-item");
+      expect(params).toMatchInlineSnapshot(`
+        {
+          "headers": {},
+          "method": "DELETE",
+          "query": {
+            "ids[]": [
+              "myId123",
+              "myId456",
+            ],
+          },
+        }
+      `);
+    });
+
+    it("should accept query param names if there is already '[]' in the name", () => {
+      const [path, params] = transformPathToQuery(
+        "removeLineItem delete /checkout/cart/line-item?ids[]",
+        {
+          "ids[]": ["myId123", "myId456"],
+        },
+      );
+      expect(path).toEqual("/checkout/cart/line-item");
+      expect(params).toMatchInlineSnapshot(`
+        {
+          "headers": {},
+          "method": "DELETE",
+          "query": {
+            "ids[]": [
+              "myId123",
+              "myId456",
+            ],
+          },
+        }
+      `);
+    });
   });
 
   it("should transform path param", async () => {


### PR DESCRIPTION
### Description

<!-- Describe the changes you did and which issue you're closing
 example: closes #230
-->

### Type of change

<!--
  Please select the relevant option.
  Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. Read more: https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation
-->
Fixes query param arrays. This fixes the way how query params are serialized. Previously, array query params were serialized as `?ids=1&ids=2`, now they are serialized as `?ids[]=1&ids[]=2`. This is the proper way of serialization in the Shopware API.
The definition of the endpoints hasn't changed, so you don't need to change anything in your code.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
