### PR TITLE
fix: do not change context token if no context-token header in api re…

### DIFF
--- a/packages/api-client-next/src/createApiClient.test.ts
+++ b/packages/api-client-next/src/createApiClient.test.ts
@@ -120,6 +120,31 @@ describe("createAPIClient", () => {
     expect(contextChangedMock).toHaveBeenCalledWith("789");
   });
 
+  it("should NOT invoke onContextChanged method when no context header is set in response", async () => {
+    const app = createApp().use(
+      "/context",
+      eventHandler(async (event) => {
+        return {};
+      }),
+    );
+
+    const baseURL = await createPortAndGetUrl(app);
+
+    const contextChangedMock = vi
+      .fn()
+      .mockImplementation((param: string) => {});
+
+    const client = createAPIClient<operations, operationPaths>({
+      accessToken: "123",
+      contextToken: "456",
+      baseURL,
+      onContextChanged: contextChangedMock,
+    });
+
+    await client.invoke("readContext get /context");
+    expect(contextChangedMock).not.toHaveBeenCalled();
+  });
+
   it("should throw error when there is a problem with request", async () => {
     const app = createApp().use(
       "/checkout/cart",

--- a/packages/api-client-next/src/index.ts
+++ b/packages/api-client-next/src/index.ts
@@ -109,8 +109,9 @@ export function createAPIClient<
         defaultHeaders["sw-context-token"] !==
           context.response.headers.get("sw-context-token")
       ) {
-        const newContextToken =
-          context.response.headers.get("sw-context-token") || "";
+        const newContextToken = context.response.headers.get(
+          "sw-context-token",
+        ) as string;
         defaultHeaders["sw-context-token"] = newContextToken;
         params.onContextChanged?.(newContextToken);
       }

--- a/packages/api-client-next/src/index.ts
+++ b/packages/api-client-next/src/index.ts
@@ -105,8 +105,9 @@ export function createAPIClient<
     // async onRequestError({ request, options, error }) {},
     async onResponse(context) {
       if (
+        context.response.headers.has("sw-context-token") &&
         defaultHeaders["sw-context-token"] !==
-        context.response.headers.get("sw-context-token")
+          context.response.headers.get("sw-context-token")
       ) {
         const newContextToken =
           context.response.headers.get("sw-context-token") || "";


### PR DESCRIPTION
### Description

closes #622 

### Type of change
 do not change the context token if no context-token header was provided in the API response
