### PR TITLE
fix(nuxt3-module): problem with autoloading composables within shopware plugin

### DIFF
--- a/.changeset/gentle-vans-tell.md
+++ b/.changeset/gentle-vans-tell.md
@@ -1,0 +1,5 @@
+---
+"@shopware-pwa/nuxt3-module": patch
+---
+
+Load composables explicitly within the shopware plugin

--- a/packages/nuxt3-module/plugin.ts
+++ b/packages/nuxt3-module/plugin.ts
@@ -37,7 +37,7 @@ const ShopwarePlugin = {
       !runtimeConfig.public?.shopware?.shopwareAccessToken
     ) {
       throw new Error(
-        "Make sure that shopwareEndpoint and shopwareAccessToken are settled in the configuration"
+        "Make sure that shopwareEndpoint and shopwareAccessToken are settled in the configuration",
       );
     }
 

--- a/packages/nuxt3-module/plugin.ts
+++ b/packages/nuxt3-module/plugin.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { defineNuxtPlugin } from "#app";
+import { defineNuxtPlugin, useRuntimeConfig, useCookie, useState } from "#app";
 import {
   createShopwareContext,
   getDefaultApiParams,
@@ -37,7 +37,7 @@ const ShopwarePlugin = {
       !runtimeConfig.public?.shopware?.shopwareAccessToken
     ) {
       throw new Error(
-        "Make sure that shopwareEndpoint and shopwareAccessToken are settled in the configuration",
+        "Make sure that shopwareEndpoint and shopwareAccessToken are settled in the configuration"
       );
     }
 


### PR DESCRIPTION


### Description
solved this problem:
![image](https://github.com/shopware/frontends/assets/5596960/205b93ab-52a0-4d6a-a57c-5ea7cf65ba6d)

### Type of change

<!--
  Please select the relevant option.
  Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. Read more: https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
