### PR TITLE
fix(helpers): correct srcset for images

### DIFF
--- a/.changeset/long-pianos-allow.md
+++ b/.changeset/long-pianos-allow.md
@@ -1,0 +1,10 @@
+---
+"@shopware-pwa/helpers-next": patch
+---
+
+Prevent from getting an incorrect srcset format when img url is not set.
+
+before when there were no urls for 400w and 800w: 
+`src="image1.jpg 100w, 400w, 800w"` 
+
+now only the entry with an URL defined is returned

--- a/packages/helpers/src/media/getSrcSetForMedia.test.ts
+++ b/packages/helpers/src/media/getSrcSetForMedia.test.ts
@@ -4,19 +4,31 @@ import { getSrcSetForMedia } from "./getSrcSetForMedia";
 describe("getSrcSetForMedia", () => {
   it("should return an empty string if media is undefined", () => {
     const result = getSrcSetForMedia(undefined);
-    expect(result).toEqual("");
+    expect(result).toBeUndefined();
   });
 
   it("should return an empty string if media.thumbnails is undefined", () => {
     const media = {};
     const result = getSrcSetForMedia(media);
-    expect(result).toEqual("");
+    expect(result).toBeUndefined();
   });
 
   it("should return an empty string if media.thumbnails is an empty array", () => {
     const media = { thumbnails: [] };
     const result = getSrcSetForMedia(media);
-    expect(result).toEqual("");
+    expect(result).toBeUndefined();
+  });
+
+  it("should return the srcset only for media that contains a proper url defined", () => {
+    const media = {
+      thumbnails: [
+        { width: 100, url: "image1.jpg" },
+        { width: 200, url: "" },
+        { width: 300, url: "" },
+      ],
+    };
+    const result = getSrcSetForMedia(media);
+    expect(result).toEqual("image1.jpg 100w");
   });
 
   it("should return the correct srcset string if media.thumbnails is not empty", () => {

--- a/packages/helpers/src/media/getSrcSetForMedia.ts
+++ b/packages/helpers/src/media/getSrcSetForMedia.ts
@@ -13,14 +13,14 @@ export function getSrcSetForMedia<
       url: string;
     }>;
   },
->(media?: T): string {
+>(media?: T): string | undefined {
   if (!media?.thumbnails?.length) {
-    return "";
+    return;
   }
 
   return media.thumbnails
     .map((thumbnail) => {
-      return `${thumbnail.url} ${thumbnail.width}w`;
-    })
+      return thumbnail.url ? `${thumbnail.url} ${thumbnail.width}w` :undefined;
+    }).filter(value => !!value)
     .join(", ");
 }

--- a/packages/helpers/src/media/getSrcSetForMedia.ts
+++ b/packages/helpers/src/media/getSrcSetForMedia.ts
@@ -20,7 +20,8 @@ export function getSrcSetForMedia<
 
   return media.thumbnails
     .map((thumbnail) => {
-      return thumbnail.url ? `${thumbnail.url} ${thumbnail.width}w` :undefined;
-    }).filter(value => !!value)
+      return thumbnail.url ? `${thumbnail.url} ${thumbnail.width}w` : undefined;
+    })
+    .filter((value) => !!value)
     .join(", ");
 }


### PR DESCRIPTION
### Description

wrong `srcset` attribute causes some problems during loading an image. because the wrong format, like `400w` without a corresponding image, the image was being loaded through a nuxt router as a normal page (in an entrypoint `[...all].vue`).


### Type of change

<!-- Comment out the type of change your PR is making -->

<!-- Bug fix (non-breaking change that fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

<!-- Add the todo's that need to be done before merge -->
<!-- Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. -->

- [x] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) 
<!-- - [ ] Documentation added/updated -->
- [x] Unit-Tests added/updated
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->

### Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/6486a8c6-ee8f-4247-9105-4f3447bcd9c0)
### Additional context

![image](https://github.com/user-attachments/assets/e4a57ad8-b01e-4fd2-b448-c3c3ca1e34be)

<!-- Add any other context about the pull request here. -->
