### PR TITLE
Fix for SeoUrls in the useListing.ts

### DIFF
--- a/packages/composables/src/useListing.ts
+++ b/packages/composables/src/useListing.ts
@@ -195,6 +195,9 @@ export function useListing(params?: {
     ) => {
       const { data } = await apiClient.invoke("searchPage post /search", {
         body: searchCriteria,
+        headers: {
+          "sw-include-seo-urls": true
+        }
       });
       return data;
     };


### PR DESCRIPTION
### Description

Fix for SeoUrls in the useListing.ts because the sw-include-seo-urls header is missing.

### Type of change

Bug fix (non-breaking change that fixes an issue)
