### PR TITLE
feat: keyboard navigation and improved mobile sidebar

### DIFF
--- a/templates/vue-demo-store/components/layout/LayoutSideMenu.vue
+++ b/templates/vue-demo-store/components/layout/LayoutSideMenu.vue
@@ -46,9 +46,9 @@ const toggleCollapse = (navigationElement: Schemas["Category"]) => {
         <div class="i-carbon-close text-3xl" />
       </button>
     </div>
-    <div class="max-w-2xl">
-      <aside aria-label="Sidebar" class="flex flex-col">
-        <div class="w-full px-4 pb-4">
+    <div class="flex-1 flex flex-row overflow-y-hidden max-w-2xl w-full">
+      <aside aria-label="Sidebar" class="flex flex-col overflow-y-auto w-full">
+        <div class="px-4 pb-4">
           <LayoutStoreSearch @link-clicked="sideMenuController.close" />
         </div>
         <div class="overflow-y-auto">

--- a/templates/vue-demo-store/components/layout/LayoutTopNavigationRecursive.vue
+++ b/templates/vue-demo-store/components/layout/LayoutTopNavigationRecursive.vue
@@ -14,6 +14,7 @@ const { formatLink } = useInternationalization(localePath);
 
 defineProps<{
   navigationElementChildren: Array<NavigationElement>;
+  lastElement?: boolean;
 }>();
 
 const emits = defineEmits<{
@@ -22,6 +23,7 @@ const emits = defineEmits<{
     navigationId: string,
     parentId: string | undefined,
   ): void;
+  (e: "focusoutLastElement", lastElement: boolean): void;
 }>();
 
 const emitUpdateActiveClass = (
@@ -34,7 +36,7 @@ const emitUpdateActiveClass = (
 
 <template>
   <template
-    v-for="childElement in navigationElementChildren"
+    v-for="(childElement, index) in navigationElementChildren"
     :key="childElement.id"
   >
     <div class="relative grid gap-6 bg-white px-3 py-2">
@@ -48,6 +50,13 @@ const emitUpdateActiveClass = (
         }"
         class="flex justify-between rounded-lg hover:bg-secondary-50 p-2"
         @click="emitUpdateActiveClass(childElement.id, childElement.parentId)"
+        @focusout="
+          $props.lastElement === true &&
+          navigationElementChildren &&
+          navigationElementChildren.length - 1 === index
+            ? emits('focusoutLastElement', true)
+            : null
+        "
       >
         <div
           class="flex flex-col flex-grow pl-2"

--- a/templates/vue-demo-store/components/layout/LayoutTopNavigationRecursive.vue
+++ b/templates/vue-demo-store/components/layout/LayoutTopNavigationRecursive.vue
@@ -34,15 +34,10 @@ const emitUpdateActiveClass = (
 
 <template>
   <template
-    v-for="(childElement, index) in navigationElementChildren"
+    v-for="childElement in navigationElementChildren"
     :key="childElement.id"
   >
-    <div
-      :class="{
-        'sm:pb-0': index !== navigationElementChildren.length - 1,
-      }"
-      class="relative grid gap-6 bg-white px-3 py-2 sm:gap-6 sm:p-3"
-    >
+    <div class="relative grid gap-6 bg-white px-3 py-2">
       <NuxtLink
         :to="formatLink(getCategoryRoute(childElement))"
         :target="


### PR DESCRIPTION
### Description

- It allows you to use ArrowDown, ArrowUp, and Escape to navigate the top navigation.
- You can now scroll inside the mobile top navigation

### Type of change

New feature (non-breaking change which adds functionality)

### Additional context

Still you could add ArrowLeft and ArrowRight for the top levels.
Also, I did not test this with a 3-level navigation.
First I want to know if there is maybe a better way to do this (discussion).
