### PR TITLE
feat(api-gen): change default content-type for admin loadSchema command

### DIFF
--- a/packages/api-gen/src/commands/loadSchema.ts
+++ b/packages/api-gen/src/commands/loadSchema.ts
@@ -78,7 +78,8 @@ export async function loadSchema(args: {
       apiJSON = await adminClient.invoke(
         "api-info get /_info/openapi3.json?type",
         {
-          type: "json",
+          // TODO: change to json once default content-type is changed NEXT-30635
+          type: "jsonapi",
         },
       );
     } else {


### PR DESCRIPTION
### Description

Enables to use `application/vnd.api+json` as default content-type when fetches admin schema.

That's because backend endpoints arent prepared yet to be `application/json` compatible.

<!-- example: closes #007 -->

### Type of change

<!-- Comment out the type of change your PR is making -->

<!-- Bug fix (non-breaking change that fixes an issue) -->
 New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

