### PR TITLE
fix: missing seo url in search endpoint

### DIFF
--- a/.changeset/fluffy-islands-float.md
+++ b/.changeset/fluffy-islands-float.md
@@ -1,0 +1,5 @@
+---
+"@shopware/api-client": patch
+---
+
+Patch for missing `sw-include-seo-url in OpenAPI schema.

--- a/.changeset/witty-zoos-work.md
+++ b/.changeset/witty-zoos-work.md
@@ -1,0 +1,5 @@
+---
+"@shopware-pwa/composables-next": patch
+---
+
+`useListing` - reverted usage of the `sw-include-swo-urls` header in the search request

--- a/examples/adyen-dropin-component/api-types/storeApiTypes.d.ts
+++ b/examples/adyen-dropin-component/api-types/storeApiTypes.d.ts
@@ -8520,6 +8520,8 @@ export type operations = {
     headers?: {
       /** Instructs Shopware to return the response in the given language. */
       "sw-language-id"?: string;
+      /** Instructs Shopware to try and resolve SEO URLs for the given navigation item */
+      "sw-include-seo-urls"?: boolean;
     };
     body: {
       /** Using the search parameter, the server performs a text search on all records based on their data model and weighting as defined in the entity definition using the SearchRanking flag. */

--- a/examples/b2b-quote-management/api-types/storeApiTypes.d.ts
+++ b/examples/b2b-quote-management/api-types/storeApiTypes.d.ts
@@ -8412,6 +8412,8 @@ export type operations = {
     headers?: {
       /** Instructs Shopware to return the response in the given language. */
       "sw-language-id"?: string;
+      /** Instructs Shopware to try and resolve SEO URLs for the given navigation item */
+      "sw-include-seo-urls"?: boolean;
     };
     body: {
       /** Using the search parameter, the server performs a text search on all records based on their data model and weighting as defined in the entity definition using the SearchRanking flag. */

--- a/examples/commercial-customized-products/api-types/storeApiTypes.d.ts
+++ b/examples/commercial-customized-products/api-types/storeApiTypes.d.ts
@@ -8451,6 +8451,8 @@ export type operations = {
     headers?: {
       /** Instructs Shopware to return the response in the given language. */
       "sw-language-id"?: string;
+      /** Instructs Shopware to try and resolve SEO URLs for the given navigation item */
+      "sw-include-seo-urls"?: boolean;
     };
     body: {
       /** Using the search parameter, the server performs a text search on all records based on their data model and weighting as defined in the entity definition using the SearchRanking flag. */

--- a/examples/commercial-quick-order/api-types/storeApiTypes.d.ts
+++ b/examples/commercial-quick-order/api-types/storeApiTypes.d.ts
@@ -8457,6 +8457,8 @@ export type operations = {
     headers?: {
       /** Instructs Shopware to return the response in the given language. */
       "sw-language-id"?: string;
+      /** Instructs Shopware to try and resolve SEO URLs for the given navigation item */
+      "sw-include-seo-urls"?: boolean;
     };
     body: {
       /** Using the search parameter, the server performs a text search on all records based on their data model and weighting as defined in the entity definition using the SearchRanking flag. */

--- a/examples/express-checkout/api-types/storeApiTypes.d.ts
+++ b/examples/express-checkout/api-types/storeApiTypes.d.ts
@@ -8433,6 +8433,8 @@ export type operations = {
     headers?: {
       /** Instructs Shopware to return the response in the given language. */
       "sw-language-id"?: string;
+      /** Instructs Shopware to try and resolve SEO URLs for the given navigation item */
+      "sw-include-seo-urls"?: boolean;
     };
     body: {
       /** Using the search parameter, the server performs a text search on all records based on their data model and weighting as defined in the entity definition using the SearchRanking flag. */

--- a/examples/mollie-credit-card/api-types/storeApiTypes.d.ts
+++ b/examples/mollie-credit-card/api-types/storeApiTypes.d.ts
@@ -8412,6 +8412,8 @@ export type operations = {
     headers?: {
       /** Instructs Shopware to return the response in the given language. */
       "sw-language-id"?: string;
+      /** Instructs Shopware to try and resolve SEO URLs for the given navigation item */
+      "sw-include-seo-urls"?: boolean;
     };
     body: {
       /** Using the search parameter, the server performs a text search on all records based on their data model and weighting as defined in the entity definition using the SearchRanking flag. */

--- a/packages/api-client/api-types/storeApiSchema.overrides.json
+++ b/packages/api-client/api-types/storeApiSchema.overrides.json
@@ -669,6 +669,19 @@
       "get": {
         "requestBody": "_DELETE_"
       }
+    },
+    "/search": {
+      "post": {
+        "parameters": [
+          {
+            "name": "sw-include-seo-urls",
+            "in": "header",
+            "description": "Instructs Shopware to try and resolve SEO URLs for the given navigation item",
+            "required": false,
+            "schema": { "type": "boolean" }
+          }
+        ]
+      }
     }
   }
 }

--- a/packages/api-client/api-types/storeApiTypes.d.ts
+++ b/packages/api-client/api-types/storeApiTypes.d.ts
@@ -8412,6 +8412,8 @@ export type operations = {
     headers?: {
       /** Instructs Shopware to return the response in the given language. */
       "sw-language-id"?: string;
+      /** Instructs Shopware to try and resolve SEO URLs for the given navigation item */
+      "sw-include-seo-urls"?: boolean;
     };
     body: {
       /** Using the search parameter, the server performs a text search on all records based on their data model and weighting as defined in the entity definition using the SearchRanking flag. */

--- a/packages/composables/src/useListing.ts
+++ b/packages/composables/src/useListing.ts
@@ -194,6 +194,9 @@ export function useListing(params?: {
       searchCriteria: operations["searchPage post /search"]["body"],
     ) => {
       const { data } = await apiClient.invoke("searchPage post /search", {
+        headers: {
+          "sw-include-seo-urls": true,
+        },
         body: searchCriteria,
       });
       return data;

--- a/templates/vue-demo-store/api-types/storeApiTypes.d.ts
+++ b/templates/vue-demo-store/api-types/storeApiTypes.d.ts
@@ -8412,6 +8412,8 @@ export type operations = {
     headers?: {
       /** Instructs Shopware to return the response in the given language. */
       "sw-language-id"?: string;
+      /** Instructs Shopware to try and resolve SEO URLs for the given navigation item */
+      "sw-include-seo-urls"?: boolean;
     };
     body: {
       /** Using the search parameter, the server performs a text search on all records based on their data model and weighting as defined in the entity definition using the SearchRanking flag. */


### PR DESCRIPTION
### Description

replaces #1077 

<!-- Describe the changes you did and which issue you're closing -->

Special thanks to @fschmtt to point the problem!

This PR is adding patch to OpenAPI schema, where header param was missing, thanks to this running 
`pnpm shopware-api-gen generate --apiType=store` or `pnpm showpare-api-gen validateJson --apiType=store` there is a clear warning what needs to be fixed in the schema. This will help the core to fix the problem and patch it for us for now.

<img width="1710" alt="image" src="https://github.com/shopware/frontends/assets/13100280/a1378fcb-bcaa-4cb5-9280-e369eed69a3f">

