### PR TITLE
fix: cached category id in listing state

### DIFF
--- a/packages/cms-base/components/public/cms/CmsPage.vue
+++ b/packages/cms-base/components/public/cms/CmsPage.vue
@@ -5,7 +5,7 @@ import {
   getCmsLayoutConfiguration,
   getBackgroundImageUrl,
 } from "@shopware-pwa/helpers-next";
-import { useCategoryListing, useNavigationContext } from "#imports";
+import { useNavigationContext, createCategoryListingContext } from "#imports";
 import { computed, h, resolveComponent } from "vue";
 import type { Schemas } from "#shopware";
 
@@ -15,7 +15,7 @@ const props = defineProps<{
 
 const { routeName } = useNavigationContext();
 if (routeName.value === "frontend.navigation.page") {
-  useCategoryListing();
+  createCategoryListingContext();
 }
 
 const cmsSections = computed<CmsSection[]>(() => {

--- a/packages/composables/src/useContext.ts
+++ b/packages/composables/src/useContext.ts
@@ -1,4 +1,5 @@
-import { inject, provide, ref, unref } from "vue";
+import { ref, unref } from "vue";
+import { provideLocal, injectLocal } from "@vueuse/core";
 import type { Ref } from "vue";
 
 /**
@@ -20,8 +21,8 @@ export function useContext<T>(
 
   const _context: Ref<T> = isNewContext
     ? (ref(unref(params?.context)) as Ref<T>)
-    : (inject(injectionName, ref()) as Ref<T>);
-  provide(injectionName, _context);
+    : (injectLocal(injectionName, ref()) as Ref<T>);
+  provideLocal(injectionName, _context);
 
   /**
    * Used for global context to replace it with new Value. Used mainly for session context


### PR DESCRIPTION
### Description

Alternative to #823
Related: #841

Creates a workaround for listing by creating listing context and addressing it in child components.
This also fixes the bug described in PR above.


@BrocksiNet please check if that covers all the cases you wanted to solve with that PR.
