### PR TITLE
feat(examples): Using multiple sales channels

### DIFF
--- a/examples/multi-sales-channel/.gitignore
+++ b/examples/multi-sales-channel/.gitignore
@@ -1,0 +1,24 @@
+# Nuxt dev/build outputs
+.output
+.data
+.nuxt
+.nitro
+.cache
+dist
+
+# Node dependencies
+node_modules
+
+# Logs
+logs
+*.log
+
+# Misc
+.DS_Store
+.fleet
+.idea
+
+# Local env files
+.env
+.env.*
+!.env.example

--- a/examples/multi-sales-channel/README.md
+++ b/examples/multi-sales-channel/README.md
@@ -1,0 +1,99 @@
+# Multi sales channel support Nuxt plugin
+
+Drop-in replacement for [@shopware-pwa/nuxt3-module](https://www.npmjs.com/package/@shopware-pwa/nuxt3-module)
+to use with the [vue-demo-store](https://github.com/shopware/frontends/tree/main/templates/vue-demo-store) template.
+
+## Features
+
+- ✨ &nbsp;Adds support for multiple sales channels
+- 🌏 &nbsp;Usable with multiple different languages on each sales channel
+- ⚙️ &nbsp;Can be used with existing projects built on the vue-demo-store
+
+## Requirements
+
+- [@shopware/api-client](https://www.npmjs.com/package/@shopware/api-client)
+- [@nuxtjs/i18n](https://www.npmjs.com/package/@nuxtjs/i18n)
+
+## Setup
+
+### Backend: Shopware 6 admin panel
+
+Set up your shopware instance with multiple sales channels.
+
+### Frontend: Nuxt 3 project
+
+1. Install the dependencies
+
+   run `pnpm i` command.
+
+2. Drop the multi-sales-channel shopware plugin (`./plugins/shopware.ts`)
+   into your nuxt project's `plugins` folder.
+
+3. Configure the shopware plugin in the `runtimeConfig > public` section of your `nuxt.config.ts`:
+   
+   ```js
+   // ./nuxt.config.ts
+   shopware: {
+      useUserContextInSSR: false, 
+      devStorefrontUrl: "",
+   
+      // Configure the sales channel credentials and locales
+      salesChannels: {
+         international: {
+            endpoint: "https://demo-frontends.shopware.store/store-api/",
+            accessToken: "ACCESS_KEY_SALES_CHANNEL_INTERNATIONAL",
+            // Each sales channel can have multiple locales, e.g. [ "de-DE", "en-DE", ... ]
+            locales: [ "en-GB" ],
+         },
+         germany: {
+            endpoint: "https://demo-frontends.shopware.store/store-api/",
+            accessToken: "ACCESS_KEY_SALES_CHANNEL_GERMANY",
+            locales: [ "de-DE" ],
+         },
+         poland: {
+            endpoint: "https://demo-frontends.shopware.store/store-api/",
+            accessToken: "ACCESS_KEY_SALES_CHANNEL_POLAND",
+            locales: [ "pl-PL" ],
+         },
+         ...
+      },
+   },
+   ```
+
+4. Configure the nuxt i18n plugin
+
+   ```js
+   i18n: {
+    strategy: "prefix",
+    defaultLocale: "en-GB",
+    // Locales from the i18n plugin should match the locales from the sales channel configuration
+    locales: [
+      {
+        code: "en-GB",
+        iso: "en-GB",
+      },
+      {
+        code: "de-DE",
+        iso: "de-DE",
+      },
+      {
+        code: "pl-PL",
+        iso: "pl-PL",
+      },
+    ],
+   },
+   ```
+
+You should now be able to switch between different sales channels!
+Just change your app's locale to one of the configured locales in the `salesChannels`
+section of your `nuxt.config.ts` and the api client will automatically communicate with
+the corresponding sales channel.
+
+## Development
+
+Run a playground project with configured multi-sales-channel plugin from current dir.
+
+```bash
+# Run a playground (nuxt 3) project in dev mode
+pnpm dev
+```

--- a/examples/multi-sales-channel/app.vue
+++ b/examples/multi-sales-channel/app.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import type { Schemas } from "#shopware";
+import { getPrefix } from "vue-demo-store/i18n/src/helpers/prefix";
+
+const { apiClient } = useShopwareContext();
+const sessionContextData = ref<Schemas["SalesChannelContext"]>();
+const contextResponse = await apiClient.invoke("readContext get /context");
+sessionContextData.value = contextResponse.data;
+
+useSessionContext(sessionContextData.value);
+
+const { languageIdChain, refreshSessionContext } = useSessionContext();
+const { locale, availableLocales, defaultLocale, localeProperties } = useI18n();
+const router = useRouter();
+const {
+  getAvailableLanguages,
+  getLanguageCodeFromId,
+  getLanguageIdFromCode,
+  changeLanguage,
+  languages: storeLanguages,
+} = useInternationalization();
+
+const { data: languages } = await useAsyncData("languages", async () => {
+  return await getAvailableLanguages();
+});
+let languageToChangeId: string | null = null;
+
+if (languages.value?.elements.length && router.currentRoute.value.name) {
+  storeLanguages.value = languages.value?.elements;
+  // Prefix from url
+  const prefix = getPrefix(
+      availableLocales,
+      router.currentRoute.value.name as string,
+      defaultLocale,
+  );
+
+  // Language set on the backend side
+  if (localeProperties.value.localeId) {
+    if (languageIdChain.value !== localeProperties.value.localeId) {
+      languageToChangeId = localeProperties.value.localeId;
+    }
+  } else {
+    const sessionLanguage = getLanguageCodeFromId(languageIdChain.value);
+
+    // If languages are not the same, set one from prefix
+    if (sessionLanguage !== prefix) {
+      languageToChangeId = getLanguageIdFromCode(
+          prefix ? prefix : defaultLocale,
+      );
+    }
+  }
+
+  if (languageToChangeId) {
+    await changeLanguage(languageToChangeId);
+    await refreshSessionContext();
+  }
+
+  locale.value = prefix ? prefix : defaultLocale;
+}
+</script>
+
+<template>
+  <div id="app" test-id="test-wrapper">
+    <NuxtLayout>
+      <NuxtPage />
+    </NuxtLayout>
+  </div>
+</template>

--- a/examples/multi-sales-channel/nuxt.config.ts
+++ b/examples/multi-sales-channel/nuxt.config.ts
@@ -1,0 +1,60 @@
+import { fileURLToPath } from "url";
+
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  extends: ["@shopware-pwa/composables-next/nuxt-layer"],
+  modules: ["@nuxtjs/i18n"],
+
+  runtimeConfig: {
+    public: {
+      shopware: {
+        useUserContextInSSR: false,
+        devStorefrontUrl: "",
+
+        salesChannels: {
+          international: {
+            endpoint: "https://demo-frontends.shopware.store/store-api/",
+            accessToken: "SWSCBHFSNTVMAWNZDNFKSHLAYW",
+            locales: [ "en-GB" ],
+          },
+          germany: {
+            endpoint: "https://demo-frontends.shopware.store/store-api/",
+            accessToken: "SWSCBHFSNTVMAWNZDNFKSHLAYW",
+            locales: [ "de-DE" ],
+          },
+          poland: {
+            endpoint: "https://demo-frontends.shopware.store/store-api/",
+            accessToken: "SWSCBHFSNTVMAWNZDNFKSHLAYW",
+            locales: [ "pl-PL" ],
+          },
+        },
+      },
+    },
+  },
+
+  i18n: {
+    strategy: "prefix",
+    defaultLocale: "en-GB",
+    // Locales from the i18n plugin have to match the sales channel configuration
+    locales: [
+      {
+        code: "en-GB",
+        iso: "en-GB",
+      },
+      {
+        code: "de-DE",
+        iso: "de-DE",
+      },
+      {
+        code: "pl-PL",
+        iso: "pl-PL",
+      },
+    ],
+  },
+
+  typescript: {
+    strict: true,
+  },
+
+  telemetry: false,
+})

--- a/examples/multi-sales-channel/package.json
+++ b/examples/multi-sales-channel/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "example-multi-sales-channel",
+  "version": "0.0.1",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "nuxt prepare && nuxt build",
+    "dev": "nuxt prepare && nuxt dev",
+    "lint": "nuxt prepare && vue-tsc --noEmit",
+    "generate": "nuxt generate",
+    "preview": "nuxt preview"
+  },
+  "dependencies": {
+    "@nuxtjs/i18n": "^8.3.1",
+    "@shopware-pwa/composables-next": "canary",
+    "@shopware/api-client": "canary",
+    "@shopware/api-gen": "canary",
+    "@types/node": "^20.14.9",
+    "nuxt": "^3.12.2",
+    "typescript": "^5.5.3",
+    "vue": "^3.4.31",
+    "vue-tsc": "^2.0.24"
+  },
+  "engines": {
+    "node": "^18.17.x || ^20.x"
+  }
+}

--- a/examples/multi-sales-channel/pages/[...all].vue
+++ b/examples/multi-sales-channel/pages/[...all].vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { getLanguageName, getTranslatedProperty } from "@shopware-pwa/helpers-next";
+
+const { languages, getLanguageCodeFromId } = useInternationalization();
+const { sessionContext, languageIdChain } = useSessionContext();
+
+const language = computed(() =>
+    languages.value.find((l) => languageIdChain.value === l.id));
+
+const onChangeHandler = async (option: Event) => {
+  const id = (option.target as HTMLSelectElement).value;
+  const code = getLanguageCodeFromId(id);
+
+  navigateTo(`/${code}`, {
+    external: true,
+  });
+};
+</script>
+
+<template>
+  <div>
+    <ul>
+      <li>Language: {{ language ? getLanguageName(language) : languageIdChain }}</li>
+      <li>Sales channel: {{ getTranslatedProperty(sessionContext?.salesChannel, "name") }}</li>
+    </ul>
+
+    <select
+        aria-label="Select language"
+        @change="onChangeHandler"
+    >
+      <option
+          v-for="language in languages"
+          :key="language.id"
+          :value="language.id"
+          :selected="languageIdChain === language.id"
+          :label="getLanguageName(language)"
+      >
+        {{ getLanguageName(language) }}
+      </option>
+    </select>
+  </div>
+</template>

--- a/examples/multi-sales-channel/plugins/shopware.ts
+++ b/examples/multi-sales-channel/plugins/shopware.ts
@@ -1,0 +1,68 @@
+import Cookies from "js-cookie";
+import { createAPIClient } from "@shopware/api-client";
+import { isMaintenanceMode } from "@shopware-pwa/helpers-next";
+
+import type { Composer } from "vue-i18n";
+
+export default defineNuxtPlugin((NuxtApp) => {
+  const runtimeConfig = useRuntimeConfig();
+  const salesChannels = runtimeConfig.public?.shopware?.salesChannels;
+
+  if (!salesChannels) {
+    throw new Error(
+      "Make sure to add your sales channels to the nuxt configuration",
+    );
+  }
+
+  const shouldUseSessionContextInServerRender =
+    !process.server ||
+    !!runtimeConfig.public?.shopware?.useUserContextInSSR;
+
+  const i18n: Composer = NuxtApp.$i18n as unknown as Composer;
+  const locale: string | undefined = i18n?.locale.value;
+
+  const salesChannel = computed(() =>
+    Object.values(salesChannels)?.find((s) => s.locales.includes(locale))
+  );
+
+  const apiClient = createAPIClient({
+    baseURL: salesChannel.value?.endpoint,
+    accessToken: salesChannel.value?.accessToken,
+    contextToken: shouldUseSessionContextInServerRender
+      ? Cookies.get("sw-context-token")
+      : "",
+  });
+
+  apiClient.hook("onContextChanged", (newContextToken) => {
+    Cookies.set("sw-context-token", newContextToken, {
+      expires: 365, // days
+      path: "/",
+      sameSite: "lax",
+      secure: salesChannel.value?.endpoint?.startsWith("https://"),
+    });
+  });
+
+  apiClient.hook("onResponseError", (response) => {
+    // @ts-expect-error TODO: check maintenance mode and fix typings here
+    const error = isMaintenanceMode(response._data?.errors ?? []);
+    if (error) {
+      throw createError({
+        statusCode: 503,
+        statusMessage: "MAINTENANCE_MODE",
+      });
+    }
+  });
+
+  NuxtApp.vueApp.provide("apiClient", apiClient);
+
+  const shopwareContext = createShopwareContext(NuxtApp.vueApp, {
+    enableDevtools: true,
+    devStorefrontUrl: runtimeConfig.public.shopware?.devStorefrontUrl || null,
+  });
+  NuxtApp.vueApp.provide("shopware", shopwareContext);
+
+  const sessionContextData = ref();
+  NuxtApp.vueApp.provide("swSessionContext", sessionContextData);
+  // in case someone tries to use it in nuxt specific code like middleware
+  useState("swSessionContext", () => sessionContextData);
+});

--- a/examples/multi-sales-channel/server/tsconfig.json
+++ b/examples/multi-sales-channel/server/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../.nuxt/tsconfig.server.json"
+}

--- a/examples/multi-sales-channel/shopware.d.ts
+++ b/examples/multi-sales-channel/shopware.d.ts
@@ -1,0 +1,19 @@
+declare module "#shopware" {
+  import type { createAPIClient } from "@shopware/api-client";
+
+  // for default types
+  export type operations =
+      import("@shopware/api-client/store-api-types").operations;
+  // or for locally generated types
+  // export type operations = import("./api-types/storeApiTypes").operations;
+
+  // for default types
+  export type Schemas =
+      import("@shopware/api-client/store-api-types").components["schemas"];
+  // or for locally generated types
+  // export type Schemas =
+  //   import("./api-types/storeApiTypes").components["schemas"];
+
+  // we're exporting our own Api Client definition as it depends on our own instance
+  export type ApiClient = ReturnType<typeof createAPIClient<operations>>;
+}

--- a/examples/multi-sales-channel/tsconfig.json
+++ b/examples/multi-sales-channel/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  // https://nuxt.com/docs/guide/concepts/typescript
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -511,6 +511,36 @@ importers:
         specifier: 2.0.29
         version: 2.0.29(typescript@5.5.4)
 
+  examples/multi-sales-channel:
+    dependencies:
+      '@nuxtjs/i18n':
+        specifier: ^8.3.1
+        version: 8.3.1(magicast@0.3.4)(rollup@4.20.0)(vue@3.4.37(typescript@5.5.4))
+      '@shopware-pwa/composables-next':
+        specifier: canary
+        version: link:../../packages/composables
+      '@shopware/api-client':
+        specifier: canary
+        version: link:../../packages/api-client
+      '@shopware/api-gen':
+        specifier: canary
+        version: link:../../packages/api-gen
+      '@types/node':
+        specifier: ^20
+        version: 20.16.1
+      nuxt:
+        specifier: ^3.12.2
+        version: 3.12.4(@biomejs/biome@1.8.3)(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@20.16.1)(encoding@0.1.13)(eslint@9.9.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.20.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.0(@types/node@20.16.1)(terser@5.31.6))(vue-tsc@2.0.29(typescript@5.5.4))
+      typescript:
+        specifier: ^5.5.3
+        version: 5.5.4
+      vue:
+        specifier: ^3.4.31
+        version: 3.4.37(typescript@5.5.4)
+      vue-tsc:
+        specifier: ^2.0.24
+        version: 2.0.29(typescript@5.5.4)
+
   examples/new-api-client:
     dependencies:
       '@shopware/api-client':
@@ -3948,8 +3978,8 @@ packages:
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
-  '@types/eslint@9.6.0':
-    resolution: {integrity: sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==}
+  '@types/eslint@8.56.7':
+    resolution: {integrity: sha512-SjDvI/x3zsZnOkYZ3lCt9lOZWZLB2jIlNKz+LBgCtDurK0JZcwucxYHn1w2BJkD34dgX9Tjnak0txtq4WTggEA==}
 
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
@@ -4018,14 +4048,8 @@ packages:
   '@types/node@20.11.17':
     resolution: {integrity: sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==}
 
-  '@types/node@20.14.14':
-    resolution: {integrity: sha512-d64f00982fS9YoOgJkAMolK7MN8Iq3TDdVjchbYHdEmjth/DHowx82GnoA+tVUAN+7vxfYUgAzi+JXbKNd2SDQ==}
-
   '@types/node@20.14.2':
     resolution: {integrity: sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==}
-
-  '@types/node@20.14.7':
-    resolution: {integrity: sha512-uTr2m2IbJJucF3KUxgnGOZvYbN0QgkGyWxG6973HCpMYFy2KfcgYuIwkJQMQkt1VbBMlvWRbpshFTLxnxCZjKQ==}
 
   '@types/node@20.16.1':
     resolution: {integrity: sha512-zJDo7wEadFtSyNz5QITDfRcrhqDvQI1xQNQ0VoizPjM/dVAODqqIUWbJPkvsxmTI0MYRGRikcdjMPhOssnPejQ==}
@@ -5810,12 +5834,12 @@ packages:
     resolution: {integrity: sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==}
     engines: {node: '>=10.13.0'}
 
-  enhanced-resolve@5.17.0:
-    resolution: {integrity: sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==}
+  enhanced-resolve@5.16.0:
+    resolution: {integrity: sha512-O+QWCviPNSSLAD9Ucn8Awv+poAkqn3T1XY5/N7kR7rQO9yfSGWkYZDwpJ+iKF7B8rxaQKWngSqACpgzeapSyoA==}
     engines: {node: '>=10.13.0'}
 
-  enhanced-resolve@5.17.1:
-    resolution: {integrity: sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==}
+  enhanced-resolve@5.17.0:
+    resolution: {integrity: sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==}
     engines: {node: '>=10.13.0'}
 
   enquirer@2.4.1:
@@ -12315,7 +12339,7 @@ snapshots:
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.24.7
-      '@types/node': 20.14.14
+      '@types/node': 20.16.1
       find-up: 4.1.0
       fs-extra: 8.1.0
 
@@ -13044,6 +13068,65 @@ snapshots:
       pkg-types: 1.1.3
       postcss: 8.4.40
       rollup-plugin-visualizer: 5.12.0(rollup@4.19.2)
+      std-env: 3.7.0
+      strip-literal: 2.1.0
+      ufo: 1.5.4
+      unenv: 1.10.0
+      unplugin: 1.11.0
+      vite: 5.4.0(@types/node@20.16.1)(terser@5.31.6)
+      vite-node: 2.0.4(@types/node@20.16.1)(terser@5.31.6)
+      vite-plugin-checker: 0.7.2(@biomejs/biome@1.8.3)(eslint@9.9.0)(optionator@0.9.3)(typescript@5.5.4)(vite@5.4.0(@types/node@20.16.1)(terser@5.31.6))(vue-tsc@2.0.29(typescript@5.5.4))
+      vue: 3.4.37(typescript@5.5.4)
+      vue-bundle-renderer: 2.1.0
+    transitivePeerDependencies:
+      - '@biomejs/biome'
+      - '@types/node'
+      - eslint
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - optionator
+      - rollup
+      - sass
+      - sass-embedded
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - typescript
+      - uWebSockets.js
+      - vls
+      - vti
+      - vue-tsc
+
+  '@nuxt/vite-builder@3.12.4(@biomejs/biome@1.8.3)(@types/node@20.16.1)(eslint@9.9.0)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.20.0)(terser@5.31.6)(typescript@5.5.4)(vue-tsc@2.0.29(typescript@5.5.4))(vue@3.4.37(typescript@5.5.4))':
+    dependencies:
+      '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.20.0)
+      '@rollup/plugin-replace': 5.0.7(rollup@4.20.0)
+      '@vitejs/plugin-vue': 5.1.2(vite@5.4.0(@types/node@20.16.1)(terser@5.31.6))(vue@3.4.37(typescript@5.5.4))
+      '@vitejs/plugin-vue-jsx': 4.0.0(vite@5.4.0(@types/node@20.16.1)(terser@5.31.6))(vue@3.4.37(typescript@5.5.4))
+      autoprefixer: 10.4.19(postcss@8.4.40)
+      clear: 0.1.0
+      consola: 3.2.3
+      cssnano: 7.0.4(postcss@8.4.40)
+      defu: 6.1.4
+      esbuild: 0.23.0
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      externality: 1.0.2
+      get-port-please: 3.1.2
+      h3: 1.12.0
+      knitwork: 1.1.0
+      magic-string: 0.30.11
+      mlly: 1.7.1
+      ohash: 1.1.3
+      pathe: 1.1.2
+      perfect-debounce: 1.0.0
+      pkg-types: 1.1.3
+      postcss: 8.4.40
+      rollup-plugin-visualizer: 5.12.0(rollup@4.20.0)
       std-env: 3.7.0
       strip-literal: 2.1.0
       ufo: 1.5.4
@@ -14457,10 +14540,10 @@ snapshots:
 
   '@types/eslint-scope@3.7.7':
     dependencies:
-      '@types/eslint': 9.6.0
+      '@types/eslint': 8.56.7
       '@types/estree': 1.0.5
 
-  '@types/eslint@9.6.0':
+  '@types/eslint@8.56.7':
     dependencies:
       '@types/estree': 1.0.5
       '@types/json-schema': 7.0.15
@@ -14483,7 +14566,7 @@ snapshots:
 
   '@types/http-proxy@1.17.14':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.16.1
 
   '@types/js-cookie@2.2.7': {}
 
@@ -14531,15 +14614,7 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@20.14.14':
-    dependencies:
-      undici-types: 5.26.5
-
   '@types/node@20.14.2':
-    dependencies:
-      undici-types: 5.26.5
-
-  '@types/node@20.14.7':
     dependencies:
       undici-types: 5.26.5
 
@@ -14573,7 +14648,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 20.14.7
+      '@types/node': 20.16.1
 
   '@types/scheduler@0.16.8': {}
 
@@ -14603,7 +14678,7 @@ snapshots:
 
   '@types/type-is@1.6.3':
     dependencies:
-      '@types/node': 20.11.17
+      '@types/node': 20.16.1
 
   '@types/unist@2.0.10': {}
 
@@ -15434,7 +15509,7 @@ snapshots:
       '@edge-runtime/node-utils': 2.3.0
       '@edge-runtime/primitives': 4.1.0
       '@edge-runtime/vm': 3.2.0
-      '@types/node': 20.14.14
+      '@types/node': 20.16.1
       '@vercel/build-utils': 8.3.6
       '@vercel/error-utils': 2.0.2
       '@vercel/nft': 0.27.3(encoding@0.1.13)
@@ -15448,7 +15523,7 @@ snapshots:
       node-fetch: 2.6.9(encoding@0.1.13)
       path-to-regexp: 6.2.1
       ts-morph: 12.0.0
-      ts-node: 10.9.1(@swc/core@1.7.10)(@types/node@20.14.14)(typescript@4.9.5)
+      ts-node: 10.9.1(@swc/core@1.7.10)(@types/node@20.16.1)(typescript@4.9.5)
       typescript: 4.9.5
       undici: 6.19.5
     transitivePeerDependencies:
@@ -17230,12 +17305,12 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.2.1
 
-  enhanced-resolve@5.17.0:
+  enhanced-resolve@5.16.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
 
-  enhanced-resolve@5.17.1:
+  enhanced-resolve@5.17.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
@@ -20782,6 +20857,114 @@ snapshots:
       - vue-tsc
       - xml2js
 
+  nuxt@3.12.4(@biomejs/biome@1.8.3)(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@20.16.1)(encoding@0.1.13)(eslint@9.9.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.20.0)(terser@5.31.6)(typescript@5.5.4)(vite@5.4.0(@types/node@20.16.1)(terser@5.31.6))(vue-tsc@2.0.29(typescript@5.5.4)):
+    dependencies:
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/devtools': 1.3.9(rollup@4.20.0)(vite@5.4.0(@types/node@20.16.1)(terser@5.31.6))
+      '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.20.0)
+      '@nuxt/schema': 3.12.4(rollup@4.20.0)
+      '@nuxt/telemetry': 2.5.4(magicast@0.3.4)(rollup@4.20.0)
+      '@nuxt/vite-builder': 3.12.4(@biomejs/biome@1.8.3)(@types/node@20.16.1)(eslint@9.9.0)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.20.0)(terser@5.31.6)(typescript@5.5.4)(vue-tsc@2.0.29(typescript@5.5.4))(vue@3.4.37(typescript@5.5.4))
+      '@unhead/dom': 1.9.16
+      '@unhead/ssr': 1.9.16
+      '@unhead/vue': 1.9.16(vue@3.4.37(typescript@5.5.4))
+      '@vue/shared': 3.4.33
+      acorn: 8.12.1
+      c12: 1.11.1(magicast@0.3.4)
+      chokidar: 3.6.0
+      compatx: 0.1.8
+      consola: 3.2.3
+      cookie-es: 1.1.0
+      defu: 6.1.4
+      destr: 2.0.3
+      devalue: 5.0.0
+      errx: 0.1.0
+      esbuild: 0.23.0
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      globby: 14.0.2
+      h3: 1.12.0
+      hookable: 5.5.3
+      ignore: 5.3.1
+      jiti: 1.21.6
+      klona: 2.0.6
+      knitwork: 1.1.0
+      magic-string: 0.30.10
+      mlly: 1.7.1
+      nitropack: 2.9.7(@opentelemetry/api@1.9.0)(encoding@0.1.13)(magicast@0.3.4)
+      nuxi: 3.12.0
+      nypm: 0.3.9
+      ofetch: 1.3.4
+      ohash: 1.1.3
+      pathe: 1.1.2
+      perfect-debounce: 1.0.0
+      pkg-types: 1.1.3
+      radix3: 1.1.2
+      scule: 1.3.0
+      semver: 7.6.3
+      std-env: 3.7.0
+      strip-literal: 2.1.0
+      ufo: 1.5.4
+      ultrahtml: 1.5.3
+      uncrypto: 0.1.3
+      unctx: 2.3.1
+      unenv: 1.10.0
+      unimport: 3.9.0(rollup@4.20.0)
+      unplugin: 1.11.0
+      unplugin-vue-router: 0.10.0(rollup@4.20.0)(vue-router@4.4.2(vue@3.4.37(typescript@5.5.4)))(vue@3.4.37(typescript@5.5.4))
+      unstorage: 1.10.2(ioredis@5.4.1)
+      untyped: 1.4.2
+      vue: 3.4.37(typescript@5.5.4)
+      vue-bundle-renderer: 2.1.0
+      vue-devtools-stub: 0.1.0
+      vue-router: 4.4.2(vue@3.4.37(typescript@5.5.4))
+    optionalDependencies:
+      '@parcel/watcher': 2.4.1
+      '@types/node': 20.16.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@biomejs/biome'
+      - '@capacitor/preferences'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - better-sqlite3
+      - bufferutil
+      - drizzle-orm
+      - encoding
+      - eslint
+      - idb-keyval
+      - ioredis
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - optionator
+      - rollup
+      - sass
+      - sass-embedded
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - typescript
+      - uWebSockets.js
+      - utf-8-validate
+      - vite
+      - vls
+      - vti
+      - vue-tsc
+      - xml2js
+
   nypm@0.3.9:
     dependencies:
       citty: 0.1.6
@@ -21388,7 +21571,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 20.14.14
+      '@types/node': 20.16.1
       long: 5.2.3
 
   protocols@2.0.1: {}
@@ -22106,7 +22289,7 @@ snapshots:
 
   sitemap@8.0.0:
     dependencies:
-      '@types/node': 20.14.7
+      '@types/node': 20.16.1
       '@types/sax': 1.2.7
       arg: 5.0.2
       sax: 1.3.0
@@ -22529,14 +22712,14 @@ snapshots:
       '@ts-morph/common': 0.24.0
       code-block-writer: 13.0.1
 
-  ts-node@10.9.1(@swc/core@1.7.10)(@types/node@20.14.14)(typescript@4.9.5):
+  ts-node@10.9.1(@swc/core@1.7.10)(@types/node@20.16.1)(typescript@4.9.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.14.14
+      '@types/node': 20.16.1
       acorn: 8.12.1
       acorn-walk: 8.3.3
       arg: 4.1.3
@@ -24065,7 +24248,7 @@ snapshots:
       acorn-import-assertions: 1.9.0(acorn@8.12.1)
       browserslist: 4.23.3
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.17.1
+      enhanced-resolve: 5.16.0
       es-module-lexer: 1.5.4
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -24096,7 +24279,7 @@ snapshots:
       acorn-import-assertions: 1.9.0(acorn@8.12.1)
       browserslist: 4.23.3
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.17.1
+      enhanced-resolve: 5.16.0
       es-module-lexer: 1.5.4
       eslint-scope: 5.1.1
       events: 3.3.0


### PR DESCRIPTION
### Description

Re-opening the pull request because of linter errors:

Adds an example for how to use the existing composables and helpers with multiple sales channels.
The shopware plugin (`/plugins/shopware.ts`) can be used as an optional replacement for the nuxt3-module in the vue-demo-store.

### ToDo's

[&nbsp;&nbsp;&nbsp;&nbsp;] Update current example configuration in nuxt.config.ts with different sales channel access keys (optional).
[✅] Documentation added/updated

### Screenshots (if applicable)

<img width="527" alt="Screenshot 2024-07-29 at 15 14 23" src="https://github.com/user-attachments/assets/bb320069-2418-49c7-a731-af2c6ae43c81">

### Additional context

The current configuration in the nuxt.config.ts uses the same sales channel three times. It would be possible to add multiple sales channels here if the current demo store is configurated accordingly.
