### PR TITLE
ci: move to macos GH actions

### DIFF
--- a/.github/workflows/audit-check.yml
+++ b/.github/workflows/audit-check.yml
@@ -17,7 +17,7 @@ jobs:
   init:
     name: Check audit
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: macos-14
 
     steps:
       - name: Check out code

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -10,7 +10,7 @@ jobs:
   init:
     name: Init dependencies
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: macos-14
 
     steps:
       - name: Check out code
@@ -38,7 +38,7 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-    runs-on: ubuntu-latest
+    runs-on: macos-14
 
     steps:
       - name: Check out code
@@ -70,7 +70,7 @@ jobs:
   test:
     name: Test
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     needs: init
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/code-examples.yml
+++ b/.github/workflows/code-examples.yml
@@ -7,7 +7,7 @@ on:
     - cron: "59 23 * * *"
 jobs:
   run-code_examples-tests:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   benchmarks:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - uses: "actions/checkout@v4"
       - uses: "actions/setup-node@v4"

--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   benchmarks:
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     steps:
       - uses: "actions/checkout@v4"
       - uses: "actions/setup-node@v4"

--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -14,16 +14,13 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: "actions/checkout@v4"
-      - uses: "actions/setup-node@v4"
-        with:
-          node-version: 20
-      - run: corepack enable
-      - run: pnpm --version
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
+      - run: corepack enable
+      - run: pnpm --version
       - name: install
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Run benchmarks

--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -14,13 +14,16 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: "actions/checkout@v4"
+      - uses: "actions/setup-node@v4"
+        with:
+          node-version: 20
+      - run: corepack enable
+      - run: pnpm --version
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
-      - run: corepack enable
-      - run: pnpm --version
       - name: install
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Run benchmarks

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,7 +7,7 @@ jobs:
   run-e2e:
     name: Playwright testing deployment ${{ github.event.deployment_status.target_url }}
     if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && !contains(github.event.deployment_status.target_url, 'frontends-docs')
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/failed-job-check.yml
+++ b/.github/workflows/failed-job-check.yml
@@ -1,13 +1,21 @@
 name: Check for jobs failure
 on:
   workflow_run:
-    workflows: [Code examples, Lighthouse CI, Vue vite blank, Vue Blank, Vue demo store, Audit check]
+    workflows:
+      [
+        Code examples,
+        Lighthouse CI,
+        Vue vite blank,
+        Vue Blank,
+        Vue demo store,
+        Audit check,
+      ]
     types: [completed]
-    branches: [main,prod]
+    branches: [main, prod]
 
 jobs:
   on-failure:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out'
     steps:
       - uses: ravsamhq/notify-slack-action@v2

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -6,7 +6,7 @@ on:
     - cron: "55 23 * * *"
 jobs:
   lighthouseci:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -15,7 +15,7 @@ jobs:
   publish:
     name: Publish canary version
     if: "!contains(github.event.commits[0].message, 'chore: next version release')"
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     permissions:
       id-token: write
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Create release PR or publish merged changesets
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/vue-blank.yml
+++ b/.github/workflows/vue-blank.yml
@@ -7,7 +7,7 @@ on:
     - cron: "51 23 * * *"
 jobs:
   run-code_examples-tests:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/vue-demo-store.yml
+++ b/.github/workflows/vue-demo-store.yml
@@ -7,7 +7,7 @@ on:
     - cron: "49 23 * * *"
 jobs:
   run-code_examples-tests:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/vue-vite-blank.yml
+++ b/.github/workflows/vue-vite-blank.yml
@@ -7,7 +7,7 @@ on:
     - cron: "46 23 * * *"
 jobs:
   run-code_examples-tests:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
### Description
Following the announcement: https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

We switch to `macos-14` runners, which should have a big impact on workflows.