### PR TITLE
fix(demo): do not execute watch if 0

### DIFF
--- a/packages/cms-base/components/listing-filters/SwFilterPrice.vue
+++ b/packages/cms-base/components/listing-filters/SwFilterPrice.vue
@@ -57,23 +57,23 @@ const dropdownElement = ref(null);
 onClickOutside(dropdownElement, () => (isFilterVisible.value = false));
 
 function onMinPriceChange(newPrice: number, oldPrice: number) {
-  if (newPrice == oldPrice) return;
+  if (newPrice == oldPrice || oldPrice == 0) return;
   emits("select-value", {
     code: "min-price",
     value: newPrice,
   });
 }
-const debounceMinPriceUpdate = useDebounceFn(onMinPriceChange, 1000);
+const debounceMinPriceUpdate = useDebounceFn(onMinPriceChange, 500);
 watch(() => prices.min, debounceMinPriceUpdate);
 
 function onMaxPriceChange(newPrice: number, oldPrice: number) {
-  if (newPrice == oldPrice) return;
+  if (newPrice == oldPrice || oldPrice == 0) return;
   emits("select-value", {
     code: "max-price",
     value: newPrice,
   });
 }
-const debounceMaxPriceUpdate = useDebounceFn(onMaxPriceChange, 1000);
+const debounceMaxPriceUpdate = useDebounceFn(onMaxPriceChange, 500);
 watch(() => prices.max, debounceMaxPriceUpdate);
 </script>
 

--- a/packages/cms-base/components/listing-filters/SwFilterPrice.vue
+++ b/packages/cms-base/components/listing-filters/SwFilterPrice.vue
@@ -57,7 +57,7 @@ const dropdownElement = ref(null);
 onClickOutside(dropdownElement, () => (isFilterVisible.value = false));
 
 function onMinPriceChange(newPrice: number, oldPrice: number) {
-  if (newPrice == oldPrice || oldPrice == 0) return;
+  if (newPrice === oldPrice || oldPrice === 0) return;
   emits("select-value", {
     code: "min-price",
     value: newPrice,
@@ -67,7 +67,7 @@ const debounceMinPriceUpdate = useDebounceFn(onMinPriceChange, 500);
 watch(() => prices.min, debounceMinPriceUpdate);
 
 function onMaxPriceChange(newPrice: number, oldPrice: number) {
-  if (newPrice == oldPrice || oldPrice == 0) return;
+  if (newPrice === oldPrice || oldPrice === 0) return;
   emits("select-value", {
     code: "max-price",
     value: newPrice,

--- a/templates/vue-demo-store/components/listing-filters/ListingFiltersPrice.vue
+++ b/templates/vue-demo-store/components/listing-filters/ListingFiltersPrice.vue
@@ -47,23 +47,23 @@ const dropdownElement = ref(null);
 onClickOutside(dropdownElement, () => (isFilterVisible.value = false));
 
 function onMinPriceChange(newPrice: number, oldPrice: number) {
-  if (newPrice == oldPrice) return;
+  if (newPrice == oldPrice || oldPrice == 0) return;
   emits("select-value", {
     code: "min-price",
     value: newPrice,
   });
 }
-const debounceMinPriceUpdate = useDebounceFn(onMinPriceChange, 1000);
+const debounceMinPriceUpdate = useDebounceFn(onMinPriceChange, 500);
 watch(() => prices.min, debounceMinPriceUpdate);
 
 function onMaxPriceChange(newPrice: number, oldPrice: number) {
-  if (newPrice == oldPrice) return;
+  if (newPrice == oldPrice || oldPrice == 0) return;
   emits("select-value", {
     code: "max-price",
     value: newPrice,
   });
 }
-const debounceMaxPriceUpdate = useDebounceFn(onMaxPriceChange, 1000);
+const debounceMaxPriceUpdate = useDebounceFn(onMaxPriceChange, 500);
 watch(() => prices.max, debounceMaxPriceUpdate);
 </script>
 

--- a/templates/vue-demo-store/components/listing-filters/ListingFiltersPrice.vue
+++ b/templates/vue-demo-store/components/listing-filters/ListingFiltersPrice.vue
@@ -47,7 +47,7 @@ const dropdownElement = ref(null);
 onClickOutside(dropdownElement, () => (isFilterVisible.value = false));
 
 function onMinPriceChange(newPrice: number, oldPrice: number) {
-  if (newPrice == oldPrice || oldPrice == 0) return;
+  if (newPrice === oldPrice || oldPrice === 0) return;
   emits("select-value", {
     code: "min-price",
     value: newPrice,
@@ -57,7 +57,7 @@ const debounceMinPriceUpdate = useDebounceFn(onMinPriceChange, 500);
 watch(() => prices.min, debounceMinPriceUpdate);
 
 function onMaxPriceChange(newPrice: number, oldPrice: number) {
-  if (newPrice == oldPrice || oldPrice == 0) return;
+  if (newPrice === oldPrice || oldPrice === 0) return;
   emits("select-value", {
     code: "max-price",
     value: newPrice,


### PR DESCRIPTION
### Description

closes #457

### Type of change

Bug fix (non-breaking change that fixes an issue)

### Additional context

The watch was also executed with the default value of 0, this we skip now and only change when a real user interaction took place. Also, a max or min price filter with 0 is not something retailers like to filter for so I guess it is safe to skip it in that case.
