### PR TITLE
fix: missing transpilation for aliases in node_modules

### DIFF
--- a/packages/cms-base/nuxt.config.ts
+++ b/packages/cms-base/nuxt.config.ts
@@ -9,4 +9,7 @@ export default defineNuxtConfig({
       // global: true,
     },
   ],
+  build: {
+    transpile: ["@shopware-pwa/cms-base"],
+  },
 });

--- a/packages/composables/nuxt.config.ts
+++ b/packages/composables/nuxt.config.ts
@@ -5,4 +5,7 @@ export default defineNuxtConfig({
   imports: {
     dirs: ["src"],
   },
+  build: {
+    transpile: ["@shopware-pwa/composables-next"],
+  },
 });


### PR DESCRIPTION
### Description

<!-- Describe the changes you did and which issue you're closing -->

<!-- example: closes #007 -->
closes #473 

For some reason, when Nuxt Layer is inside `node_modules`, transpilation is turned off (even though full path is added to transpilation array) it's ommited. This PR should fix that.