### PR TITLE
feat(e2e): add slack notification only on fail

### DIFF
--- a/.github/workflows/failed-job-check.yml
+++ b/.github/workflows/failed-job-check.yml
@@ -1,0 +1,20 @@
+name: Check for jobs failure
+on:
+  workflow_run:
+    workflows: [Code examples, Lighthouse CI, Vue vite blank, Vue Blank, Vue demo store, Audit check]
+    types: [completed]
+    branches: [main,prod]
+
+jobs:
+  on-failure:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out'
+    steps:
+      - uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ github.event.workflow_run.conclusion }}
+          notification_title: " ${{github.event.workflow_run.name}} - ${{github.event.workflow_run.conclusion}} on ${{github.event.workflow_run.head_branch}} - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>"
+          message_format: ":fire: *${{github.event.workflow_run.name}}* ${{github.event.workflow_run.conclusion}} in <${{github.server_url}}/${{github.repository}}/${{github.event.workflow_run.head_branch}}|${{github.repository}}>"
+          footer: "Linked Repo <${{github.server_url}}/${{github.repository}}|${{github.repository}}> | <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.FAIL_SLACK_URL }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -3,7 +3,7 @@ run-name: run Lighthouse CI 🚀
 on: 
   workflow_dispatch:
   schedule:
-    - cron: '59 23 * * *'
+    - cron: '55 23 * * *'
 jobs:
   lighthouseci:
     runs-on: ubuntu-latest

--- a/.github/workflows/vue-blank.yml
+++ b/.github/workflows/vue-blank.yml
@@ -4,7 +4,7 @@ run-name: Playwright is testing vue blank 🚀
 on: 
   workflow_dispatch:
   schedule:
-    - cron: '54 23 * * *'
+    - cron: '51 23 * * *'
 jobs:
   run-code_examples-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/vue-demo-store.yml
+++ b/.github/workflows/vue-demo-store.yml
@@ -4,7 +4,7 @@ run-name: Playwright is testing vue demo store 🚀
 on: 
   workflow_dispatch:
   schedule:
-    - cron: '52 23 * * *'
+    - cron: '49 23 * * *'
 jobs:
   run-code_examples-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/vue-vite-blank.yml
+++ b/.github/workflows/vue-vite-blank.yml
@@ -4,7 +4,7 @@ run-name: Playwright is testing vue vite blank 🚀
 on: 
   workflow_dispatch:
   schedule:
-    - cron: '50 23 * * *'
+    - cron: '46 23 * * *'
 jobs:
   run-code_examples-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add slack notification only on fail jobs (Code examples, Lighthouse CI, Vue vite blank, Vue Blank, Vue demo store, Audit check)
![image](https://github.com/shopware/frontends/assets/30267600/58d0e149-444f-48a7-9e05-d55b6957be7b)


!!! add webhook slack channel url to github secret (name FAIL_SLACK_URL)


After taking all PR actions, you can run the unsubscribe command for this repository from the Slack channel

<!-- Describe the changes you did and which issue you're closing
 example: closes #230
-->

### Type of change

<!--
  Please select the relevant option.
  Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. Read more: https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
