### PR TITLE
fix(api-gen): reading variables from the process.env instead of the dotenv config

### DIFF
--- a/.changeset/smart-bobcats-film.md
+++ b/.changeset/smart-bobcats-film.md
@@ -1,0 +1,5 @@
+---
+"@shopware/api-gen": patch
+---
+
+reading environment variables not only from the .env file but also injected by the system

--- a/packages/api-gen/src/commands/generate.ts
+++ b/packages/api-gen/src/commands/generate.ts
@@ -18,7 +18,8 @@ import {
   loadJsonOverrides,
 } from "../jsonOverrideUtils";
 
-const config = dotenv.config().parsed || {};
+// read .env file and load it into process.env
+dotenv.config();
 
 export async function generate(args: {
   cwd: string;
@@ -92,7 +93,7 @@ export async function generate(args: {
       });
 
       schema = await openapiTS(patchedSchema, {
-        version: +(config.OPENAPI_VERSION || 3),
+        version: +(process.env.OPENAPI_VERSION || 3),
         exportType: true,
         // pathParamsAsTypes: true,
         // rawSchema: false,


### PR DESCRIPTION


### Description

should fix the probelm from the slack channel, where CLI was ignoring the env variable provided by the system and reading only the .env file