### PR TITLE
fix(api-gen): better validation rule for COMPONENTS_API_ALIAS flag and proper overrides loading

### DIFF
--- a/.changeset/orange-glasses-worry.md
+++ b/.changeset/orange-glasses-worry.md
@@ -1,0 +1,5 @@
+---
+"@shopware/api-gen": patch
+---
+
+`COMPONENTS_API_ALIAS` rule - additional message suggesting that the schema component name might be incorrect

--- a/.changeset/thick-donkeys-sip.md
+++ b/.changeset/thick-donkeys-sip.md
@@ -1,0 +1,5 @@
+---
+"@shopware/api-gen": patch
+---
+
+Correct api overrides load, depending on the apiType

--- a/packages/api-client/api-gen.config.json
+++ b/packages/api-client/api-gen.config.json
@@ -1,5 +1,4 @@
 {
   "$schema": "../api-gen/api-gen.schema.json",
-  "rules": ["COMPONENTS_API_ALIAS"],
-  "patches": "./api-types/storeApiSchema.overrides.json"
+  "rules": ["COMPONENTS_API_ALIAS"]
 }

--- a/packages/api-client/api-types/adminApiSchema.overrides.json
+++ b/packages/api-client/api-types/adminApiSchema.overrides.json
@@ -1,0 +1,4 @@
+{
+  "components": {},
+  "paths": {}
+}

--- a/packages/api-gen/src/commands/generate.ts
+++ b/packages/api-gen/src/commands/generate.ts
@@ -67,7 +67,10 @@ export async function generate(args: {
       const configJSON = await loadApiGenConfig({
         silent: true, // we allow to not have the config file in this command
       });
-      const jsonOverrides = await loadJsonOverrides(configJSON?.patches);
+      const jsonOverrides = await loadJsonOverrides({
+        path: configJSON?.patches,
+        apiType: args.apiType,
+      });
 
       const {
         patchedSchema,

--- a/packages/api-gen/src/commands/validateJson.ts
+++ b/packages/api-gen/src/commands/validateJson.ts
@@ -57,7 +57,10 @@ export async function validateJson(args: {
   }
 
   const errors: string[] = [];
-  const jsonOverrides = await loadJsonOverrides(configJSON.patches);
+  const jsonOverrides = await loadJsonOverrides({
+    path: configJSON.patches,
+    apiType: args.apiType,
+  });
 
   Object.entries(fileContentAsJson.components?.schemas || {}).forEach(
     (schema) => {

--- a/packages/api-gen/src/validation-rules/componentsApiAlias.rule.ts
+++ b/packages/api-gen/src/validation-rules/componentsApiAlias.rule.ts
@@ -1,8 +1,8 @@
-import { snakeCase } from "scule";
+import { snakeCase, pascalCase } from "scule";
 import { equals } from "@vitest/expect";
 import { diff } from "@vitest/utils/diff";
 import c from "picocolors";
-import type { ObjectSubtype } from "openapi-typescript";
+import type { ObjectSubtype, StringSubtype } from "openapi-typescript";
 
 export default (componentName: string, body: ObjectSubtype) => {
   // aliast needs to be in snake case. Examples:
@@ -11,22 +11,23 @@ export default (componentName: string, body: ObjectSubtype) => {
   const properAliasDefinition = {
     type: "string",
     enum: [snakeCase(componentName)],
-  };
+  } as StringSubtype;
 
-  const bodyValue = body.properties?.apiAlias;
+  const bodyValue = body.properties?.apiAlias as ObjectSubtype;
 
   // skip if apiAlias is not defined
   if (!bodyValue) {
     return null;
   }
 
-  // check if apiAlias is required
-  if (body.required && !body.required.includes("apiAlias")) {
-    return `Component ${c.bold(componentName)} has invalid ${c.bold("apiAlias")} definition. This field should be required.`;
-  }
-
   const result = equals(properAliasDefinition, bodyValue);
   if (!result) {
+    let additionalMessage = "";
+    const bodyEnumValue = bodyValue?.enum?.[0] as string | undefined;
+    if (bodyEnumValue && properAliasDefinition.enum![0] !== bodyEnumValue) {
+      additionalMessage = `It's also possible, that the schema component name is not correct and apiApias is proper. In that case schema component name should be ${c.bold(pascalCase(bodyEnumValue))}. Confirm proper solution with the source code.`;
+    }
+
     return `Component ${c.bold(componentName)} has invalid ${c.bold("apiAlias")} definition. Diff:\n ${diff(
       properAliasDefinition,
       bodyValue,
@@ -34,7 +35,12 @@ export default (componentName: string, body: ObjectSubtype) => {
         aColor: c.green,
         bColor: c.red,
       },
-    )}`;
+    )}${additionalMessage.length ? `\n${additionalMessage}` : ""}`;
+  }
+
+  // check if apiAlias is required
+  if (!body.required?.includes("apiAlias")) {
+    return `Component ${c.bold(componentName)} has invalid ${c.bold("apiAlias")} definition. This field should be required.`;
   }
 
   return null;


### PR DESCRIPTION
### Description

- fixes problem with overrides loading
- improves validation message suggesting that schema component name might be incorrect
- added more tests for the rule
<img width="1122" alt="image" src="https://github.com/shopware/frontends/assets/13100280/1ba5d31d-a4fc-4e1b-9427-3f995f82f0d7">

