### PR TITLE
feat: keyboard navigation and improved mobile sidebar

### DIFF
--- a/.changeset/young-files-laugh.md
+++ b/.changeset/young-files-laugh.md
@@ -1,0 +1,5 @@
+---
+"@shopware-pwa/cms-base": patch
+---
+
+Moved the svg 3d media placeholder to the vue component

--- a/packages/cms-base/components/public/cms/element/CmsElementImageGallery.vue
+++ b/packages/cms-base/components/public/cms/element/CmsElementImageGallery.vue
@@ -195,10 +195,8 @@ function next() {
               @click="() => changeCover(i)"
             >
               <div v-if="isSpatial(image.media)" class="h-full relative">
-                <img
+                <CmsElementImageGallery3dPlaceholder
                   class="w-full h-full object-center"
-                  src="~/assets/3d.svg"
-                  alt="3d object"
                 />
                 <span
                   class="absolute bottom-0 text-sm bg-gray rounded px-1 text-white"

--- a/packages/cms-base/components/public/cms/element/CmsElementImageGallery3dPlaceholder.vue
+++ b/packages/cms-base/components/public/cms/element/CmsElementImageGallery3dPlaceholder.vue
@@ -1,0 +1,53 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="552"
+    height="383"
+    viewBox="0 0 552 383"
+  >
+    <defs>
+      <g
+        fill="none"
+        fill-rule="evenodd"
+        opacity=".65"
+        id="icons-default-placeholder"
+      >
+        <rect
+          width="333.061"
+          height="499.591"
+          x="84.659"
+          y="-82.663"
+          fill="#E9EBF2"
+          fill-rule="nonzero"
+          transform="rotate(-89.862 251.19 167.132)"
+        ></rect>
+        <g transform="translate(51 49)">
+          <rect
+            width="333.06"
+            height="499.59"
+            x="83.983"
+            y="-83.234"
+            fill="#DADDE5"
+            fill-rule="nonzero"
+            transform="rotate(-90 250.513 166.561)"
+          ></rect>
+          <polygon
+            fill="#E9EBF2"
+            points="137.18 333.1 500.31 333.1 500.31 302.36 322.15 110.42"
+          ></polygon>
+          <circle cx="113.04" cy="65.68" r="35.9" fill="#F5F7FC"></circle>
+          <polygon
+            fill="#F5F7FC"
+            points="219.88 157.3 73.85 333.1 383.05 333.1"
+          ></polygon>
+        </g>
+      </g>
+    </defs>
+    <use
+      xlink:href="#icons-default-placeholder"
+      fill="#758CA3"
+      fill-rule="evenodd"
+    ></use>
+  </svg>
+</template>

--- a/templates/vue-demo-store/components/layout/LayoutSideMenu.vue
+++ b/templates/vue-demo-store/components/layout/LayoutSideMenu.vue
@@ -46,9 +46,9 @@ const toggleCollapse = (navigationElement: Schemas["Category"]) => {
         <div class="i-carbon-close text-3xl" />
       </button>
     </div>
-    <div class="max-w-2xl">
-      <aside aria-label="Sidebar" class="flex flex-col">
-        <div class="w-full px-4 pb-4">
+    <div class="flex-1 flex flex-row overflow-y-hidden max-w-2xl w-full">
+      <aside aria-label="Sidebar" class="flex flex-col overflow-y-auto w-full">
+        <div class="px-4 pb-4">
           <LayoutStoreSearch @link-clicked="sideMenuController.close" />
         </div>
         <div class="overflow-y-auto">

--- a/templates/vue-demo-store/components/layout/LayoutTopNavigationRecursive.vue
+++ b/templates/vue-demo-store/components/layout/LayoutTopNavigationRecursive.vue
@@ -14,6 +14,7 @@ const { formatLink } = useInternationalization(localePath);
 
 defineProps<{
   navigationElementChildren: Array<NavigationElement>;
+  lastElement?: boolean;
 }>();
 
 const emits = defineEmits<{
@@ -22,6 +23,7 @@ const emits = defineEmits<{
     navigationId: string,
     parentId: string | undefined,
   ): void;
+  (e: "focusoutLastElement", lastElement: boolean): void;
 }>();
 
 const emitUpdateActiveClass = (
@@ -34,7 +36,7 @@ const emitUpdateActiveClass = (
 
 <template>
   <template
-    v-for="childElement in navigationElementChildren"
+    v-for="(childElement, index) in navigationElementChildren"
     :key="childElement.id"
   >
     <div class="relative grid gap-6 bg-white px-3 py-2">
@@ -48,6 +50,13 @@ const emitUpdateActiveClass = (
         }"
         class="flex justify-between rounded-lg hover:bg-secondary-50 p-2"
         @click="emitUpdateActiveClass(childElement.id, childElement.parentId)"
+        @focusout="
+          $props.lastElement === true &&
+          navigationElementChildren &&
+          navigationElementChildren.length - 1 === index
+            ? emits('focusoutLastElement', true)
+            : null
+        "
       >
         <div
           class="flex flex-col flex-grow pl-2"

--- a/templates/vue-demo-store/components/layout/LayoutTopNavigationRecursive.vue
+++ b/templates/vue-demo-store/components/layout/LayoutTopNavigationRecursive.vue
@@ -34,15 +34,10 @@ const emitUpdateActiveClass = (
 
 <template>
   <template
-    v-for="(childElement, index) in navigationElementChildren"
+    v-for="childElement in navigationElementChildren"
     :key="childElement.id"
   >
-    <div
-      :class="{
-        'sm:pb-0': index !== navigationElementChildren.length - 1,
-      }"
-      class="relative grid gap-6 bg-white px-3 py-2 sm:gap-6 sm:p-3"
-    >
+    <div class="relative grid gap-6 bg-white px-3 py-2">
       <NuxtLink
         :to="formatLink(getCategoryRoute(childElement))"
         :target="


### PR DESCRIPTION
### Description

- It allows you to use ArrowDown, ArrowUp, and Escape to navigate the top navigation.
- You can now scroll inside the mobile top navigation

### Type of change

New feature (non-breaking change which adds functionality)

### Additional context

Still you could add ArrowLeft and ArrowRight for the top levels.
Also, I did not test this with a 3-level navigation.
First I want to know if there is maybe a better way to do this (discussion).
