### PR TITLE
fix(cms-base): prevent using setTimeout on server side for SwSlider

### DIFF
--- a/.changeset/perfect-shirts-beam.md
+++ b/.changeset/perfect-shirts-beam.md
@@ -1,0 +1,5 @@
+---
+"@shopware-pwa/cms-base": patch
+---
+
+Use setTimeout in SwSlider once component is mounted

--- a/packages/cms-base/components/SwSlider.vue
+++ b/packages/cms-base/components/SwSlider.vue
@@ -91,7 +91,7 @@ onBeforeUnmount(() => {
 });
 
 watch(
-  () => props.autoplay,
+  () => props.autoplay && isReady.value,
   (value) => {
     if (value) {
       autoPlayInterval.value = setInterval(() => {


### PR DESCRIPTION
### Description

hotfix solves 500 error on SSR caused by this problem: 
_vue:error H3Error: [nuxt] `setInterval` should not be used on the server. Consider wrapping it with an `onNuxtReady`, `onBeforeMount` or `onMounted` lifecycle hook, or ensure you only call it in the browser by checking `false`._

<!-- example: closes #007 -->

### Type of change

<!-- Comment out the type of change your PR is making -->

Bug fix (non-breaking change that fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

<!-- Add the todo's that need to be done before merge -->
<!-- Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. -->

 [x] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) 
<!-- - [ ] Documentation added/updated -->
<!-- - [ ] Unit-Tests added/updated -->
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
