### PR TITLE
feat(api-gen): command to validate json output

### DIFF
--- a/.changeset/nine-readers-relate.md
+++ b/.changeset/nine-readers-relate.md
@@ -1,0 +1,5 @@
+---
+"@shopware/api-gen": minor
+---
+
+New command `validateJson` to check correctness of your OpenAPI json file.

--- a/packages/api-gen/README.md
+++ b/packages/api-gen/README.md
@@ -150,6 +150,31 @@ SHOPWARE_ADMIN_USERNAME="my@username.com"
 SHOPWARE_ADMIN_PASSWORD="my-password"
 ```
 
+### `validateJson`
+
+This command allow to validate the output JSON file of your instance. You can configure which rules should be applied, we provide you with the schema configuration file, so you can easily modify it.
+
+options:
+
+```bash
+pnpx @shopware/api-gen validateJson --help
+
+# validate JSON file
+pnpx @shopware/api-gen validateJson --apiType=store
+```
+
+this searches for `api-types/storeApiTypes.json` file and validates it. Use [loadSchema](#loadSchema) command first to fetch your JSON file.
+
+Prepare your config file named **api-gen.config.json**:
+
+```JSON
+{
+  "$schema": "https://raw.githubusercontent.com/shopware/frontends/main/packages/api-gen/api-gen.schema.json",
+  "rules": [
+    "COMPONENTS_API_ALIAS" // you have description on autocompletion what specific rule does, this one for example ensures correctness of the apiAlias field
+  ]
+}
+
 <!-- AUTO GENERATED CHANGELOG -->
 
 ## Changelog
@@ -164,3 +189,4 @@ Full changelog for stable version is available [here](https://github.com/shopwar
 
   - Changed dependency _openapi-typescript_ from **^6.7.0** to **^6.7.1**
   - Changed dependency _prettier_ from **^3.0.3** to **^3.1.0**
+```

--- a/packages/api-gen/README.md
+++ b/packages/api-gen/README.md
@@ -174,6 +174,7 @@ Prepare your config file named **api-gen.config.json**:
     "COMPONENTS_API_ALIAS" // you have description on autocompletion what specific rule does, this one for example ensures correctness of the apiAlias field
   ]
 }
+```
 
 <!-- AUTO GENERATED CHANGELOG -->
 
@@ -189,4 +190,3 @@ Full changelog for stable version is available [here](https://github.com/shopwar
 
   - Changed dependency _openapi-typescript_ from **^6.7.0** to **^6.7.1**
   - Changed dependency _prettier_ from **^3.0.3** to **^3.1.0**
-```

--- a/packages/api-gen/api-gen.schema.json
+++ b/packages/api-gen/api-gen.schema.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "rules": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "anyOf": [
+          {
+            "const": "COMPONENTS_API_ALIAS",
+            "description": "Enforce proper apiAlias fields on components"
+          }
+        ]
+      }
+    }
+  },
+  "required": ["rules"]
+}

--- a/packages/api-gen/src/cli.ts
+++ b/packages/api-gen/src/cli.ts
@@ -5,6 +5,7 @@ import { hideBin } from "yargs/helpers";
 import { generate } from "./commands/generate";
 import packageJson from "../package.json";
 import { loadSchema } from "./commands/loadSchema";
+import { validateJson } from "./commands/validateJson";
 
 export interface CommonOptions {
   cwd: string;
@@ -66,6 +67,26 @@ yargs(hideBin(process.argv))
         .help();
     },
     async (args) => loadSchema(args),
+  )
+  .command(
+    "validateJson",
+    "Validate JSON schema with the ruleset",
+    (args) => {
+      return commonOptions(args)
+        .option("apiType", {
+          describe:
+            "Type of the API schema to load. It can be 'store' or 'admin'",
+          default: "store",
+          choices: ["store", "admin"],
+        })
+        .positional("filename", {
+          type: "string",
+          describe:
+            "name of the schema json file. The default (based on apiType parameter) is 'storeApiSchema.json' or 'adminApiSchema.json'",
+        })
+        .help();
+    },
+    async (args) => validateJson(args),
   )
   .showHelpOnFail(false)
   .alias("h", "help")

--- a/packages/api-gen/src/commands/validateJson.ts
+++ b/packages/api-gen/src/commands/validateJson.ts
@@ -1,0 +1,104 @@
+import { join } from "node:path";
+import c from "picocolors";
+import { readFileSync } from "node:fs";
+import type { ObjectSubtype, OpenAPI3 } from "openapi-typescript";
+import { validationRules } from "../validation-rules";
+
+export async function validateJson(args: {
+  cwd: string;
+  filename?: string;
+  apiType: string;
+}) {
+  const schemaFilenameToValidate = args.filename
+    ? args.filename
+    : `${args.apiType}ApiSchema.json`;
+
+  const filePath = join("api-types", schemaFilenameToValidate);
+  const fileContent = await readFileSync(filePath, {
+    encoding: "utf-8",
+  });
+
+  let fileContentAsJson: OpenAPI3;
+  try {
+    fileContentAsJson = JSON.parse(fileContent) as OpenAPI3;
+  } catch (error) {
+    console.error(
+      c.red(
+        `Error while parsing JSON schema file ${filePath}. Check whether the file is correct JSON file.\n`,
+      ),
+      error,
+    );
+    process.exit(1);
+  }
+
+  // load config
+  let configJSON: { rules: string[] };
+  try {
+    const config = await readFileSync("api-gen.config.json", {
+      // TODO: use c12 library for that
+      // name: "api-gen", // file should be "api-gen.config.json"
+      encoding: "utf-8",
+    });
+    configJSON = JSON.parse(config);
+  } catch (error) {
+    console.error(
+      c.red(
+        `Error while parsing config file api-gen.config.json. Check whether the file is correct JSON file.\n`,
+      ),
+      error,
+    );
+    process.exit(1);
+  }
+
+  const rulesToProcess = (configJSON?.rules || []) as Array<
+    keyof typeof validationRules
+  >;
+
+  if (!rulesToProcess.length) {
+    console.error(
+      c.red(
+        `No rules to process. Check your ${c.bold("api-gen.config.json")} file.`,
+      ),
+    );
+    process.exit(1);
+  }
+
+  const errors: string[] = [];
+
+  Object.entries(fileContentAsJson.components?.schemas || {}).forEach(
+    (schema) => {
+      rulesToProcess.forEach((ruleName) => {
+        if (!validationRules[ruleName]) {
+          console.error(
+            c.red(
+              `Validation rule ${c.bold(
+                ruleName,
+              )} is not implemented. Check your ${c.bold("api-gen.config.json")} file.`,
+            ),
+          );
+          process.exit(1);
+        }
+        const res = validationRules[ruleName]?.(
+          schema[0],
+          schema[1] as ObjectSubtype,
+        );
+        if (res) {
+          errors.push(res);
+        }
+      });
+    },
+  );
+
+  if (errors.length) {
+    console.error(c.red("Errors found:"));
+    errors.forEach((error) => {
+      console.error(`\n<==== ${c.red("ERROR")}:\n${error}\n====>\n\n`);
+    });
+    console.error(
+      c.red(`Validation failed with ${c.bold(errors.length)} errors.`),
+    );
+    process.exit(1);
+  } else {
+    console.log(c.green("Validation passed successfully."));
+  }
+}

--- a/packages/api-gen/src/validation-rules/componentsApiAlias.rule.test.ts
+++ b/packages/api-gen/src/validation-rules/componentsApiAlias.rule.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import componentsApiAliasRule from "./componentsApiAlias.rule";
+import { ObjectSubtype } from "openapi-typescript";
+
+describe("componentsApiAlias.rule", async () => {
+  it("Lowercase component name is proper name", async () => {
+    const componentName = "Category";
+    const body = {
+      type: "object",
+      properties: {
+        apiAlias: {
+          type: "string",
+          enum: ["category"],
+        },
+      },
+    } as ObjectSubtype;
+
+    const result = componentsApiAliasRule(componentName, body);
+
+    expect(result).toBe(null);
+  });
+
+  it("alias should be written in snake_case", async () => {
+    const componentName = "CmsBlock";
+    const body = {
+      type: "object",
+      properties: {
+        apiAlias: {
+          type: "string",
+          enum: ["cms_block"],
+        },
+      },
+    } as ObjectSubtype;
+
+    const result = componentsApiAliasRule(componentName, body);
+
+    expect(result).toBe(null);
+  });
+
+  it("should fail if alias is not in snake_case", async () => {
+    const componentName = "CmsBlock";
+    const body = {
+      type: "object",
+      properties: {
+        apiAlias: {
+          type: "string",
+          enum: ["cmsBlock"],
+        },
+      },
+    } as ObjectSubtype;
+
+    const result = componentsApiAliasRule(componentName, body);
+
+    expect(result).not.toBe(null);
+  });
+
+  it("should fail if name is not matching component name", async () => {
+    const componentName = "PriceDefinition";
+    const body = {
+      type: "object",
+      properties: {
+        apiAlias: {
+          type: "string",
+          enum: ["cart_price_quantity"],
+        },
+      },
+    } as ObjectSubtype;
+
+    const result = componentsApiAliasRule(componentName, body);
+
+    expect(result).not.toBe(null);
+  });
+
+  it("should not fail if component definition does not have apiAlias", async () => {
+    const componentName = "PriceDefinition";
+    const body = {
+      type: "object",
+      properties: {},
+    } as ObjectSubtype;
+
+    const result = componentsApiAliasRule(componentName, body);
+
+    expect(result).toBe(null);
+  });
+
+  it("should fail if apiALias exist but is not marked as required", async () => {
+    const componentName = "Cart";
+    const body = {
+      type: "object",
+      required: ["id"],
+      properties: {
+        apiAlias: {
+          type: "string",
+          enum: ["cart"],
+        },
+      },
+    } as ObjectSubtype;
+
+    const result = componentsApiAliasRule(componentName, body);
+
+    expect(result).not.toBe(null);
+  });
+});

--- a/packages/api-gen/src/validation-rules/componentsApiAlias.rule.ts
+++ b/packages/api-gen/src/validation-rules/componentsApiAlias.rule.ts
@@ -1,0 +1,41 @@
+import { snakeCase } from "scule";
+import { equals } from "@vitest/expect";
+import { diff } from "@vitest/utils/diff";
+import c from "picocolors";
+import type { ObjectSubtype } from "openapi-typescript";
+
+export default (componentName: string, body: ObjectSubtype) => {
+  // aliast needs to be in snake case. Examples:
+  // - "Category" is "category"
+  // - "CmsBlock" is "cms_block"
+  const properAliasDefinition = {
+    type: "string",
+    enum: [snakeCase(componentName)],
+  };
+
+  const bodyValue = body.properties?.apiAlias;
+
+  // skip if apiAlias is not defined
+  if (!bodyValue) {
+    return null;
+  }
+
+  // check if apiAlias is required
+  if (body.required && !body.required.includes("apiAlias")) {
+    return `Component ${c.bold(componentName)} has invalid ${c.bold("apiAlias")} definition. This field should be required.`;
+  }
+
+  const result = equals(properAliasDefinition, bodyValue);
+  if (!result) {
+    return `Component ${c.bold(componentName)} has invalid ${c.bold("apiAlias")} definition. Diff:\n ${diff(
+      properAliasDefinition,
+      bodyValue,
+      {
+        aColor: c.green,
+        bColor: c.red,
+      },
+    )}`;
+  }
+
+  return null;
+};

--- a/packages/api-gen/src/validation-rules/index.ts
+++ b/packages/api-gen/src/validation-rules/index.ts
@@ -1,0 +1,5 @@
+import componentsApiAliasRule from "./componentsApiAlias.rule";
+
+export const validationRules = {
+  COMPONENTS_API_ALIAS: componentsApiAliasRule,
+};

--- a/packages/api-gen/vitest.config.ts
+++ b/packages/api-gen/vitest.config.ts
@@ -5,8 +5,27 @@ export default defineConfig({
   plugins: [codspeedPlugin()],
   test: {
     coverage: {
-      // enabled: true,
-      "100": true,
+      enabled: true,
+      reportOnFailure: true,
+      include: ["src"],
+      exclude: [
+        // "**/cli.ts", // this file is only a config
+        // "**/patches.ts", // this file will be removed, as patching is done by overrides now
+        // "**/commands/generate.ts", // TODO: this file should be tested
+        // "**/*.test-d.ts",
+        // "**/*.bench.ts",
+        // "**/*/playground.ts",
+      ],
+      thresholds: {
+        // {
+        "**/**.rule.ts": {
+          branches: 100,
+          functions: 100,
+          lines: 100,
+          statements: 100,
+        },
+        // }
+      },
     },
   },
 });


### PR DESCRIPTION
### Description

<!-- Describe the changes you did and which issue you're closing -->

<!-- example: closes #007 -->
With this new command in CLI we can validate JSON schema output with configured rules.

For now, only the first rule is added. Every rule must have 100% test coverage and a description in the schema file.

Example of validation with errors (current store schema):
![image](https://github.com/shopware/frontends/assets/13100280/d4ef9ca6-3b68-4fe3-a2e1-dbda79bbf17d)
