### PR TITLE
fix(api-client): use `Accept: application/json` header by default

### DIFF
--- a/.changeset/loud-chicken-sin.md
+++ b/.changeset/loud-chicken-sin.md
@@ -1,0 +1,5 @@
+---
+"@shopware/api-client": patch
+---
+
+Added `Accept: application/json` default header to get only JSON responses.

--- a/packages/api-client-next/src/createApiClient.test.ts
+++ b/packages/api-client-next/src/createApiClient.test.ts
@@ -41,7 +41,6 @@ describe("createAPIClient", () => {
     const app = createApp().use(
       "/checkout/cart",
       eventHandler(async (event) => {
-        setHeader;
         return {
           headers: event.node.req.headers,
         };
@@ -142,6 +141,34 @@ describe("createAPIClient", () => {
       client.invoke("readCart get /checkout/cart"),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       "[ApiClientError: Failed request]",
+    );
+  });
+
+  it(`should by default include "Accept" header with "application/json" value`, async () => {
+    const seoUrlheadersSpy = vi.fn().mockImplementation((param: string) => {});
+    const app = createApp().use(
+      "/checkout/cart",
+      eventHandler(async (event) => {
+        const requestHeaders = getHeaders(event);
+        seoUrlheadersSpy(requestHeaders);
+        return {};
+      }),
+    );
+
+    const baseURL = await createPortAndGetUrl(app);
+
+    const client = createAPIClient<operations, operationPaths>({
+      accessToken: "123",
+      contextToken: "456",
+      baseURL,
+    });
+
+    await client.invoke("readCart get /checkout/cart");
+
+    expect(seoUrlheadersSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accept: "application/json",
+      }),
     );
   });
 });

--- a/packages/api-client-next/src/index.ts
+++ b/packages/api-client-next/src/index.ts
@@ -78,6 +78,7 @@ export function createAPIClient<
 }) {
   const defaultHeaders: Record<string, string> = {
     "sw-access-key": params.accessToken,
+    Accept: "application/json",
   };
 
   // protection from setting "null" or "undefined" as a token in API side
@@ -182,6 +183,7 @@ export function createAdminAPIClient<
 
   const defaultHeaders = {
     Authorization: createAuthorizationHeader(sessionData.accessToken),
+    Accept: "application/json",
   };
 
   function updateSessionData(responseData: {


### PR DESCRIPTION
### Description

<!-- Describe the changes you did and which issue you're closing -->

<!-- example: closes #007 -->
closes #554 

### Type of change
Header `Accept: application/json` should be enabled by default in requests