### PR TITLE
feat(composables): Export default order associations

### DIFF
--- a/packages/composables/src/useOrderDetails.ts
+++ b/packages/composables/src/useOrderDetails.ts
@@ -7,7 +7,7 @@ import type { Schemas } from "#shopware";
 /**
  * Data for api requests to fetch all necessary data
  */
-const orderAssociations: Schemas["Criteria"] & { checkPromotion?: boolean } = {
+export const orderAssociations: Schemas["Criteria"] & { checkPromotion?: boolean } = {
   associations: {
     stateMachineState: {},
     lineItems: {


### PR DESCRIPTION
### Description

This PR exports the default order associations.

I tried to extend the useOrderDetails function and I need the defaults. I don't want to copy it.  
<!-- Describe the changes you did and which issue you're closing -->

<!-- example: closes #007 -->

### Type of change

<!-- Comment out the type of change your PR is making -->

<!-- Bug fix (non-breaking change that fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

<!-- Add the todo's that need to be done before merge -->
<!-- Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. -->

<!-- - [ ] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) -->
<!-- - [ ] Documentation added/updated -->
<!-- - [ ] Unit-Tests added/updated -->
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
