### PR TITLE
feat(api-client): headers management for api clients

### DIFF
--- a/.changeset/mean-pans-rescue.md
+++ b/.changeset/mean-pans-rescue.md
@@ -1,0 +1,28 @@
+---
+"@shopware/api-client": minor
+---
+
+Management of defaultHeaders. You can now set them on apiClient init or runtime.
+
+```ts
+const apiClient = createApiClient({
+  ...,
+  defaultHeaders: {
+    'sw-language-id': 'my-id',
+  },
+});
+
+console.log('Debug default headers:', apiClient.defaultHeaders);
+
+// Change header runtime
+apiClient.defaultHeaders['sw-language-id'] = 'my-new-id';
+
+// Remove header runtime
+apiClient.defaultHeaders['sw-language-id'] = "";
+
+// Change multiple headers runtime
+apiClient.defaultHeaders.apply({
+  'sw-language-id': 'another-id',
+  'sw-currency-id': 'currency-id',
+})
+```

--- a/packages/api-client-next/src/createApiClient.test.ts
+++ b/packages/api-client-next/src/createApiClient.test.ts
@@ -196,4 +196,33 @@ describe("createAPIClient", () => {
       }),
     );
   });
+
+  it("should change default headers", async () => {
+    const seoUrlheadersSpy = vi.fn().mockImplementation((param: string) => {});
+    const app = createApp().use(
+      "/checkout/cart",
+      eventHandler(async (event) => {
+        const requestHeaders = getHeaders(event);
+        seoUrlheadersSpy(requestHeaders);
+        return {};
+      }),
+    );
+
+    const baseURL = await createPortAndGetUrl(app);
+
+    const client = createAPIClient<operations, operationPaths>({
+      accessToken: "123",
+      contextToken: "456",
+      baseURL,
+    });
+
+    client.defaultHeaders.apply({ "sw-language-id": "my-language-id" });
+    await client.invoke("readCart get /checkout/cart");
+
+    expect(seoUrlheadersSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "sw-language-id": "my-language-id",
+      }),
+    );
+  });
 });

--- a/packages/api-client-next/src/createHeaders.test.ts
+++ b/packages/api-client-next/src/createHeaders.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { createHeaders } from "./defaultHeaders";
+
+describe("createHeaders", () => {
+  it("should create initial headers proxy", async () => {
+    const headers = createHeaders({});
+    expect(headers).toEqual({ "Content-Type": "application/json" });
+  });
+
+  it("should create proxi with initial data", async () => {
+    const headers = createHeaders({ "Content-Type": "text/plain" });
+    expect(headers).toEqual({ "Content-Type": "text/plain" });
+  });
+
+  it('should not allow to override "apply" method', async () => {
+    const headers = createHeaders({});
+    expect(() => {
+      // @ts-expect-error should not allow to override apply method
+      headers.apply = () => {};
+    }).toThrowErrorMatchingInlineSnapshot(
+      "[Error: Cannot override apply method]",
+    );
+  });
+
+  it("should delete header if value is nullish", async () => {
+    const headers = createHeaders({ "Content-Type": "text/plain" });
+    headers.apply({ "Content-Type": "" });
+    expect(headers).toEqual({});
+  });
+});

--- a/packages/api-client-next/src/defaultHeaders.ts
+++ b/packages/api-client-next/src/defaultHeaders.ts
@@ -1,0 +1,71 @@
+/**
+ * Source: https://github.com/shopware/shopware/blob/trunk/src/Core/PlatformRequest.php#L16
+ */
+type RequestHeaderName =
+  | "sw-context-token"
+  | "sw-access-key"
+  | "sw-language-id"
+  | "sw-currency-id"
+  | "sw-inheritance"
+  | "sw-version-id"
+  | "sw-include-seo-urls"
+  | "sw-skip-trigger-flow"
+  | "sw-app-integration-id"
+  | "indexing-behavior"
+  | "indexing-skip";
+
+export type ClientHeaders = Record<RequestHeaderName | string, string>;
+
+export type ClientHeadersProxy = ClientHeaders & {
+  /**
+   * Set default headers for the client.
+   * Default headers are added to every request.
+   * If the header value is falsy, it will be removed from the headers.
+   *
+   * @example
+   * ```ts
+   * apiClient.defaultHeaders.apply({
+   *  "sw-language-id": "my-language-id",
+   * });
+   * ```
+   */
+  readonly apply: (headers: ClientHeaders) => void;
+};
+
+export function createHeaders(init: ClientHeaders): ClientHeadersProxy {
+  const _headers: ClientHeaders = {
+    "Content-Type": "application/json",
+  };
+
+  const handler: ProxyHandler<ClientHeadersProxy> = {
+    get: (target: ClientHeaders, prop: string) => {
+      if (prop === "apply") {
+        return apply;
+      }
+      return Reflect.get(target, prop);
+    },
+    set: (target: ClientHeaders, prop: string, value: string) => {
+      if (prop === "apply") {
+        throw new Error("Cannot override apply method");
+      }
+      return Reflect.set(target, prop, value);
+    },
+  };
+
+  const headersProxy = new Proxy<ClientHeadersProxy>(
+    _headers as ClientHeadersProxy,
+    handler,
+  );
+  function apply(headers: ClientHeaders) {
+    for (const [key, value] of Object.entries(headers)) {
+      if (value) {
+        headersProxy[key] = value;
+      } else {
+        delete headersProxy[key];
+      }
+    }
+  }
+  headersProxy.apply({ ...init });
+
+  return headersProxy;
+}

--- a/packages/api-client-next/src/transformPathToQuery.ts
+++ b/packages/api-client-next/src/transformPathToQuery.ts
@@ -8,7 +8,7 @@ export function transformPathToQuery<T extends Record<string, unknown>>(
   {
     method: HttpMethod;
     query: Record<string, unknown>;
-    headers: HeadersInit;
+    headers: Record<string, string>;
     body?: Partial<T>;
   },
 ] {
@@ -30,7 +30,7 @@ export function transformPathToQuery<T extends Record<string, unknown>>(
 
   const headerParamnames = headerParams?.split(",") || [];
 
-  const headers: HeadersInit = {};
+  const headers: Record<string, string> = {};
 
   for (const paramName of headerParamnames) {
     headers[paramName] = params[paramName] as string;
@@ -52,7 +52,7 @@ export function transformPathToQuery<T extends Record<string, unknown>>(
     query,
   } as {
     method: HttpMethod;
-    headers: HeadersInit;
+    headers: Record<string, string>;
     query: Record<string, unknown>;
     body?: Partial<T>;
   };


### PR DESCRIPTION
### Description
closes #624
extended functionality of #625 


Possibility of setting, displaying and changing default headers, which are added to every request within the API client.