### PR TITLE
fix: regex for disable inputs plugin

### DIFF
--- a/packages/vite-vue-plugin-disable-inputs/src/index.ts
+++ b/packages/vite-vue-plugin-disable-inputs/src/index.ts
@@ -44,7 +44,9 @@ function VueDisableInputsBeforeMount(): PluginOption {
         );
 
         const foundSelectElements =
-          component.match(/<(select|input|button)(.*\s?)([\s\S]*?)?\>/gm) || [];
+          component.match(
+            /<(select|input|button)[^>]*>(.*?)<\/(select|input|button)>/gm,
+          ) || [];
 
         for (const selectBlock of foundSelectElements) {
           if (hasDisabled(selectBlock)) {


### PR DESCRIPTION
### Description

closes #329

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

### Additional context

For review maybe @kstala and @mkucmus are needed.

I just tested the regex.

![image](https://github.com/shopware/frontends/assets/3763023/501f4338-fc33-4334-b662-a63458fa42a9)

