### PR TITLE
feat(vue-demo-store): disable vite plugin

### DIFF
--- a/packages/vite-vue-plugin-disable-inputs/README.md
+++ b/packages/vite-vue-plugin-disable-inputs/README.md
@@ -4,6 +4,10 @@ Test your Vue applications with Playwright without worrying that Playwright is t
 
 Thanks to this plugin all inputs and buttons are initially disabled until application is mounted. So nothing can be invoked by playwright too early causing tests to fail.
 
+## ⚠️ DEPRECATED
+
+Using [expect.toPass](https://playwright.dev/docs/test-assertions#expecttopass) seems to be a better, and less invasive solution in order to achieve the same goal. Even though an app is not mounted, `toPass` assertion will retry the same test block, reflecting more human behavior, when for instance, some button is not active, an user will try to click it twice.
+
 ## Installation
 
 Add the package as `devDependency` using your favorite package manager:

--- a/packages/vite-vue-plugin-disable-inputs/package.json
+++ b/packages/vite-vue-plugin-disable-inputs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-vue-plugin-disable-inputs",
   "version": "0.1.1",
-  "description": "Disable input elements before mount",
+  "description": "Disable input elements before mount. DEPRECATED.",
   "author": "Shopware",
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -920,9 +920,6 @@ importers:
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
-      vite-vue-plugin-disable-inputs:
-        specifier: canary
-        version: link:../../packages/vite-vue-plugin-disable-inputs
       vue-eslint-parser:
         specifier: ^9.3.1
         version: 9.3.1(eslint@8.45.0)

--- a/templates/vue-demo-store/nuxt.config.ts
+++ b/templates/vue-demo-store/nuxt.config.ts
@@ -1,5 +1,4 @@
 import i18nConfig from "./i18n/src/config";
-import { VueDisableInputsBeforeMount } from "vite-vue-plugin-disable-inputs";
 // https://v3.nuxtjs.org/docs/directory-structure/nuxt.config
 export default defineNuxtConfig({
   runtimeConfig: {
@@ -99,8 +98,5 @@ export default defineNuxtConfig({
     defaultLocale: i18nConfig.defaultLocale,
     langDir: "i18n/src/",
     locales: i18nConfig.locales,
-  },
-  vite: {
-    plugins: [VueDisableInputsBeforeMount()],
   },
 });

--- a/templates/vue-demo-store/package.json
+++ b/templates/vue-demo-store/package.json
@@ -36,7 +36,6 @@
     "eslint-plugin-vue": "^9.15.1",
     "nuxt": "^3.6.3",
     "typescript": "^5.1.6",
-    "vite-vue-plugin-disable-inputs": "canary",
     "vue-eslint-parser": "^9.3.1",
     "vue-tsc": "^1.8.5"
   },


### PR DESCRIPTION
### Description

disables vite plugin for nuxt template.

@patzick - after release, please [mark npm package as deprecated](https://docs.npmjs.com/deprecating-and-undeprecating-packages-or-package-versions) in package settings with appropriate message.

### Type of change

<!--
  Please select the relevant option.
  Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. Read more: https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
