### PR TITLE
fix(cms): shared listing bug

### DIFF
--- a/examples/adyen-dropin-component/app.vue
+++ b/examples/adyen-dropin-component/app.vue
@@ -9,7 +9,9 @@ const {
 } = useRuntimeConfig();
 
 // useListing for further product search
-const { search, getElements } = useProductSearchListing();
+const { search, getElements } = useListing({
+  listingType: "productSearchListing",
+});
 // composable used to add to cart a product
 const { addProduct } = useCart();
 // configured apiClient instance in order to make a custom API call

--- a/packages/cms-base/components/SwProductListingFilters.vue
+++ b/packages/cms-base/components/SwProductListingFilters.vue
@@ -8,7 +8,7 @@ import type {
   CmsElementSidebarFilter,
 } from "@shopware-pwa/composables-next";
 import { useCmsTranslations } from "@shopware-pwa/composables-next";
-import { useCategoryListing } from "#imports";
+import { useListing } from "#imports";
 import { onClickOutside } from "@vueuse/core";
 import { useRoute, useRouter } from "vue-router";
 import type { RequestParameters } from "#shopware";
@@ -48,7 +48,7 @@ const {
   getInitialFilters,
   getSortingOrders,
   search,
-} = useCategoryListing();
+} = useListing({ listingType: "categoryListing" });
 
 const sidebarSelectedFilters: UnwrapNestedRefs<{
   [key: string]: any;

--- a/packages/cms-base/components/public/cms/CmsPage.vue
+++ b/packages/cms-base/components/public/cms/CmsPage.vue
@@ -5,7 +5,7 @@ import {
   getCmsLayoutConfiguration,
   getBackgroundImageUrl,
 } from "@shopware-pwa/helpers-next";
-import { useCategoryListing, useNavigationContext } from "#imports";
+import { useListing, useNavigationContext } from "#imports";
 import { computed, h, resolveComponent } from "vue";
 import type { Schemas } from "#shopware";
 
@@ -15,7 +15,7 @@ const props = defineProps<{
 
 const { routeName } = useNavigationContext();
 if (routeName.value === "frontend.navigation.page") {
-  useCategoryListing();
+  useListing({ listingType: "categoryListing" });
 }
 
 const cmsSections = computed<CmsSection[]>(() => {

--- a/packages/cms-base/components/public/cms/element/CmsElementProductListing.vue
+++ b/packages/cms-base/components/public/cms/element/CmsElementProductListing.vue
@@ -3,7 +3,7 @@ import type { CmsElementProductListing } from "@shopware-pwa/composables-next";
 import { useCmsTranslations } from "@shopware-pwa/composables-next";
 import SwProductCard from "../../../SwProductCard.vue";
 import SwPagination from "../../../SwPagination.vue";
-import { useCategoryListing } from "#imports";
+import { useListing } from "#imports";
 import { computed, ref, watch } from "vue";
 import { defu } from "defu";
 import { useRoute, useRouter } from "vue-router";
@@ -40,9 +40,9 @@ const {
   getCurrentPage,
   getElements,
   getTotalPagesCount,
-  loading,
+  sharedLoading,
   setInitialListing,
-} = useCategoryListing();
+} = useListing({ listingType: "categoryListing" });
 const route = useRoute();
 const router = useRouter();
 const limit = ref(
@@ -156,7 +156,7 @@ compareRouteQueryWithInitialListing();
     <div class="max-w-2xl mx-auto lg:max-w-full">
       <div class="mt-6">
         <div
-          v-if="!loading"
+          v-if="!sharedLoading"
           class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6 lg:gap-8 p-4 md:p-6 lg:p-8"
         >
           <SwProductCard
@@ -168,7 +168,7 @@ compareRouteQueryWithInitialListing();
           />
         </div>
         <div
-          v-if="loading"
+          v-if="sharedLoading"
           data-testid="loading"
           class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6 lg:gap-8 p-4 md:p-6 lg:p-8"
         >

--- a/packages/composables/src/useListing.ts
+++ b/packages/composables/src/useListing.ts
@@ -4,7 +4,7 @@ import { getListingFilters } from "@shopware-pwa/helpers-next";
 import { useShopwareContext, useCategory } from "#imports";
 import ContextError from "./helpers/ContextError";
 import type { Schemas, RequestParameters } from "#shopware";
-import { createSharedComposable } from "@vueuse/core";
+import { useListingSharedLoading } from "./useListingSharedLoading";
 
 function isObject<T>(item: T): boolean {
   return item && typeof item === "object" && !Array.isArray(item);
@@ -151,6 +151,10 @@ export type UseListingReturn = {
    */
   loading: ComputedRef<boolean>;
   /**
+   * Indicates if the listing is being fetched
+   */
+  sharedLoading: ComputedRef<boolean>;
+  /**
    * Indicates if the listing is being fetched via `loadMore` method
    */
   loadingMore: ComputedRef<boolean>;
@@ -224,19 +228,6 @@ export function useListing(params?: {
 }
 
 /**
- * Temporary workaround over `useListing` to support shared data. This composable API will change in the future.
- */
-export const useCategoryListing = createSharedComposable(() =>
-  useListing({ listingType: "categoryListing" }),
-);
-/**
- * Temporary workaround over `useListing` to support shared data. This composable API will change in the future.
- */
-export const useProductSearchListing = createSharedComposable(() =>
-  useListing({ listingType: "productSearchListing" }),
-);
-
-/**
  * Factory to create your own listing.
  *
  * By default you can use useListing composable, which provides you predefined listings for category(cms) listing and product search listing.
@@ -268,6 +259,7 @@ export function createListingComposable({
   //   : contextName;
 
   const loading = ref(false);
+  const { sharedLoading } = useListingSharedLoading();
   const loadingMore = ref(false);
 
   // const { sharedRef } = useSharedState();
@@ -298,6 +290,7 @@ export function createListingComposable({
     criteria: RequestParameters<"searchPage">,
   ): Promise<Schemas["ProductListingResult"]> => {
     loading.value = true;
+    sharedLoading.value = true;
     try {
       const searchCriteria = merge(
         {} as RequestParameters<"searchPage">,
@@ -310,6 +303,7 @@ export function createListingComposable({
       throw e;
     } finally {
       loading.value = false;
+      sharedLoading.value = false;
     }
   };
 
@@ -320,6 +314,7 @@ export function createListingComposable({
     },
   ) {
     loading.value = true;
+    sharedLoading.value = true;
     try {
       const searchCriteria = merge(
         {} as RequestParameters<"searchPage">,
@@ -333,6 +328,7 @@ export function createListingComposable({
       throw e;
     } finally {
       loading.value = false;
+      sharedLoading.value = false;
     }
   }
 
@@ -533,6 +529,7 @@ export function createListingComposable({
     initSearch,
     loadMore,
     loading: computed(() => loading.value),
+    sharedLoading: computed(() => sharedLoading.value),
     loadingMore: computed(() => loadingMore.value),
     resetFilters,
     search,

--- a/packages/composables/src/useListingSharedLoading.ts
+++ b/packages/composables/src/useListingSharedLoading.ts
@@ -1,0 +1,13 @@
+import { ref } from "vue";
+import { createSharedComposable } from "@vueuse/core";
+
+function useListingSharedLoadingFunction() {
+  const sharedLoading = ref(false);
+  return {
+    sharedLoading,
+  };
+}
+
+export const useListingSharedLoading = createSharedComposable(
+  useListingSharedLoadingFunction,
+);

--- a/packages/composables/src/useProductSearchSuggest.ts
+++ b/packages/composables/src/useProductSearchSuggest.ts
@@ -1,6 +1,6 @@
 import { ref } from "vue";
 import type { ComputedRef, Ref } from "vue";
-import { useProductSearchListing } from "#imports";
+import { useListing } from "#imports";
 import type { Schemas, RequestParameters } from "#shopware";
 
 export type UseProductSearchSuggestReturn = {
@@ -42,7 +42,7 @@ export type UseProductSearchSuggestReturn = {
 export function useProductSearchSuggest(): UseProductSearchSuggestReturn {
   const searchTerm = ref("");
 
-  const listingComposable = useProductSearchListing();
+  const listingComposable = useListing({ listingType: "productSearchListing" });
 
   const search = async (
     additionalCriteria = {} as RequestParameters<"searchPage">,

--- a/templates/vue-demo-store/components/listing-filters/ListingFilters.vue
+++ b/templates/vue-demo-store/components/listing-filters/ListingFilters.vue
@@ -10,7 +10,7 @@ const {
   getCurrentSortingOrder,
   getInitialFilters,
   search,
-} = useProductSearchListing();
+} = useListing({ listingType: "productSearchListing" });
 
 const route = useRoute();
 const router = useRouter();

--- a/templates/vue-demo-store/pages/search.vue
+++ b/templates/vue-demo-store/pages/search.vue
@@ -15,7 +15,7 @@ const {
   loading,
   search,
   setInitialListing,
-} = useProductSearchListing();
+} = useListing({ listingType: "productSearchListing" });
 const { t } = useI18n();
 useBreadcrumbs([
   {


### PR DESCRIPTION
### Description

This will fix [this](https://shopwarecommunity.slack.com/archives/C050L6NCMGQ/p1711102032975949) issue, reported by the community.

**_In short:_**
Pagination shows the wrong products when jumping between categories and using multiple pages.

### Type of change

Bug fix (non-breaking change that fixes an issue)

### Additional context

I know we wanted to create a complete sharedComposable but currently, I reverted changes from @patzick because it kind of "cached" too much. With this approach loading effect is working and pagination shows the correct products. Anyway, we can discuss how to make this more beauty with a complete refactoring of useListing.
