### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/.changeset/tame-ears-joke.md
+++ b/.changeset/tame-ears-joke.md
@@ -1,0 +1,5 @@
+---
+"@shopware-pwa/nuxt3-module": patch
+---
+
+This improves performance slightly when developing; we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.

--- a/examples/adyen-dropin-component/components/AdyenCreditCard.vue
+++ b/examples/adyen-dropin-component/components/AdyenCreditCard.vue
@@ -7,7 +7,7 @@ import {
   useShopwareContext,
   useRuntimeConfig,
 } from "#imports";
-import { useNuxtApp } from "#app";
+import { useNuxtApp } from "#imports";
 
 const emits = defineEmits<{
   // to inform the upper levels of an app that payButton was clicked (that means it was validated by Adyen and we can proceed)

--- a/examples/adyen-dropin-component/components/AdyenCreditCard.vue
+++ b/examples/adyen-dropin-component/components/AdyenCreditCard.vue
@@ -3,11 +3,11 @@ import "@adyen/adyen-web/dist/adyen.css";
 import type { SessionContext } from "@shopware-pwa/types";
 import {
   onMounted,
+  useNuxtApp,
   useSessionContext,
   useShopwareContext,
   useRuntimeConfig,
 } from "#imports";
-import { useNuxtApp } from "#imports";
 
 const emits = defineEmits<{
   // to inform the upper levels of an app that payButton was clicked (that means it was validated by Adyen and we can proceed)

--- a/examples/adyen-dropin-component/plugins/AdyenCheckout.client.ts
+++ b/examples/adyen-dropin-component/plugins/AdyenCheckout.client.ts
@@ -1,5 +1,4 @@
-import { defineNuxtPlugin } from "#imports";
-import { useRuntimeConfig } from "#imports";
+import { defineNuxtPlugin, useRuntimeConfig } from "#imports";
 import AdyenCheckout from "@adyen/adyen-web";
 import { defu } from "defu";
 

--- a/examples/adyen-dropin-component/plugins/AdyenCheckout.client.ts
+++ b/examples/adyen-dropin-component/plugins/AdyenCheckout.client.ts
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin } from "#app";
+import { defineNuxtPlugin } from "#imports";
 import { useRuntimeConfig } from "#imports";
 import AdyenCheckout from "@adyen/adyen-web";
 import { defu } from "defu";

--- a/examples/mollie-credit-card/src/runtime/plugins/plugin.client.ts
+++ b/examples/mollie-credit-card/src/runtime/plugins/plugin.client.ts
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin } from "#app";
+import { defineNuxtPlugin } from "#imports";
 import { useRuntimeConfig } from "#imports";
 import { CreateLocaleInstanceArgs, MolliePlugin } from "../../types";
 

--- a/examples/mollie-credit-card/src/runtime/plugins/plugin.client.ts
+++ b/examples/mollie-credit-card/src/runtime/plugins/plugin.client.ts
@@ -1,5 +1,4 @@
-import { defineNuxtPlugin } from "#imports";
-import { useRuntimeConfig } from "#imports";
+import { defineNuxtPlugin, useRuntimeConfig } from "#imports";
 import { CreateLocaleInstanceArgs, MolliePlugin } from "../../types";
 
 export default defineNuxtPlugin({

--- a/examples/mollie-credit-card/src/runtime/plugins/plugin.server.ts
+++ b/examples/mollie-credit-card/src/runtime/plugins/plugin.server.ts
@@ -1,5 +1,4 @@
-import { defineNuxtPlugin } from "#imports";
-import { useServerHead } from "#imports";
+import { defineNuxtPlugin, useServerHead } from "#imports";
 
 export default defineNuxtPlugin({
   name: "mollie-register",

--- a/examples/mollie-credit-card/src/runtime/plugins/plugin.server.ts
+++ b/examples/mollie-credit-card/src/runtime/plugins/plugin.server.ts
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin } from "#app";
+import { defineNuxtPlugin } from "#imports";
 import { useServerHead } from "#imports";
 
 export default defineNuxtPlugin({

--- a/packages/nuxt3-module/plugin.ts
+++ b/packages/nuxt3-module/plugin.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { defineNuxtPlugin, useRuntimeConfig, useCookie, useState } from "#app";
+import { defineNuxtPlugin, useRuntimeConfig, useCookie, useState } from "#imports";
 import {
   createShopwareContext,
   getDefaultApiParams,


### PR DESCRIPTION
### Description

This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.

### Type of change

Bug fix (non-breaking change that fixes an issue)

### ToDo's

<!-- Add the todo's that need to be done before merge -->
<!-- Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. -->

<!-- - [x] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) -->
<!-- - [ ] Documentation added/updated -->
<!-- - [ ] Unit-Tests added/updated -->
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
