### PR TITLE
fix(cms-base): improve getOptionsFromNode helper

### DIFF
--- a/.changeset/swift-flies-fetch.md
+++ b/.changeset/swift-flies-fetch.md
@@ -1,0 +1,5 @@
+---
+"@shopware-pwa/cms-base": patch
+---
+
+Potential problems with CmsElementText rendering, when Node object is incorrect

--- a/packages/cms-base/components/public/cms/element/CmsElementText.vue
+++ b/packages/cms-base/components/public/cms/element/CmsElementText.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { CmsElementText } from "@shopware-pwa/composables-next";
-import { useCmsElementConfig } from "#imports";
+import { useCmsElementConfig, useUrlResolver } from "#imports";
 import { computed, getCurrentInstance, h } from "vue";
 import { decodeHTML } from "entities";
 import type { CSSProperties } from "vue";
@@ -25,6 +25,8 @@ const style = computed<CSSProperties>(() => ({
 const hasVerticalAlignment = computed(() => !!style.value.alignItems);
 
 const CmsTextRender = () => {
+  const { resolveUrl } = useUrlResolver();
+
   const config = {
     textTransformer: (text: string) => decodeHTML(text),
     extraComponentsMap: {
@@ -42,7 +44,7 @@ const CmsTextRender = () => {
             {
               class:
                 "underline text-base font-normal text-primary hover:text-secondary-900",
-              ...getOptionsFromNode(node).attrs,
+              ...getOptionsFromNode(node, resolveUrl).attrs,
             },
             [...children],
           );
@@ -71,7 +73,7 @@ const CmsTextRender = () => {
             "a",
             {
               class: _class,
-              ...getOptionsFromNode(node).attrs,
+              ...getOptionsFromNode(node, resolveUrl).attrs,
             },
             [...children],
           );
@@ -95,7 +97,7 @@ const CmsTextRender = () => {
             "span",
             {
               style: newStyle,
-              ...getOptionsFromNode(node).attrs,
+              ...getOptionsFromNode(node, resolveUrl).attrs,
             },
             [...children],
           );
@@ -106,7 +108,10 @@ const CmsTextRender = () => {
           return node.type === "tag" && node.name === "img";
         },
         renderer(node: any, children: any, createElement: any) {
-          return createElement("img", getOptionsFromNode(node)?.attrs);
+          return createElement(
+            "img",
+            getOptionsFromNode(node, resolveUrl)?.attrs,
+          );
         },
       },
     },
@@ -115,7 +120,7 @@ const CmsTextRender = () => {
     mappedContent.value?.length > 0
       ? mappedContent.value
       : "<div class='cms-element-text missing-content-element'></div>";
-  return renderHtml(rawHtml, config, h, context);
+  return renderHtml(rawHtml, config, h, context, resolveUrl);
 };
 </script>
 <template>

--- a/packages/cms-base/helpers/html-to-vue/getOptionsFromNode.test.ts
+++ b/packages/cms-base/helpers/html-to-vue/getOptionsFromNode.test.ts
@@ -1,0 +1,107 @@
+import { getOptionsFromNode } from "./getOptionsFromNode";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+describe("getOptionsFromNode", () => {
+  const consoleErrorSpy = vi.spyOn(console, "error");
+  const urlResolverMock = vi.fn();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    consoleErrorSpy.mockImplementation(() => {});
+    urlResolverMock.mockImplementation((url) => "resolved-url" + url);
+  });
+
+  it("should return empty object if node is undefined", () => {
+    const options = getOptionsFromNode(undefined, urlResolverMock);
+
+    expect(options).toEqual({
+      attrs: {},
+    });
+  });
+
+  it("should return options object with style, classNames, and align", () => {
+    const node = {
+      attrs: {
+        style: "color: red",
+        class: "my-class",
+        align: "center",
+      },
+    };
+
+    const options = getOptionsFromNode(node, urlResolverMock);
+
+    expect(options).toEqual({
+      style: "color: red",
+      class: "my-class",
+      align: "center",
+      attrs: {},
+    });
+  });
+
+  it("should return options object without style, classNames, and align if they are not present in node.attrs", () => {
+    const node = {
+      attrs: {},
+    };
+
+    const options = getOptionsFromNode(node, urlResolverMock);
+
+    expect(options).toEqual({
+      attrs: {},
+    });
+  });
+
+  it("should return empty object when no attrs in node", () => {
+    const node = {
+      attrs: undefined,
+    };
+
+    const options = getOptionsFromNode(node, urlResolverMock);
+
+    expect(options).toEqual({
+      attrs: {},
+    });
+  });
+
+  it("should resolve URL if attrs.href exists", () => {
+    const node = {
+      attrs: {
+        href: "/path/to/page",
+      },
+    };
+
+    const options = getOptionsFromNode(node, urlResolverMock);
+
+    expect(options.attrs.href).toEqual("resolved-url/path/to/page");
+  });
+
+  it('should add additional attrs to "attrs" object', () => {
+    const node = {
+      attrs: {
+        href: "/path/to/page",
+        "data-test": "test",
+      },
+    };
+
+    const options = getOptionsFromNode(node, urlResolverMock);
+
+    expect(options.attrs.href).toEqual("resolved-url/path/to/page");
+    expect(options.attrs["data-test"]).toEqual("test");
+  });
+
+  it("should show console error if something went wrong", () => {
+    const node = {
+      attrs: {
+        href: "/path/to/page",
+      },
+    };
+
+    const consoleErrorSpy = vi.spyOn(console, "error");
+
+    const options = getOptionsFromNode(node, undefined as any);
+
+    expect(options).toEqual({
+      attrs: {},
+    });
+    expect(consoleErrorSpy).toBeCalled();
+  });
+});

--- a/packages/cms-base/helpers/html-to-vue/getOptionsFromNode.ts
+++ b/packages/cms-base/helpers/html-to-vue/getOptionsFromNode.ts
@@ -1,5 +1,3 @@
-import { useUrlResolver } from "#imports";
-
 export type NodeObject = {
   type: string;
   name: string;
@@ -11,43 +9,44 @@ export type NodeObject = {
 
 type Options = {
   align?: string;
-  attrs?: Record<string, string>;
+  attrs: Record<string, string>;
   class?: string;
   color?: string;
   style?: string;
+  href?: string;
 };
 
-export function getOptionsFromNode(node: any): Options {
-  let style = undefined;
-  let classNames = undefined;
-  let align = undefined;
-
-  if (node.attrs.style && node.attrs.style !== "") {
-    style = node.attrs.style;
-    delete node.attrs.style; // we delete the nodes otherwise it would be added to rest again
-  }
-
-  if (node.attrs.class && node.attrs.class !== "") {
-    classNames = node.attrs.class;
-    delete node.attrs.class;
-  }
-
-  if (node.attrs.align && node.attrs.align !== "") {
-    align = node.attrs.align;
-    delete node.attrs.align;
-  }
-  const attrs = Object.keys(node.attrs).length === 0 ? null : { ...node.attrs };
-
-  // Resolve URL if exist
-  if (attrs?.href) {
-    const { resolveUrl } = useUrlResolver();
-    attrs.href = `${resolveUrl(attrs.href)}`;
-  }
-
-  return {
-    ...(typeof align != "undefined" && { align }),
-    ...(typeof attrs != "undefined" && { attrs }),
-    ...(typeof classNames != "undefined" && { class: classNames }),
-    ...(typeof style != "undefined" && { style }),
+export function getOptionsFromNode(
+  node: any,
+  resolveUrl: (url: string) => string,
+): Options {
+  const response: Options = {
+    attrs: {},
   };
+  try {
+    if (!node?.attrs) {
+      return response;
+    }
+
+    const { align, style, class: classNames, href, ...attrs } = node.attrs;
+
+    if (align) {
+      response.align = align;
+    }
+    if (style) {
+      response.style = style;
+    }
+    if (classNames) {
+      response.class = classNames;
+    }
+    if (attrs && Object.keys(attrs).length > 0) {
+      response.attrs = attrs;
+    }
+    if (href) {
+      response.attrs.href = resolveUrl(href);
+    }
+  } catch (e) {
+    console.error("[Shopware][cms][getOptionsFromNode] error", e);
+  }
+  return response;
 }

--- a/packages/cms-base/helpers/html-to-vue/renderToHtml.ts
+++ b/packages/cms-base/helpers/html-to-vue/renderToHtml.ts
@@ -28,10 +28,17 @@ export function renderHtml(
   config: Partial<DefaultConfig>,
   createElement: any,
   context: any,
+  resolveUrl: (url: string) => string,
 ) {
   const mergedConfig = Object.assign(defaultConfig, config);
   const _ast = generateAST(html);
   const _rectifiedAst = rectifyAST(_ast, config);
 
-  return renderer(_rectifiedAst, mergedConfig, createElement, context);
+  return renderer(
+    _rectifiedAst,
+    mergedConfig,
+    createElement,
+    context,
+    resolveUrl,
+  );
 }

--- a/packages/cms-base/helpers/html-to-vue/renderer.ts
+++ b/packages/cms-base/helpers/html-to-vue/renderer.ts
@@ -13,7 +13,7 @@ import { getOptionsFromNode } from "./getOptionsFromNode";
  * @param {*} createElement vue's createElement
  * @param {*} context vue functional component context
  */
-export function renderer(ast, config, createElement, context) {
+export function renderer(ast, config, createElement, context, resolveUrl) {
   function _render(h, node, parent, key, index) {
     if (Array.isArray(node)) {
       const nodes = [];
@@ -28,7 +28,7 @@ export function renderer(ast, config, createElement, context) {
         return config.textTransformer(node.content); // return text
       }
       if (node.type === "tag") {
-        const transformedNode = getOptionsFromNode(node);
+        const transformedNode = getOptionsFromNode(node, resolveUrl);
         const children = [];
         node.children.forEach((child, index) => {
           children.push(_render.call(this, h, child, transformedNode, index));

--- a/packages/cms-base/package.json
+++ b/packages/cms-base/package.json
@@ -32,7 +32,8 @@
     "eslint": "eslint components/**/*.vue* --fix --max-warnings=0",
     "lint": "pnpm run eslint && pnpm run typecheck",
     "typecheck": "tsc --noEmit",
-    "test": "echo \"Warn: no test specified yet\""
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@nuxt/kit": "^3.9.3",
@@ -49,6 +50,7 @@
   "devDependencies": {
     "@nuxt/schema": "^3.9.3",
     "@shopware-pwa/types": "workspace:*",
+    "@vitest/coverage-v8": "^1.2.1",
     "@vue/eslint-config-typescript": "^12.0.0",
     "eslint-config-shopware": "workspace:*",
     "eslint-plugin-vue": "^9.20.1",
@@ -56,6 +58,7 @@
     "tsconfig": "workspace:*",
     "typescript": "^5.3.3",
     "unbuild": "^2.0.0",
+    "vitest": "^1.2.1",
     "vue-eslint-parser": "^9.4.2",
     "vue-router": "^4.2.5",
     "vue-tsc": "^1.8.27"

--- a/packages/cms-base/vitest.config.ts
+++ b/packages/cms-base/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import { resolve } from "path";
+
+export default defineConfig({
+  test: {
+    environment: "happy-dom",
+    coverage: {
+      enabled: true,
+    },
+    alias: {
+      "#imports": resolve(__dirname, "./composables.d.ts"),
+      "#shopware": resolve(__dirname, "./types/api-types.d.ts"),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -675,6 +675,9 @@ importers:
       '@shopware-pwa/types':
         specifier: workspace:*
         version: link:../types
+      '@vitest/coverage-v8':
+        specifier: ^1.2.1
+        version: 1.2.1(vitest@1.2.1)
       '@vue/eslint-config-typescript':
         specifier: ^12.0.0
         version: 12.0.0(eslint-plugin-vue@9.20.1)(eslint@8.56.0)(typescript@5.3.3)
@@ -696,6 +699,9 @@ importers:
       unbuild:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.3.3)
+      vitest:
+        specifier: ^1.2.1
+        version: 1.2.1(@types/node@20.11.5)(happy-dom@13.3.1)
       vue-eslint-parser:
         specifier: ^9.4.2
         version: 9.4.2(eslint@8.56.0)
@@ -1686,13 +1692,6 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
 
-  /@babel/parser@7.23.5:
-    resolution: {integrity: sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.23.6
-
   /@babel/parser@7.23.6:
     resolution: {integrity: sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==}
     engines: {node: '>=6.0.0'}
@@ -1896,14 +1895,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/types@7.23.5:
-    resolution: {integrity: sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-string-parser': 7.23.4
-      '@babel/helper-validator-identifier': 7.22.20
-      to-fast-properties: 2.0.0
 
   /@babel/types@7.23.6:
     resolution: {integrity: sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==}
@@ -3108,7 +3099,7 @@ packages:
       estree-walker: 2.0.2
       jsonc-eslint-parser: 2.3.0
       magic-string: 0.30.5
-      mlly: 1.4.2
+      mlly: 1.5.0
       source-map-js: 1.0.2
       vue-i18n: 9.8.0(vue@3.4.15)
       yaml-eslint-parser: 1.2.2
@@ -3187,7 +3178,7 @@ packages:
       fast-glob: 3.3.2
       js-yaml: 4.1.0
       json5: 2.2.3
-      pathe: 1.1.1
+      pathe: 1.1.2
       picocolors: 1.0.0
       source-map-js: 1.0.2
       unplugin: 1.6.0
@@ -3618,7 +3609,7 @@ packages:
       diff: 5.1.0
       execa: 7.2.0
       global-directory: 4.0.1
-      magicast: 0.3.2
+      magicast: 0.3.3
       pathe: 1.1.2
       pkg-types: 1.0.3
       prompts: 2.4.2
@@ -3652,7 +3643,7 @@ packages:
       is-installed-globally: 1.0.0
       launch-editor: 2.6.1
       local-pkg: 0.5.0
-      magicast: 0.3.2
+      magicast: 0.3.3
       nuxt: 3.9.3(@types/node@20.11.5)(eslint@8.56.0)(typescript@5.3.3)
       nypm: 0.3.4
       ohash: 1.1.3
@@ -3704,7 +3695,7 @@ packages:
       is-installed-globally: 1.0.0
       launch-editor: 2.6.1
       local-pkg: 0.5.0
-      magicast: 0.3.2
+      magicast: 0.3.3
       nuxt: 3.9.3(@types/node@20.11.5)(eslint@8.56.0)(rollup@3.28.1)(typescript@5.3.3)(vue-tsc@1.8.27)
       nypm: 0.3.4
       ohash: 1.1.3
@@ -3757,7 +3748,7 @@ packages:
       is-installed-globally: 1.0.0
       launch-editor: 2.6.1
       local-pkg: 0.5.0
-      magicast: 0.3.2
+      magicast: 0.3.3
       nuxt: 3.9.3(@types/node@20.11.5)(eslint@8.56.0)(rollup@3.29.4)(typescript@5.3.3)(vue-tsc@1.8.27)
       nypm: 0.3.4
       ohash: 1.1.3
@@ -3796,7 +3787,7 @@ packages:
       jiti: 1.21.0
       knitwork: 1.0.0
       mlly: 1.4.2
-      pathe: 1.1.1
+      pathe: 1.1.2
       pkg-types: 1.0.3
       scule: 1.2.0
       semver: 7.5.4
@@ -3868,7 +3859,7 @@ packages:
       consola: 3.2.3
       defu: 6.1.4
       hookable: 5.5.3
-      pathe: 1.1.1
+      pathe: 1.1.2
       pkg-types: 1.0.3
       scule: 1.2.0
       std-env: 3.7.0
@@ -4071,7 +4062,7 @@ packages:
       ufo: 1.3.2
       unplugin: 1.6.0
       vite: 5.0.12(@types/node@20.11.5)
-      vite-node: 1.1.3(@types/node@20.11.5)
+      vite-node: 1.2.1(@types/node@20.11.5)
       vite-plugin-checker: 0.6.2(eslint@8.56.0)(typescript@5.3.3)(vite@5.0.12)(vue-tsc@1.8.27)
       vue: 3.4.15(typescript@5.3.3)
       vue-bundle-renderer: 2.0.0
@@ -4131,7 +4122,7 @@ packages:
       ufo: 1.3.2
       unplugin: 1.6.0
       vite: 5.0.12(@types/node@20.11.5)
-      vite-node: 1.1.3(@types/node@20.11.5)
+      vite-node: 1.2.1(@types/node@20.11.5)
       vite-plugin-checker: 0.6.2(eslint@8.56.0)(typescript@5.3.3)(vite@5.0.12)(vue-tsc@1.8.27)
       vue: 3.4.15(typescript@5.3.3)
       vue-bundle-renderer: 2.0.0
@@ -4190,7 +4181,7 @@ packages:
       ufo: 1.3.2
       unplugin: 1.6.0
       vite: 5.0.12(@types/node@20.11.5)
-      vite-node: 1.1.3(@types/node@20.11.5)
+      vite-node: 1.2.1(@types/node@20.11.5)
       vite-plugin-checker: 0.6.2(eslint@8.56.0)(typescript@5.3.3)(vite@5.0.12)(vue-tsc@1.8.27)
       vue: 3.4.15(typescript@5.3.3)
       vue-bundle-renderer: 2.0.0
@@ -4249,7 +4240,7 @@ packages:
       ufo: 1.3.2
       unplugin: 1.6.0
       vite: 5.0.12(@types/node@20.8.6)
-      vite-node: 1.1.3(@types/node@20.8.6)
+      vite-node: 1.2.1(@types/node@20.8.6)
       vite-plugin-checker: 0.6.2(typescript@5.3.3)(vite@5.0.12)(vue-tsc@1.8.27)
       vue: 3.4.15(typescript@5.3.3)
       vue-bundle-renderer: 2.0.0
@@ -4271,7 +4262,6 @@ packages:
       - vls
       - vti
       - vue-tsc
-    dev: true
 
   /@nuxt/vite-builder@3.9.3(@types/node@20.8.6)(typescript@5.3.3)(vue@3.4.15):
     resolution: {integrity: sha512-HruOrxn0g6TS31j3jycJvGZ7pt3JNEbcXNByVh7YJwQx6ToFX8kPWRu4LPeMhrLYvZzeUr2w3iELBECFxbDmvw==}
@@ -4309,7 +4299,7 @@ packages:
       ufo: 1.3.2
       unplugin: 1.6.0
       vite: 5.0.12(@types/node@20.8.6)
-      vite-node: 1.1.3(@types/node@20.8.6)
+      vite-node: 1.2.1(@types/node@20.8.6)
       vite-plugin-checker: 0.6.2(eslint@8.56.0)(typescript@5.3.3)(vite@5.0.12)(vue-tsc@1.8.27)
       vue: 3.4.15(typescript@5.3.3)
       vue-bundle-renderer: 2.0.0
@@ -6574,7 +6564,7 @@ packages:
       consola: 2.15.3
       fast-glob: 3.3.2
       magic-string: 0.27.0
-      pathe: 1.1.1
+      pathe: 1.1.2
       perfect-debounce: 0.1.3
     transitivePeerDependencies:
       - rollup
@@ -6596,7 +6586,7 @@ packages:
       consola: 3.2.3
       fast-glob: 3.3.2
       magic-string: 0.30.5
-      pathe: 1.1.1
+      pathe: 1.1.2
       perfect-debounce: 1.0.0
     transitivePeerDependencies:
       - rollup
@@ -7237,14 +7227,14 @@ packages:
     dependencies:
       '@vitest/utils': 1.2.1
       p-limit: 5.0.0
-      pathe: 1.1.1
+      pathe: 1.1.2
     dev: true
 
   /@vitest/snapshot@1.2.1:
     resolution: {integrity: sha512-Tmp/IcYEemKaqAYCS08sh0vORLJkMr0NRV76Gl8sHGxXT5151cITJCET20063wk0Yr/1koQ6dnmP6eEqezmd/Q==}
     dependencies:
       magic-string: 0.30.5
-      pathe: 1.1.1
+      pathe: 1.1.2
       pretty-format: 29.7.0
     dev: true
 
@@ -7331,7 +7321,7 @@ packages:
       '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.3)
       '@babel/template': 7.22.5
       '@babel/traverse': 7.23.7
-      '@babel/types': 7.23.5
+      '@babel/types': 7.23.6
       '@vue/babel-helper-vue-transform-on': 1.1.5
       camelcase: 6.3.0
       html-tags: 3.3.1
@@ -7349,7 +7339,7 @@ packages:
       '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.7)
       '@babel/template': 7.22.5
       '@babel/traverse': 7.23.7
-      '@babel/types': 7.23.5
+      '@babel/types': 7.23.6
       '@vue/babel-helper-vue-transform-on': 1.1.5
       camelcase: 6.3.0
       html-tags: 3.3.1
@@ -7404,7 +7394,7 @@ packages:
   /@vue/compiler-sfc@3.3.10:
     resolution: {integrity: sha512-xpcTe7Rw7QefOTRFFTlcfzozccvjM40dT45JtrE3onGm/jBLZ0JhpKu3jkV7rbDFLeeagR/5RlJ2Y9SvyS0lAg==}
     dependencies:
-      '@babel/parser': 7.23.5
+      '@babel/parser': 7.23.6
       '@vue/compiler-core': 3.3.10
       '@vue/compiler-dom': 3.3.10
       '@vue/compiler-ssr': 3.3.10
@@ -7726,7 +7716,7 @@ packages:
       '@vueuse/core': 10.7.2(vue@3.4.15)
       '@vueuse/metadata': 10.7.2
       local-pkg: 0.5.0
-      nuxt: 3.9.3(@types/node@20.11.5)(eslint@8.56.0)(typescript@5.3.3)
+      nuxt: 3.9.3(@types/node@20.8.6)(typescript@5.3.3)(vue-tsc@1.8.27)
       vue-demi: 0.14.6(vue@3.4.15)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -7788,12 +7778,12 @@ packages:
       acorn: 8.11.3
     dev: true
 
-  /acorn-jsx@5.3.2(acorn@8.11.2):
+  /acorn-jsx@5.3.2(acorn@8.11.3):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.11.2
+      acorn: 8.11.3
 
   /acorn-walk@8.3.2:
     resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
@@ -7804,6 +7794,7 @@ packages:
     resolution: {integrity: sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+    dev: true
 
   /acorn@8.11.3:
     resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
@@ -10375,8 +10366,8 @@ packages:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.11.2
-      acorn-jsx: 5.3.2(acorn@8.11.2)
+      acorn: 8.11.3
+      acorn-jsx: 5.3.2(acorn@8.11.3)
       eslint-visitor-keys: 3.4.3
 
   /esprima@4.0.1:
@@ -12473,7 +12464,7 @@ packages:
     resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
     engines: {node: '>=14'}
     dependencies:
-      mlly: 1.4.2
+      mlly: 1.5.0
       pkg-types: 1.0.3
 
   /locate-path@5.0.0:
@@ -12633,20 +12624,12 @@ packages:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  /magicast@0.3.2:
-    resolution: {integrity: sha512-Fjwkl6a0syt9TFN0JSYpOybxiMCkYNEeOTnOTNRbjphirLakznZXAqrXgj/7GG3D1dvETONNwrBfinvAbpunDg==}
-    dependencies:
-      '@babel/parser': 7.23.6
-      '@babel/types': 7.23.6
-      source-map-js: 1.0.2
-
   /magicast@0.3.3:
     resolution: {integrity: sha512-ZbrP1Qxnpoes8sz47AM0z08U+jW6TyRgZzcWy3Ma3vDhJttwMwAFDMMQFobwdBxByBD46JYmxRzeF7w2+wJEuw==}
     dependencies:
       '@babel/parser': 7.23.6
       '@babel/types': 7.23.6
       source-map-js: 1.0.2
-    dev: true
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -13585,7 +13568,7 @@ packages:
       jiti: 1.21.0
       mlly: 1.4.2
       mri: 1.2.0
-      pathe: 1.1.1
+      pathe: 1.1.2
       typescript: 5.3.3
     dev: true
 
@@ -13593,7 +13576,7 @@ packages:
     resolution: {integrity: sha512-ua8PAThnTwpprIaU47EPeZ/bPUVp2QYBbWMphUQpVdBI3Lgqzm5KZQ45Agm3YJedHXaIHl6pBGabaLSUPPSptg==}
     dependencies:
       acorn: 8.11.2
-      pathe: 1.1.1
+      pathe: 1.1.2
       pkg-types: 1.0.3
       ufo: 1.3.2
     dev: true
@@ -13602,7 +13585,7 @@ packages:
     resolution: {integrity: sha512-i/Ykufi2t1EZ6NaPLdfnZk2AX8cs0d+mTzVKuPfqPKPatxLApaBoxJQ9x1/uckXtrS/U5oisPMDkNs0yQTaBRg==}
     dependencies:
       acorn: 8.11.3
-      pathe: 1.1.1
+      pathe: 1.1.2
       pkg-types: 1.0.3
       ufo: 1.3.2
 
@@ -14554,7 +14537,6 @@ packages:
       - vti
       - vue-tsc
       - xml2js
-    dev: true
 
   /nypm@0.3.4:
     resolution: {integrity: sha512-1JLkp/zHBrkS3pZ692IqOaIKSYHmQXgqfELk6YTOfVBnwealAmPA1q2kKK7PHJAHSMBozerThEFZXP3G6o7Ukg==}
@@ -14959,6 +14941,7 @@ packages:
 
   /pathe@1.1.1:
     resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
+    dev: true
 
   /pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -17676,7 +17659,7 @@ packages:
       fast-glob: 3.3.2
       local-pkg: 0.5.0
       magic-string: 0.30.5
-      mlly: 1.4.2
+      mlly: 1.5.0
       pathe: 1.1.2
       pkg-types: 1.0.3
       scule: 1.2.0
@@ -17695,7 +17678,7 @@ packages:
       fast-glob: 3.3.2
       local-pkg: 0.5.0
       magic-string: 0.30.5
-      mlly: 1.4.2
+      mlly: 1.5.0
       pathe: 1.1.2
       pkg-types: 1.0.3
       scule: 1.2.0
@@ -17714,7 +17697,7 @@ packages:
       fast-glob: 3.3.2
       local-pkg: 0.5.0
       magic-string: 0.30.5
-      mlly: 1.4.2
+      mlly: 1.5.0
       pathe: 1.1.2
       pkg-types: 1.0.3
       scule: 1.2.0
@@ -18144,7 +18127,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.5
       '@babel/standalone': 7.22.9
-      '@babel/types': 7.23.5
+      '@babel/types': 7.23.6
       defu: 6.1.4
       jiti: 1.21.0
       mri: 1.2.0
@@ -18393,47 +18376,6 @@ packages:
       teex: 1.0.1
     dev: false
 
-  /vite-node@1.1.3(@types/node@20.11.5):
-    resolution: {integrity: sha512-BLSO72YAkIUuNrOx+8uznYICJfTEbvBAmWClY3hpath5+h1mbPS5OMn42lrTxXuyCazVyZoDkSRnju78GiVCqA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.4
-      pathe: 1.1.2
-      picocolors: 1.0.0
-      vite: 5.0.12(@types/node@20.11.5)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  /vite-node@1.1.3(@types/node@20.8.6):
-    resolution: {integrity: sha512-BLSO72YAkIUuNrOx+8uznYICJfTEbvBAmWClY3hpath5+h1mbPS5OMn42lrTxXuyCazVyZoDkSRnju78GiVCqA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.4
-      pathe: 1.1.2
-      picocolors: 1.0.0
-      vite: 5.0.12(@types/node@20.8.6)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
   /vite-node@1.2.1(@types/node@20.11.5):
     resolution: {integrity: sha512-fNzHmQUSOY+y30naohBvSW7pPn/xn3Ib/uqm+5wAJQJiqQsU0NBR78XdRJb04l4bOFKjpTWld0XAfkKlrDbySg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -18441,7 +18383,7 @@ packages:
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
-      pathe: 1.1.1
+      pathe: 1.1.2
       picocolors: 1.0.0
       vite: 5.0.12(@types/node@20.11.5)
     transitivePeerDependencies:
@@ -18453,7 +18395,6 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
 
   /vite-node@1.2.1(@types/node@20.8.6):
     resolution: {integrity: sha512-fNzHmQUSOY+y30naohBvSW7pPn/xn3Ib/uqm+5wAJQJiqQsU0NBR78XdRJb04l4bOFKjpTWld0XAfkKlrDbySg==}
@@ -18462,7 +18403,7 @@ packages:
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
-      pathe: 1.1.1
+      pathe: 1.1.2
       picocolors: 1.0.0
       vite: 5.0.12(@types/node@20.8.6)
     transitivePeerDependencies:
@@ -18474,7 +18415,6 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
 
   /vite-plugin-checker@0.6.2(eslint@8.56.0)(typescript@5.3.3)(vite@5.0.12)(vue-tsc@1.8.27):
     resolution: {integrity: sha512-YvvvQ+IjY09BX7Ab+1pjxkELQsBd4rPhWNw8WLBeFVxu/E7O+n6VYAqNsKdK/a2luFlX/sMpoWdGFfg4HvwdJQ==}
@@ -18584,7 +18524,6 @@ packages:
       vscode-languageserver-textdocument: 1.0.8
       vscode-uri: 3.0.7
       vue-tsc: 1.8.27(typescript@5.3.3)
-    dev: true
 
   /vite-plugin-inspect@0.8.1(@nuxt/kit@3.9.3):
     resolution: {integrity: sha512-oPBPVGp6tBd5KdY/qY6lrbLXqrbHRG0hZLvEaJfiZ/GQfDB+szRuLHblQh1oi1Hhh8GeLit/50l4xfs2SA+TCA==}


### PR DESCRIPTION
### Description

<!-- Describe the changes you did and which issue you're closing -->

This is alternative resolution to #540

<!-- example: closes #007 -->

### Type of change

<!-- Comment out the type of change your PR is making -->

<!-- Bug fix (non-breaking change that fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

- refactored `getOptionsFromNode` with code simplification
- added vitest to the package
- added error message when there's some error there, component is still rendered but for example without styles
![image](https://github.com/shopware/frontends/assets/13100280/e1d74122-eb22-41a1-8a69-6ff5e2546291)
- fully tested method, 100% coverage
![image](https://github.com/shopware/frontends/assets/13100280/2d25dd90-1551-4f38-8fa1-daee300da799)
- moved `resolveUrl` as param, composables should not be used inside methods, so injection potentially was invoked in every node + potentially Urls could work in the wrong way