### PR TITLE
feat(composables): useDefaultOrderAssociations for accessing associations

### DIFF
--- a/.changeset/sixty-teachers-allow.md
+++ b/.changeset/sixty-teachers-allow.md
@@ -1,0 +1,5 @@
+---
+"@shopware-pwa/composables-next": minor
+---
+
+New `useDefaultOrderAssociations` composable to be used or overriden separately in user project. This composable just returns default associations object.

--- a/packages/composables/src/index.ts
+++ b/packages/composables/src/index.ts
@@ -33,6 +33,7 @@ export * from "./useContext";
 export * from "./useCountries";
 export * from "./useCustomerOrders";
 export * from "./useCustomerPassword";
+export * from "./useDefaultOrderAssociations";
 export * from "./useInternationalization";
 export * from "./useLandingSearch";
 export * from "./useListing";

--- a/packages/composables/src/useDefaultOrderAssociations.test.ts
+++ b/packages/composables/src/useDefaultOrderAssociations.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { useSetup } from "./_test";
+import { useDefaultOrderAssociations } from "./useDefaultOrderAssociations";
+
+describe("useDefaultOrderAssociations", () => {
+  it("returns default associations object", async () => {
+    const { vm } = useSetup(() => useDefaultOrderAssociations());
+
+    expect(vm).toMatchInlineSnapshot(`
+      {
+        "associations": {
+          "addresses": {},
+          "deliveries": {
+            "associations": {
+              "shippingMethod": {},
+              "shippingOrderAddress": {},
+              "stateMachineState": {},
+            },
+          },
+          "lineItems": {
+            "associations": {
+              "cover": {},
+              "downloads": {
+                "associations": {
+                  "media": {},
+                },
+              },
+            },
+          },
+          "stateMachineState": {},
+          "transactions": {
+            "associations": {
+              "paymentMethod": {},
+              "stateMachineState": {},
+            },
+          },
+        },
+        "checkPromotion": true,
+      }
+    `);
+  });
+});

--- a/packages/composables/src/useDefaultOrderAssociations.ts
+++ b/packages/composables/src/useDefaultOrderAssociations.ts
@@ -1,0 +1,45 @@
+import type { Schemas } from "#shopware";
+
+export type UseDefaultOrderAssociationsReturn = Schemas["Criteria"] & {
+  checkPromotion?: boolean;
+};
+
+/**
+ * Returns default order associations. You can override this composable in your project.
+ * @public
+ */
+export function useDefaultOrderAssociations(): UseDefaultOrderAssociationsReturn {
+  const orderAssociations: Schemas["Criteria"] & { checkPromotion?: boolean } =
+    {
+      associations: {
+        stateMachineState: {},
+        lineItems: {
+          associations: {
+            cover: {},
+            downloads: {
+              associations: {
+                media: {},
+              },
+            },
+          },
+        },
+        addresses: {},
+        deliveries: {
+          associations: {
+            shippingMethod: {},
+            shippingOrderAddress: {},
+            stateMachineState: {},
+          },
+        },
+        transactions: {
+          associations: {
+            paymentMethod: {},
+            stateMachineState: {},
+          },
+        },
+      },
+      checkPromotion: true,
+    };
+
+  return orderAssociations;
+}

--- a/packages/composables/src/useOrderDetails.ts
+++ b/packages/composables/src/useOrderDetails.ts
@@ -1,42 +1,8 @@
 import { computed, ref, inject, provide } from "vue";
 import type { ComputedRef, Ref } from "vue";
 import { defu } from "defu";
-import { useShopwareContext } from "#imports";
+import { useDefaultOrderAssociations, useShopwareContext } from "#imports";
 import type { Schemas } from "#shopware";
-
-/**
- * Data for api requests to fetch all necessary data
- */
-const orderAssociations: Schemas["Criteria"] & { checkPromotion?: boolean } = {
-  associations: {
-    stateMachineState: {},
-    lineItems: {
-      associations: {
-        cover: {},
-        downloads: {
-          associations: {
-            media: {},
-          },
-        },
-      },
-    },
-    addresses: {},
-    deliveries: {
-      associations: {
-        shippingMethod: {},
-        shippingOrderAddress: {},
-        stateMachineState: {},
-      },
-    },
-    transactions: {
-      associations: {
-        paymentMethod: {},
-        stateMachineState: {},
-      },
-    },
-  },
-  checkPromotion: true,
-};
 
 export type UseOrderDetailsReturn = {
   /**
@@ -170,6 +136,8 @@ export function useOrderDetails(
     ref(),
   );
   provide("swOrderDetails", _sharedOrder);
+
+  const orderAssociations = useDefaultOrderAssociations();
 
   const paymentMethod = computed(
     () => _sharedOrder.value?.transactions?.[0]?.paymentMethod,


### PR DESCRIPTION


### Description

another approach of #1184 to allow access and override default order associations