### PR TITLE
fix(composables): adds parameter to loadMore to accept an optional query

### DIFF
--- a/.changeset/chilly-cameras-speak.md
+++ b/.changeset/chilly-cameras-speak.md
@@ -1,0 +1,5 @@
+---
+"@shopware-pwa/composables-next": patch
+---
+
+Adds the ability to specify a query for the loadMore function in the useListing composable.

--- a/packages/composables/src/useListing.ts
+++ b/packages/composables/src/useListing.ts
@@ -81,7 +81,7 @@ export type UseListingReturn<ELEMENTS_TYPE> = {
   /**
    * Loads more (next page) elements to the listing
    */
-  loadMore(): Promise<void>;
+  loadMore(query?: Partial<ShopwareSearchParams>): Promise<void>;
   /**
    * Listing that is currently set
    */
@@ -305,15 +305,19 @@ export function createListingComposable<ELEMENTS_TYPE>({
     }
   }
 
-  const loadMore = async (): Promise<void> => {
+  const loadMore = async (
+    query?: Partial<ShopwareSearchParams>,
+  ): Promise<void> => {
     loadingMore.value = true;
     try {
-      const query = {
-        // ...router.currentRoute.query,
-        p: getCurrentPage.value + 1,
-      };
+      const q = query
+        ? query
+        : {
+            // ...router.currentRoute.query,
+            p: getCurrentPage.value + 1,
+          };
 
-      const searchCriteria = merge({}, searchDefaults, query);
+      const searchCriteria = merge({}, searchDefaults, q);
       const result = await searchMethod(searchCriteria);
       _storeAppliedListing.value = {
         ...getCurrentListing.value,


### PR DESCRIPTION
### Description

I'm marking this as a bugfix, as I assume it was not intended for the function to not have a query parameter. Should close #379.

The current problem is that filters, if set, will not be applied to the query on loadMore. This means, that when using a non-pagination style of content fetching, the functionality breaks there. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Additional context

I was trying to follow the contributing guidelines as well as I could, but please check if I missed something when making this edit (like documentation or something like that).
