### PR TITLE
fix(cms): unify search and listing style

### DIFF
--- a/packages/cms-base/components/SwProductListingFilters.vue
+++ b/packages/cms-base/components/SwProductListingFilters.vue
@@ -189,7 +189,7 @@ onClickOutside(dropdownElement, () => (isSortMenuOpen.value = false));
   <div class="bg-white">
     <div class="mx-auto m-0" :class="{ 'px-5': isDefaultSidebarFilter }">
       <div
-        class="relative lg:flex lg:items-baseline lg:justify-between pt-6 pb-6 border-b border-gray-200"
+        class="relative flex items-baseline justify-between pt-6 pb-6 border-b border-gray-200"
       >
         <div class="text-4xl tracking-tight text-gray-900">
           {{ translations.listing.filters }}

--- a/packages/cms-base/components/public/cms/element/CmsElementProductListing.vue
+++ b/packages/cms-base/components/public/cms/element/CmsElementProductListing.vue
@@ -157,25 +157,25 @@ compareRouteQueryWithInitialListing();
       <div class="mt-6">
         <div
           v-if="!loading"
-          class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6 lg:gap-8 p-4 md:p-6 lg:p-8"
+          class="flex justify-center flex-wrap p-4 md:p-6 lg:p-8"
         >
           <SwProductCard
             v-for="product in getElements"
             :key="product.id"
             :product="product"
             :isProductListing="isProductListing"
-            class="p-4 border rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out"
+            class="p-4 border rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 ease-in-out w-full lg:w-3/7 2xl:w-7/24 mr-0 sm:mr-8 mb-8"
           />
         </div>
         <div
           v-if="loading"
           data-testid="loading"
-          class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6 lg:gap-8 p-4 md:p-6 lg:p-8"
+          class="flex justify-center flex-wrap p-4 md:p-6 lg:p-8"
         >
           <ProductCardSkeleton
             v-for="index in limit"
             :key="index"
-            class="w-full mb-8"
+            class="w-full mb-8 sm:w-3/7 lg:w-2/7 2xl:w-7/24 mr-0 sm:mr-8 mb-8"
           />
         </div>
         <div

--- a/packages/cms-base/components/public/cms/section/CmsSectionSidebar.vue
+++ b/packages/cms-base/components/public/cms/section/CmsSectionSidebar.vue
@@ -23,7 +23,7 @@ const { category } = useCategory();
         {{ getTranslatedProperty(category, "name") }}
       </h1>
     </div>
-    <div class="col-span-12 md:col-span-9 order-1 md:order-2">
+    <div class="col-span-12 md:col-span-7 lg:col-span-9 order-1 md:order-2">
       <CmsGenericBlock
         v-for="cmsBlock in mainBlocks"
         class="overflow-auto"
@@ -33,7 +33,7 @@ const { category } = useCategory();
     </div>
     <div
       :class="{
-        'align-top col-span-12 md:col-span-3 order-2 md:order-1':
+        'align-top col-span-12 md:col-span-5 lg:col-span-3 order-2 md:order-1':
           mobileBehavior !== 'hidden',
         'hidden md:block': mobileBehavior === 'hidden',
       }"

--- a/templates/vue-demo-store/pages/search.vue
+++ b/templates/vue-demo-store/pages/search.vue
@@ -305,7 +305,7 @@ export default {
 <template>
   <LayoutBreadcrumbs />
   <div class="mb-8 mx-4 md:mx-auto" data-testid="search-results-container">
-    <h1 class="mb-8 mt-8 md:mt-0 text-3xl text-center">
+    <h1 class="mb-8 mt-8 lg:mt-0 text-3xl text-center">
       <span v-if="products?.length"
         >{{ $t("search.resultsHeader") }} "<strong>{{
           route.query.search
@@ -315,10 +315,12 @@ export default {
       <span v-else>{{ $t("search.noResults") }}</span>
     </h1>
     <div class="cms-section-sidebar grid grid-cols-12 md:grid">
-      <div class="align-top col-span-12 md:col-span-3 order-2 md:order-1">
+      <div
+        class="align-top col-span-12 md:col-span-5 lg:col-span-3 order-2 md:order-1"
+      >
         <div class="px-5 mx-auto m-0">
           <div
-            class="relative lg:flex lg:items-baseline lg:justify-between pt-6 pb-6 border-b border-gray-200"
+            class="relative flex items-baseline justify-between pt-6 pb-6 border-b border-gray-200"
           >
             <div class="text-4xl tracking-tight text-gray-900">
               {{ $t("search.filters") }}
@@ -380,27 +382,27 @@ export default {
           <ListingFilters class="pr-4 md:pr-8 pb-16" />
         </div>
       </div>
-      <div class="col-span-12 md:col-span-9 order-1 md:order-2">
+      <div class="col-span-12 md:col-span-7 lg:col-span-9 order-1 md:order-2">
         <div
           v-if="loading"
           data-testid="loading"
-          class="flex justify-center lg:justify-initial flex-wrap p-4 md:p-6 lg:p-8"
+          class="flex justify-center flex-wrap p-4 md:p-6 lg:p-8"
         >
           <ProductCardSkeleton
             v-for="index in limit"
             :key="index"
-            class="w-full sm:w-3/7 lg:w-2/7 mr-0 sm:mr-8 mb-8"
+            class="w-full lg:w-3/7 2xl:w-7/24 mr-0 sm:mr-8 mb-8"
           />
         </div>
         <div
           v-if="!loading"
-          class="flex justify-center lg:justify-initial flex-wrap p-4 md:p-6 lg:p-8"
+          class="flex justify-center flex-wrap p-4 md:p-6 lg:p-8"
         >
           <ProductCard
             v-for="product in products"
             :key="product.id"
             :product="product"
-            class="w-full sm:w-3/7 lg:w-2/7 mr-0 sm:mr-8 mb-8"
+            class="w-full lg:w-3/7 2xl:w-7/24 mr-0 sm:mr-8 mb-8"
           />
         </div>
         <div


### PR DESCRIPTION
### Description

With that changes search and listing using the same flex style (removed grid) to display the products.

It looks much better on the different sizes ... also with fixed max-width elements like CMS pages.

### Type of change

Bug fix (non-breaking change that fixes an issue)

### Additional context

Compare the demo with the preview. You will :heart: it. :smiley: 
