### PR TITLE
fix(vue-demo): password reset page

### DIFF
--- a/.changeset/metal-clocks-repeat.md
+++ b/.changeset/metal-clocks-repeat.md
@@ -1,0 +1,6 @@
+---
+"vue-demo-store": patch
+---
+
+- Added missing `same password` error message
+- Changed the success message block to reset after each click on the main button

--- a/templates/vue-demo-store/components/account/AccountChangePassword.vue
+++ b/templates/vue-demo-store/components/account/AccountChangePassword.vue
@@ -49,6 +49,7 @@ const $v = useVuelidate(rules, state);
 
 const invokeChange = async (): Promise<void> => {
   loadingData.value = true;
+  isSuccess.value = false;
   try {
     errors.value = [];
     const isFormCorrect = await $v.value.$validate();

--- a/templates/vue-demo-store/i18n/de-DE/validations.json
+++ b/templates/vue-demo-store/i18n/de-DE/validations.json
@@ -18,6 +18,7 @@
     "requiredIf": "Der Wert ist erforderlich",
     "requiredUnless": "Der Wert ist erforderlich",
     "sameAs": "Der Wert muss dem Wert {otherName} entsprechen",
-    "url": "Der Wert ist keine gültige URL-Adresse"
+    "url": "Der Wert ist keine gültige URL-Adresse",
+    "newPasswordConfirm": "Die Passwörter stimmen nicht überein"
   }
 }

--- a/templates/vue-demo-store/i18n/en-GB/validations.json
+++ b/templates/vue-demo-store/i18n/en-GB/validations.json
@@ -18,6 +18,7 @@
     "requiredIf": "The value is required",
     "requiredUnless": "The value is required",
     "sameAs": "The value must be equal to the {otherName} value",
-    "url": "The value is not a valid URL address"
+    "url": "The value is not a valid URL address",
+    "newPasswordConfirm": "The passwords needs to be the same"
   }
 }

--- a/templates/vue-demo-store/i18n/pl-PL/validations.json
+++ b/templates/vue-demo-store/i18n/pl-PL/validations.json
@@ -18,6 +18,7 @@
     "requiredIf": "Wartość jest wymagana",
     "requiredUnless": "Wartość jest wymagana",
     "sameAs": "Wartość musi być równa wartości {otherName}",
-    "url": "Wartość nie jest prawidłowym adresem URL"
+    "url": "Wartość nie jest prawidłowym adresem URL",
+    "newPasswordConfirm": "Hasła nie są takie same"
   }
 }


### PR DESCRIPTION
### Description

- Added missing `same password` error message
- Changed the success message block to reset after each click on the main button


closes #1016 

### Type of change

<!-- Comment out the type of change your PR is making -->

<!-- Bug fix (non-breaking change that fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

<!-- Add the todo's that need to be done before merge -->
<!-- Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. -->

<!-- - [ ] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) -->
<!-- - [ ] Documentation added/updated -->
<!-- - [ ] Unit-Tests added/updated -->
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
