### PR TITLE
fix(cms-base): getOptionsFromNode

### DIFF
--- a/.changeset/seven-gifts-run.md
+++ b/.changeset/seven-gifts-run.md
@@ -1,0 +1,5 @@
+---
+"@shopware-pwa/cms-base": minor
+---
+
+Make helper getOptionsFromNode more reliable, add error stack

--- a/packages/cms-base/helpers/html-to-vue/getOptionsFromNode.ts
+++ b/packages/cms-base/helpers/html-to-vue/getOptionsFromNode.ts
@@ -22,32 +22,47 @@ export function getOptionsFromNode(node: any): Options {
   let classNames = undefined;
   let align = undefined;
 
-  if (node.attrs.style && node.attrs.style !== "") {
-    style = node.attrs.style;
-    delete node.attrs.style; // we delete the nodes otherwise it would be added to rest again
+  try {
+    if (Object.keys(node).length === 0) {
+      return {};
+    }
+
+    if (Object.keys(node.attrs).length > 0) {
+      if (node.attrs.style && node.attrs.style !== "") {
+        style = node.attrs.style;
+        delete node.attrs.style; // we delete the nodes otherwise it would be added to rest again
+      }
+
+      if (node.attrs.class && node.attrs.class !== "") {
+        classNames = node.attrs.class;
+        delete node.attrs.class;
+      }
+
+      if (node.attrs.align && node.attrs.align !== "") {
+        align = node.attrs.align;
+        delete node.attrs.align;
+      }
+    }
+
+    const attrs =
+      Object.keys(node.attrs).length === 0 ? "undefined" : { ...node.attrs };
+
+    // Resolve URL if exist
+    if (attrs?.href) {
+      const { resolveUrl } = useUrlResolver();
+      attrs.href = `${resolveUrl(attrs.href)}`;
+    }
+
+    return {
+      ...(typeof align !== "undefined" && { align }),
+      ...(attrs !== "undefined" && typeof attrs !== "undefined" && { attrs }),
+      ...(typeof classNames !== "undefined" && { class: classNames }),
+      ...(typeof style !== "undefined" && { style }),
+    };
+  } catch (e) {
+    console.error("Error in getOptionsFromNode", e);
+    console.error(new Error().stack);
   }
 
-  if (node.attrs.class && node.attrs.class !== "") {
-    classNames = node.attrs.class;
-    delete node.attrs.class;
-  }
-
-  if (node.attrs.align && node.attrs.align !== "") {
-    align = node.attrs.align;
-    delete node.attrs.align;
-  }
-  const attrs = Object.keys(node.attrs).length === 0 ? null : { ...node.attrs };
-
-  // Resolve URL if exist
-  if (attrs?.href) {
-    const { resolveUrl } = useUrlResolver();
-    attrs.href = `${resolveUrl(attrs.href)}`;
-  }
-
-  return {
-    ...(typeof align != "undefined" && { align }),
-    ...(typeof attrs != "undefined" && { attrs }),
-    ...(typeof classNames != "undefined" && { class: classNames }),
-    ...(typeof style != "undefined" && { style }),
-  };
+  return {};
 }


### PR DESCRIPTION
### Description

There was an error thrown for a customer project.
The error message was like "undefined can not converted to object".

### Type of change

Bug fix (non-breaking change that fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

- [ ] Unit-Tests added/updated

### Additional context

In old versions, attr was outputted to the HTML DOM.
Current testing no error in console and no empty attributes in HTML DOM.
