### PR TITLE
feat(templates): new way of handling a context change for vue-vite-blank

### DIFF
--- a/templates/vue-vite-blank/src/apiClient.ts
+++ b/templates/vue-vite-blank/src/apiClient.ts
@@ -6,11 +6,4 @@ export const apiClient = createAPIClient<operations>({
   baseURL: import.meta.env.VITE_DEMO_API_URL,
   accessToken: import.meta.env.VITE_DEMO_API_ACCESS_TOKEN,
   contextToken: Cookies.get("sw-context-token"),
-  onContextChanged(newContextToken) {
-    Cookies.set("sw-context-token", newContextToken, {
-      expires: 365, // days
-      path: "/",
-      sameSite: "lax",
-    });
-  },
 });

--- a/templates/vue-vite-blank/src/apiClient.ts
+++ b/templates/vue-vite-blank/src/apiClient.ts
@@ -2,8 +2,19 @@ import { createAPIClient } from "@shopware/api-client";
 import type { operations } from "#shopware";
 import Cookies from "js-cookie";
 
+const shopwareEndpoint = import.meta.env.VITE_DEMO_API_URL;
+
 export const apiClient = createAPIClient<operations>({
-  baseURL: import.meta.env.VITE_DEMO_API_URL,
+  baseURL: shopwareEndpoint,
   accessToken: import.meta.env.VITE_DEMO_API_ACCESS_TOKEN,
   contextToken: Cookies.get("sw-context-token"),
+});
+
+apiClient.hook("onContextChanged", (newContextToken) => {
+  Cookies.set("sw-context-token", newContextToken, {
+    expires: 365, // days
+    path: "/",
+    sameSite: "lax",
+    secure: shopwareEndpoint.startsWith("https://"),
+  });
 });

--- a/templates/vue-vite-blank/src/main.ts
+++ b/templates/vue-vite-blank/src/main.ts
@@ -1,9 +1,17 @@
 import { createApp } from "vue";
 import "./style.css";
 import App from "./App.vue";
-
+import Cookies from "js-cookie";
 import { createShopwareContext } from "@shopware-pwa/composables-next/lib";
 import { apiClient } from "./apiClient";
+
+apiClient.hook("onContextChanged", (newContextToken) => {
+  Cookies.set("sw-context-token", newContextToken, {
+    expires: 365, // days
+    path: "/",
+    sameSite: "lax",
+  });
+});
 
 const app = createApp(App);
 

--- a/templates/vue-vite-blank/src/main.ts
+++ b/templates/vue-vite-blank/src/main.ts
@@ -1,17 +1,8 @@
 import { createApp } from "vue";
 import "./style.css";
 import App from "./App.vue";
-import Cookies from "js-cookie";
 import { createShopwareContext } from "@shopware-pwa/composables-next/lib";
 import { apiClient } from "./apiClient";
-
-apiClient.hook("onContextChanged", (newContextToken) => {
-  Cookies.set("sw-context-token", newContextToken, {
-    expires: 365, // days
-    path: "/",
-    sameSite: "lax",
-  });
-});
 
 const app = createApp(App);
 


### PR DESCRIPTION
### Description

fixes the vue-vite-blank template to run it without having the console errors about deprecation

you can preview the template after update: https://stackblitz.com/github/shopware/frontends/tree/feat/new-hook-vue-vite-blank/templates/vue-vite-blank

### Type of change

<!-- Comment out the type of change your PR is making -->

<!-- Bug fix (non-breaking change that fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

<!-- Add the todo's that need to be done before merge -->
<!-- Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. -->

<!-- - [ ] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) -->
<!-- - [ ] Documentation added/updated -->
<!-- - [ ] Unit-Tests added/updated -->
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
