### PR TITLE
fix(cms): more beauty image gallery

### DIFF
--- a/packages/cms-base/components/SwSlider.vue
+++ b/packages/cms-base/components/SwSlider.vue
@@ -189,8 +189,6 @@ function buildImageSliderTrackStyle(
       height = childComponent?.children[0].children[0].clientHeight
         ? `${childComponent.clientHeight}px`
         : (height = `auto`);
-    } else if (displayModeValue.value === "contain") {
-      height = `${imageSliderTrack.value?.clientHeight}px`;
     }
     styleObj = {
       ...styleObj,

--- a/packages/cms-base/components/public/cms/element/CmsElementImage.vue
+++ b/packages/cms-base/components/public/cms/element/CmsElementImage.vue
@@ -10,6 +10,7 @@ import { computed, ref } from "vue";
 
 const props = defineProps<{
   content: CmsElementImage | CmsElementManufacturerLogo;
+  imageGallery?: boolean;
 }>();
 
 const { getUrlPrefix } = useUrlResolver();
@@ -54,6 +55,9 @@ const imageComputedContainerAttrs = computed(() => {
   <component
     v-if="imageAttrs.src"
     class="cms-element-image relative h-full w-full"
+    :class="{
+      'flex justify-center items-center': imageGallery,
+    }"
     :is="imageLink.url ? 'a' : 'div'"
     :style="containerStyle"
     v-bind="imageComputedContainerAttrs"
@@ -75,9 +79,11 @@ const imageComputedContainerAttrs = computed(() => {
       ref="imageElement"
       loading="lazy"
       :class="{
-        'h-full w-full': true,
+        'w-full h-full': !imageGallery,
+        'w-4/5': imageGallery,
         'absolute inset-0': ['cover', 'stretch'].includes(displayMode),
         'object-cover': displayMode === 'cover',
+        'object-contain': imageGallery,
       }"
       :alt="imageAttrs.alt"
       :src="srcPath"

--- a/packages/cms-base/components/public/cms/element/CmsElementImageGallery.vue
+++ b/packages/cms-base/components/public/cms/element/CmsElementImageGallery.vue
@@ -186,7 +186,7 @@ function next() {
             :key="image.media.url"
           >
             <div
-              class="w-14 h-20 overflow-hidden cursor-pointer p-1 border-secondary-200 rounded transition duration-150 ease-in-out"
+              class="w-20 h-20 overflow-hidden cursor-pointer p-1 border-secondary-200 rounded transition duration-150 ease-in-out"
               :class="{
                 border: i !== currentIndex,
                 'border-indigo-500 border-3': i === currentIndex,
@@ -228,6 +228,7 @@ function next() {
         <CmsElementImage
           v-for="image of mediaGallery"
           :key="image.media.url"
+          :imageGallery="true"
           :content="{ data: image, config: props.content.config } as any"
         />
       </SwSlider>


### PR DESCRIPTION
### Description

After a hard reload the image gallery was nice but with client navigation, it often happens that the images on PDP looked ugly. With those changes, this is fixed and always "beautiful". :joy: 

closes: #799

### Type of change

Bug fix (non-breaking change that fixes an issue)

### Screenshots (if applicable)

This (**current**):
![image](https://github.com/shopware/frontends/assets/3763023/6709b30f-b5b9-49ed-b0e7-f570afcec4f9)

vs

This (**fixed**):
![image](https://github.com/shopware/frontends/assets/3763023/1bbb45eb-8438-4246-a567-fcd4b3005f68)
