### PR TITLE
fix(api-gen): parse json5 responses for overrides

### DIFF
--- a/.changeset/rich-lies-tease.md
+++ b/.changeset/rich-lies-tease.md
@@ -1,0 +1,5 @@
+---
+"@shopware/api-gen": patch
+---
+
+Parse Json5 responses when using default overrides

--- a/packages/api-gen/src/jsonOverrideUtils.ts
+++ b/packages/api-gen/src/jsonOverrideUtils.ts
@@ -64,6 +64,7 @@ export async function loadJsonOverrides({
     if (isURL(pathToResolve)) {
       const response = await ofetch(pathToResolve, {
         responseType: "json",
+        parseResponse: json5.parse,
       });
       return response;
     } else {


### PR DESCRIPTION
### Description
Fixes the problem with fetching overrises in json5 format