### PR TITLE
fix(demo-store): nuxt warnings

### DIFF
--- a/templates/vue-demo-store/composables/useCartNotification.ts
+++ b/templates/vue-demo-store/composables/useCartNotification.ts
@@ -2,7 +2,7 @@ import { CartErrors } from "@shopware-pwa/types";
 
 const successCodes = ["promotion-discount-added"];
 
-export type UseCmsHeadReturn = {
+export type useCartNotificationReturn = {
   codeErrorsNotification(): void;
 };
 
@@ -11,7 +11,7 @@ export type UseCmsHeadReturn = {
  *
  * @returns
  */
-export function useCartNotification() {
+export function useCartNotification(): useCartNotificationReturn {
   const { pushError, pushSuccess } = useNotifications();
   const { consumeCartErrors } = useCart();
 

--- a/templates/vue-demo-store/nuxt.config.ts
+++ b/templates/vue-demo-store/nuxt.config.ts
@@ -76,7 +76,12 @@ export default defineNuxtConfig({
   ],
   // components: true,
   components: {
-    dirs: ["~/components"],
+    dirs: [
+      {
+        path: "~/components",
+        priority: 2,
+      },
+    ],
     global: true,
   },
   vueuse: {


### PR DESCRIPTION
### Description
closes #391
and 
Fixes a warning with UseCmsHeadReturn.

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

### Additional context
The components priority for the demo-store (2) is higher than from cms-base package with components (0/1).
