### PR TITLE
feat: deprecate vue3 plugin

### DIFF
--- a/.changeset/afraid-flowers-search.md
+++ b/.changeset/afraid-flowers-search.md
@@ -1,0 +1,5 @@
+---
+"vue-vite-blank": patch
+---
+
+Change the way how Shopware Context plugin is created

--- a/.changeset/six-weeks-travel.md
+++ b/.changeset/six-weeks-travel.md
@@ -1,0 +1,5 @@
+---
+"@shopware-pwa/vue3-plugin": patch
+---
+
+Mark package as deprecated

--- a/packages/vue3-plugin/README.md
+++ b/packages/vue3-plugin/README.md
@@ -1,0 +1,5 @@
+# Frontends plugin for Vue 3
+
+## ⚠️ DEPRECATED
+
+The plugin can be created by using `creatingInstance` method of `@shopware-pwa/composables-next` package. [See the details](https://www.npmjs.com/package/@shopware-pwa/composables-next).

--- a/packages/vue3-plugin/README.md
+++ b/packages/vue3-plugin/README.md
@@ -2,4 +2,4 @@
 
 ## ⚠️ DEPRECATED
 
-The plugin can be created by using `creatingInstance` method of `@shopware-pwa/composables-next` package. [See the details](https://www.npmjs.com/package/@shopware-pwa/composables-next).
+The plugin can be created by using `createInstance` method of `@shopware-pwa/composables-next` package. [See the details](https://www.npmjs.com/package/@shopware-pwa/composables-next).

--- a/packages/vue3-plugin/package.json
+++ b/packages/vue3-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopware-pwa/vue3-plugin",
   "version": "0.1.36",
-  "description": "Shopware Fromends Vue3 plugin",
+  "description": "Shopware Frontends plugin for Vue 3. DEPRECATED.",
   "author": "Shopware",
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -929,6 +929,9 @@ importers:
 
   templates/vue-vite-blank:
     dependencies:
+      '@shopware-pwa/api-client':
+        specifier: canary
+        version: link:../../packages/api-client
       '@shopware-pwa/composables-next':
         specifier: canary
         version: link:../../packages/composables

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -932,9 +932,6 @@ importers:
       '@shopware-pwa/composables-next':
         specifier: canary
         version: link:../../packages/composables
-      '@shopware-pwa/vue3-plugin':
-        specifier: canary
-        version: link:../../packages/vue3-plugin
       vue:
         specifier: ^3.3.4
         version: 3.3.4

--- a/templates/vue-vite-blank/package.json
+++ b/templates/vue-vite-blank/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@shopware-pwa/api-client": "canary",
     "@shopware-pwa/composables-next": "canary",
-    "@shopware-pwa/vue3-plugin": "canary",
     "vue": "^3.3.4"
   },
   "devDependencies": {

--- a/templates/vue-vite-blank/src/main.ts
+++ b/templates/vue-vite-blank/src/main.ts
@@ -1,18 +1,24 @@
 import { createApp } from "vue";
 import "./style.css";
 import App from "./App.vue";
-import ShopwareContext, {
-  ShopwareFrontendsOptions,
-} from "@shopware-pwa/vue3-plugin";
+
+import { createShopwareContext } from "@shopware-pwa/composables-next";
+import { createInstance } from "@shopware-pwa/api-client";
+
+const apiInstance = createInstance({
+  endpoint: import.meta.env.VITE_DEMO_API_URL,
+  accessToken: import.meta.env.VITE_DEMO_API_ACCESS_TOKEN,
+});
 
 const app = createApp(App);
 
 // setup shopware plugin
-const options: ShopwareFrontendsOptions = {
-  shopwareEndpoint: import.meta.env.VITE_DEMO_API_URL,
-  shopwareAccessToken: import.meta.env.VITE_DEMO_API_ACCESS_TOKEN,
-};
-// register the plugin
-app.use(ShopwareContext, options);
+const shopwareContext = createShopwareContext(app, {
+  apiInstance,
+  // devStorefrontUrl: "https://your-sales-channel-configured-domain.com",
+});
+
+// register a plugin in a Vue instance
+app.use(shopwareContext);
 
 app.mount("#app");


### PR DESCRIPTION
### Description

closes: #350 

working stackblitz instance: https://stackblitz.com/github/shopware/frontends/tree/feat/deprecate-vue3-plugin/templates/vue-vite-blank

after release, only requirement is to set the package as deprecated in npm settings

### Type of change

<!--
  Please select the relevant option.
  Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. Read more: https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
