### PR TITLE
fix(demo): click on label bug

### DIFF
--- a/packages/cms-base/components/listing-filters/SwFilterProperties.vue
+++ b/packages/cms-base/components/listing-filters/SwFilterProperties.vue
@@ -59,7 +59,7 @@ const toggle = () => {
             v-for="option in props.filter.options || props.filter.entities"
             :key="`${option.id}-${selectedOptionIds?.includes(option.id)}`"
             class="flex items-center"
-            @click="
+            @click.once="
               emits('select-value', {
                 code: props.filter.code,
                 value: option.id,
@@ -100,12 +100,6 @@ const toggle = () => {
             <label
               :for="`filter-mobile-${props.filter.code}-${option.id}`"
               class="ml-3 text-gray-600"
-              @click="
-                emits('select-value', {
-                  code: props.filter.code,
-                  value: option.id,
-                })
-              "
             >
               {{ getTranslatedProperty(option, "name") }}
             </label>

--- a/templates/vue-demo-store/components/listing-filters/ListingFiltersProperties.vue
+++ b/templates/vue-demo-store/components/listing-filters/ListingFiltersProperties.vue
@@ -53,12 +53,13 @@ const toggle = () => {
     </h3>
     <transition name="fade" mode="out-in">
       <div v-show="isFilterVisible" id="filter-section-0" class="pt-6">
-        <div class="space-y-4">
+        <fieldset class="space-y-4">
+          <legend class="sr-only">{{ props.filter.name }}</legend>
           <div
             v-for="option in props.filter.options || props.filter.entities"
             :key="`${option.id}-${selectedOptionIds?.includes(option.id)}`"
             class="flex items-center"
-            @click="
+            @click.once="
               emits('select-value', {
                 code: props.filter.code,
                 value: option.id,
@@ -99,7 +100,7 @@ const toggle = () => {
               {{ getTranslatedProperty(option, "name") }}
             </label>
           </div>
-        </div>
+        </fieldset>
       </div>
     </transition>
   </div>


### PR DESCRIPTION
### Description
Related to PR https://github.com/shopware/frontends/pull/484

### Type of change

Bug fix (non-breaking change that fixes an issue)

### Additional context

After the fieldset was introduced for accessibility the click event was not working on the label.
Currently, the event is fired twice and also not working for labels only for the input.
With these changes, it works on category and search the same way.
