### PR TITLE
feat(api-client): expose fetchOptions to extend requests with AbortController, timeout etc.

### DIFF
--- a/.changeset/clean-maps-wash.md
+++ b/.changeset/clean-maps-wash.md
@@ -1,0 +1,19 @@
+---
+"@shopware/api-client": minor
+---
+
+We're exposing `fetchOptions` inside params of `invoke` method. You can now use `ofetch` features like `timeout` or `signal` with AbortController
+
+Example for the AbortController:
+
+```ts
+const controller = new AbortController();
+
+const request = client.invoke("readContext get /context", {
+  fetchOptions: {
+    signal: controller.signal,
+  },
+});
+
+controller.abort(); // At this point client will throw an error with the information, that the request has been cancelled
+```

--- a/packages/api-client-next/README.md
+++ b/packages/api-client-next/README.md
@@ -35,6 +35,8 @@ bun install @shopware/api-client
 
 <!-- /automd -->
 
+## Store API client setup
+
 Recommended practice is to create a separate module file. For example `src/apiClient.ts`, and import it whenever you need to use API Client.
 
 ```typescript
@@ -152,6 +154,47 @@ async function loadProducts() {
   });
 }
 ```
+
+### Fetch features
+
+The new API client is leveraging [ofetch](https://github.com/unjs/ofetch) library, which has built in support for AbortController, timeout and other features.
+
+Example usage of AbortController to cancell your request:
+
+```typescript
+const controller = new AbortController();
+
+const request = client.invoke("readContext get /context", {
+  fetchOptions: {
+    signal: controller.signal,
+  },
+});
+
+controller.abort(); // At this point client will throw an error with the information, that the request has been cancelled
+```
+
+Other example of using `fetchOptions` for setting the timeout:
+
+```typescript
+const request = client.invoke("readContext get /context", {
+  fetchOptions: {
+    timeout: 5000, // 5 seconds
+  },
+});
+```
+
+All exposed options available under `fetchOptions` are:
+
+- `cache`
+- `duplex`
+- `keepalive`
+- `priority`
+- `redirect`
+- `retry`
+- `retryDelay`
+- `retryStatusCodes`
+- `signal`
+- `timeout`
 
 ### Predefining methods
 

--- a/packages/api-client-next/src/tests/RequestParameters.test-d.ts
+++ b/packages/api-client-next/src/tests/RequestParameters.test-d.ts
@@ -1,5 +1,5 @@
 import { describe, it, assertType } from "vitest";
-import type { RequestParameters } from "../createAdminApiClient";
+import type { RequestParameters } from "../createApiClient";
 
 import type { operations } from "../../api-types/adminApiTypes";
 


### PR DESCRIPTION
### Description

closes #1022

Support for `ofetch` additional params, like AbortController's signal, timeout, retry etc.