### PR TITLE
feat(api-client): provide optional `credentials` field for automatic authentication

### DIFF
--- a/.changeset/happy-doors-love.md
+++ b/.changeset/happy-doors-love.md
@@ -1,0 +1,5 @@
+---
+"@shopware/api-client": minor
+---
+
+[createAdminAPIClient] ability to pass optional field `credentials` to be used as authentication method before invoking any Admin API endpoint.

--- a/.changeset/quiet-rockets-laugh.md
+++ b/.changeset/quiet-rockets-laugh.md
@@ -1,5 +1,0 @@
----
-"@shopware/api-client": minor
----
-
-[createAdminAPIClient] Add the ability to use client_credentials (token-based) authentication for admin scope

--- a/packages/api-client-next/README.md
+++ b/packages/api-client-next/README.md
@@ -73,7 +73,45 @@ export type ApiReturnType<OPERATION_NAME extends keyof operations> =
 
 ## Admin API client setup
 
-The setup works the same way as `creteAPIClient` function, with few differences:
+The setup works the same way as `creteAPIClient` function, with few differences
+
+### credentials (optional) - Quick scripting or token-based authentication
+
+We provide optional `credentials` parameter to `createAdminAPIClient`. Which allows you to use authentication type of your choice whenever you wish to create connection to any endpoint.
+
+Example:
+
+```typescript
+import type {
+  operationPaths,
+  operations,
+  components,
+} from "@shopware/api-client/admin-api-types"; // we take default admin api types from different directory than store-api - use your own types by generating schema with @shopware/api-gen CLI
+
+const adminApiClient = createAdminAPIClient<operations, operationPaths>({
+  baseURL: `${process.env.SHOP_URL}/api`,
+  credentials: {
+    grant_type: "password",
+    client_id: "administration",
+    scopes: "write",
+    username: process.env.SHOP_ADMIN_USERNAME,
+    password: process.env.SHOP_ADMIN_PASSWORD,
+  },
+  // credentials: { // or token-based example
+  //   grant_type: "client_credentials",
+  //   client_id: "administration",
+  //   client_secret: process.env.SHOP_ADMIN_TOKEN,
+  // },
+});
+
+await adminApiClient.invoke(...); // invoke defined endpoint
+```
+
+### sessionData (optional) - Persistent authentication
+
+This parameter is used to store session data in cookies (or other place you want to store it), so you can keep your session persistent.
+
+You can combine this option with `credentials` property.
 
 ```typescript
 // example adminApiClient.ts file

--- a/packages/api-client-next/src/adminApiClientCredentials.test.ts
+++ b/packages/api-client-next/src/adminApiClientCredentials.test.ts
@@ -1,0 +1,181 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { listen } from "listhen";
+import type { Listener } from "listhen";
+import { createApp, eventHandler, toNodeListener, readBody } from "h3";
+import type { App } from "h3";
+import { createAdminAPIClient } from ".";
+import type { operationPaths, operations } from "../admin-api-types";
+
+describe("createAdminAPIClient - credentials", () => {
+  const listeners: Listener[] = [];
+  const consoleWarnSpy = vi.spyOn(console, "warn");
+  const authEndpointSpy = vi.fn().mockImplementation((param: string) => {});
+  const orderEndpointSpy = vi.fn().mockImplementation((param: string) => {});
+  let baseURL: string;
+
+  async function createPortAndGetUrl(appToCreate: App) {
+    try {
+      const listener = await listen(toNodeListener(appToCreate), {
+        port: {
+          portRange: [3700, 3799],
+        },
+      });
+      listeners.push(listener);
+      return listener.url;
+    } catch (e) {
+      console.error("Problem with port. Getting new one...", e);
+      return createPortAndGetUrl(appToCreate);
+    }
+  }
+
+  beforeAll(async () => {
+    const app = createApp()
+      .use(
+        "/order",
+        eventHandler(async (event) => {
+          orderEndpointSpy();
+          return {
+            orderResponse: 123,
+          };
+        }),
+      )
+      .use(
+        "/oauth/token",
+        eventHandler(async (event) => {
+          const body = await readBody(event);
+          authEndpointSpy(body);
+          return {
+            headers: event.node.req.headers,
+          };
+        }),
+      );
+
+    baseURL = await createPortAndGetUrl(app);
+    consoleWarnSpy.mockImplementation(() => {});
+  });
+
+  afterAll(async () => {
+    for (const listener of listeners) {
+      await listener.close().catch(console.error);
+    }
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should display warning before calling /oauth/token endpoint if neither credentials nor sessionData are passed", async () => {
+    const client = createAdminAPIClient<operations, operationPaths>({
+      baseURL,
+    });
+    await client.invoke("getOrderList get /order?limit,page,query", {});
+
+    expect(consoleWarnSpy).toHaveBeenLastCalledWith(
+      "[ApiClientWarning] No `credentials` or `sessionData` provided. Provide at least one of them to ensure authentication.",
+    );
+    expect(authEndpointSpy).toHaveBeenCalledWith({
+      client_id: "administration",
+      grant_type: "refresh_token",
+      refresh_token: "",
+    });
+  });
+
+  it("should use credentials when no session data available", async () => {
+    const client = createAdminAPIClient<operations, operationPaths>({
+      baseURL,
+      credentials: {
+        grant_type: "password",
+        username: "user",
+        password: "password",
+        client_id: "administration",
+        scopes: "write",
+      },
+    });
+    await client.invoke("getOrderList get /order?limit,page,query", {});
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(authEndpointSpy).toHaveBeenCalledWith({
+      grant_type: "password",
+      username: "user",
+      password: "password",
+      client_id: "administration",
+      scopes: "write",
+    });
+  });
+
+  it("should use token credentials when no session data available", async () => {
+    const client = createAdminAPIClient<operations, operationPaths>({
+      baseURL,
+      credentials: {
+        grant_type: "client_credentials",
+        client_id: "administration",
+        client_secret: "secret",
+      },
+    });
+    await client.invoke("getOrderList get /order?limit,page,query", {});
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(authEndpointSpy).toHaveBeenCalledWith({
+      grant_type: "client_credentials",
+      client_id: "administration",
+      client_secret: "secret",
+    });
+  });
+
+  it("should not use credentials when sessionData is available with refresh_token", async () => {
+    const client = createAdminAPIClient<operations, operationPaths>({
+      baseURL,
+      credentials: {
+        grant_type: "password",
+        username: "user",
+        password: "password",
+        client_id: "administration",
+        scopes: "write",
+      },
+      sessionData: {
+        refreshToken: "my-refresh-token",
+        accessToken: "my-access-token",
+        expirationTime: 0,
+      },
+    });
+    await client.invoke("getOrderList get /order?limit,page,query", {});
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(authEndpointSpy).toHaveBeenCalledWith({
+      grant_type: "refresh_token",
+      client_id: "administration",
+      refresh_token: "my-refresh-token",
+    });
+  });
+
+  it("should use credentials when it's token-based authentication and session expired", async () => {
+    const client = createAdminAPIClient<operations, operationPaths>({
+      baseURL,
+      credentials: {
+        grant_type: "client_credentials",
+        client_id: "administration",
+        client_secret: "secret",
+      },
+      sessionData: {
+        accessToken: "my-access-token",
+        expirationTime: 0,
+      },
+    });
+    await client.invoke("getOrderList get /order?limit,page,query", {});
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(authEndpointSpy).toHaveBeenCalledWith({
+      grant_type: "client_credentials",
+      client_id: "administration",
+      client_secret: "secret",
+    });
+  });
+});

--- a/packages/api-client-next/src/adminSessionData.test.ts
+++ b/packages/api-client-next/src/adminSessionData.test.ts
@@ -37,8 +37,7 @@ describe("Admin client session data", () => {
     });
   });
 
-  // TODO: skipped until https://github.com/vitest-dev/vitest/pull/4250 is released in >= 0.34.7
-  test.skip("fresh test should have empty session data", async ({
+  test("fresh test should have empty session data", async ({
     adminApiClient,
   }) => {
     expect(adminApiClient.getSessionData()).toEqual({

--- a/packages/api-client-next/src/createAdminApiClient.test.ts
+++ b/packages/api-client-next/src/createAdminApiClient.test.ts
@@ -156,9 +156,10 @@ describe("createAdminAPIClient", () => {
 
     const client = createAdminAPIClient<operations, operationPaths>({
       baseURL,
-      clientData: {
-        clientId: "my-client-id",
-        clientSecret: "my-client-secret-token",
+      credentials: {
+        grant_type: "client_credentials",
+        client_id: "my-client-id",
+        client_secret: "my-client-secret-token",
       },
       onAuthChange: onAuthChangeSpy,
     });
@@ -205,9 +206,10 @@ describe("createAdminAPIClient", () => {
 
     const client = createAdminAPIClient<operations, operationPaths>({
       baseURL,
-      clientData: {
-        clientId: "my-client-id",
-        clientSecret: "my-client-secret-token",
+      credentials: {
+        grant_type: "client_credentials",
+        client_id: "my-client-id",
+        client_secret: "my-client-secret-token",
       },
       onAuthChange: onAuthChangeSpy,
     });

--- a/templates/vue-demo-store/shopware.d.ts
+++ b/templates/vue-demo-store/shopware.d.ts
@@ -12,9 +12,9 @@ declare module "#shopware" {
 
   type changedComponents = defaultComponents;
   // example how to extend Cart schema:
-  // type changedComponents = components & {
+  // type changedComponents = defaultComponents & {
   //   schemas: {
-  //     Cart: components["schemas"]["Cart"] & {
+  //     Cart: defaultComponents["schemas"]["Cart"] & {
   //       myspecialfield: "hello field";
   //     };
   //   };


### PR DESCRIPTION

### Description

<!-- Describe the changes you did and which issue you're closing -->

<!-- example: closes #007 -->
closes: #553 

### Type of change

Replaced additional only token-based `clientData` with `optional `credentials` field.

This way, scripts or apps can provide admin authentication of their choice to be used automatically before invoking any endpoint.