### PR TITLE
feat(cms-base): Improve CmsElementImage

### DIFF
--- a/.changeset/popular-spies-raise.md
+++ b/.changeset/popular-spies-raise.md
@@ -1,0 +1,6 @@
+---
+"@shopware-pwa/composables-next": minor
+"@shopware-pwa/cms-base": minor
+---
+
+Adding the missing srcset attribute to the image tag in the CmsElementImage component. as well as adding support for HTML video elements as in Shopware management, it is possible for users to associate videos to any Cms image element.

--- a/packages/cms-base/components/public/cms/element/CmsElementImage.vue
+++ b/packages/cms-base/components/public/cms/element/CmsElementImage.vue
@@ -59,8 +59,9 @@ const imageComputedContainerAttrs = computed(() => {
         'absolute inset-0': ['cover', 'stretch'].includes(displayMode),
         'object-cover': displayMode === 'cover',
       }"
-      alt="Image link"
+      :alt="imageAttrs.alt"
       :src="srcPath"
+      :srcset="imageAttrs.srcset"
     />
   </component>
 </template>

--- a/packages/cms-base/components/public/cms/element/CmsElementImage.vue
+++ b/packages/cms-base/components/public/cms/element/CmsElementImage.vue
@@ -16,6 +16,8 @@ const {
   imageContainerAttrs,
   imageAttrs,
   imageLink,
+  isVideoElement,
+  mimeType,
 } = useCmsElementImage(props.content);
 
 const DEFAULT_THUMBNAIL_SIZE = 10;
@@ -51,7 +53,20 @@ const imageComputedContainerAttrs = computed(() => {
     :style="containerStyle"
     v-bind="imageComputedContainerAttrs"
   >
+    <video
+      v-if="isVideoElement"
+      controls
+      :class="{
+        'h-full w-full': true,
+        'absolute inset-0': ['cover', 'stretch'].includes(displayMode),
+        'object-cover': displayMode === 'cover',
+      }"
+    >
+      <source :src="imageAttrs.src" :type="mimeType" />
+      Your browser does not support the video tag.
+    </video>
     <img
+      v-else
       ref="imageElement"
       loading="lazy"
       :class="{

--- a/packages/composables/src/cms/useCmsElementImage.ts
+++ b/packages/composables/src/cms/useCmsElementImage.ts
@@ -27,6 +27,8 @@ export type UseCmsElementImage = {
   imageContainerAttrs: ComputedRef<ImageContainerAttrs>;
   imageLink: ComputedRef<{ newTab: boolean; url: string }>;
   displayMode: ComputedRef<DisplayMode>;
+  isVideoElement: ComputedRef<boolean>;
+  mimeType: ComputedRef<string>;
 };
 
 /**
@@ -77,6 +79,14 @@ export function useCmsElementImage(
     () => getConfigValue("displayMode") || "initial",
   );
 
+  const isVideoElement = computed(() => {
+    return !!element.data?.media?.mimeType?.includes("video");
+  });
+
+  const mimeType = computed(() => {
+    return element.data?.media?.mimeType;
+  });
+
   return {
     containerStyle,
     anchorAttrs,
@@ -84,5 +94,7 @@ export function useCmsElementImage(
     imageContainerAttrs,
     imageLink,
     displayMode,
+    isVideoElement,
+    mimeType,
   };
 }


### PR DESCRIPTION
### Description

<!-- Describe the changes you did and which issue you're closing
 example: closes #230
-->
Add missing srcset attribute to image tag in the CmsElementImage component. as well as adding support for html video elements as in Shopware administration it is possible for users to assign videos to any cms image element. 

### Type of change

<!--
  Please select the relevant option.
  Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. Read more: https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
