### PR TITLE
feat(api-client): access admin client session data and change in in the runtime

### DIFF
--- a/.changeset/calm-hounds-heal.md
+++ b/.changeset/calm-hounds-heal.md
@@ -1,0 +1,5 @@
+---
+"@shopware/api-client": minor
+---
+
+Added `getSessionData` and `setSessionData` methods in admin API client for test purposes.

--- a/packages/api-client-next/package.json
+++ b/packages/api-client-next/package.json
@@ -25,7 +25,10 @@
     "admin-api-types"
   ],
   "exports": {
-    "import": "./dist/index.mjs"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs"
+    }
   },
   "scripts": {
     "build": "export NODE_ENV=production && unbuild && pnpm build:types",

--- a/packages/api-client-next/src/adminSessionData.test.ts
+++ b/packages/api-client-next/src/adminSessionData.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test as baseTest } from "vitest";
+import { createAdminAPIClient } from ".";
+import { operations, operationPaths } from "../admin-api-types";
+
+const baseURL = "https://demo-frontends.shopware.store/store-api";
+
+const test = baseTest.extend<{
+  adminApiClient: ReturnType<
+    typeof createAdminAPIClient<operations, operationPaths>
+  >;
+}>({
+  adminApiClient: async ({}, use) => {
+    // setup the fixture before each test function
+    const adminApiClient = createAdminAPIClient<operations, operationPaths>({
+      baseURL,
+    });
+
+    // use the fixture value
+    await use(adminApiClient);
+  },
+});
+
+describe("Admin client session data", () => {
+  test("setting session data should return changed data", async ({
+    adminApiClient,
+  }) => {
+    const newData = adminApiClient.setSessionData({
+      accessToken: "123",
+      expirationTime: 456,
+      refreshToken: "789",
+    });
+
+    expect(newData).toEqual({
+      accessToken: "123",
+      expirationTime: 456,
+      refreshToken: "789",
+    });
+  });
+
+  test("fresh test should have empty session data", async ({
+    adminApiClient,
+  }) => {
+    expect(adminApiClient.getSessionData()).toEqual({
+      accessToken: "",
+      expirationTime: 0,
+      refreshToken: "",
+    });
+  });
+
+  test("setSessionData should affect getSessionData", async ({
+    adminApiClient,
+  }) => {
+    adminApiClient.setSessionData({
+      accessToken: "123",
+      expirationTime: 456,
+      refreshToken: "789",
+    });
+
+    expect(adminApiClient.getSessionData()).toEqual({
+      accessToken: "123",
+      expirationTime: 456,
+      refreshToken: "789",
+    });
+  });
+});

--- a/packages/api-client-next/src/index.ts
+++ b/packages/api-client-next/src/index.ts
@@ -188,6 +188,18 @@ export function createAdminAPIClient<
     }
   }
 
+  function setSessionData(data: AdminSessionData): AdminSessionData {
+    sessionData.accessToken = data.accessToken;
+    sessionData.refreshToken = data.refreshToken;
+    sessionData.expirationTime = data.expirationTime;
+
+    return getSessionData();
+  }
+
+  function getSessionData() {
+    return { ...sessionData };
+  }
+
   const defaultHeaders = {
     Authorization: createAuthorizationHeader(sessionData.accessToken),
   };
@@ -257,7 +269,19 @@ export function createAdminAPIClient<
   }
 
   return {
+    /**
+     * Invoke API request based on provided path definition.
+     */
     invoke,
+    /**
+     * Enables to change session data in runtime. Useful for testing purposes.
+     * Setting session data with this methis will **not** fire `onAuthChange` hook.
+     */
+    setSessionData,
+    /**
+     * Returns current session data. Useful for testing purposes, as in most cases you'll want to use `onAuthChange` hook for that.
+     */
+    getSessionData,
   };
 }
 


### PR DESCRIPTION

### Description

Idea from @jleifeld

Creates the ability to access and change admin client session data for testing purposes. This comes with fixture example of creating a new API instance per test