### PR TITLE
feat(docs): multi-context support

### DIFF
--- a/.github/scripts/docs-after-clone.sh
+++ b/.github/scripts/docs-after-clone.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/env bash
+set -e
+
+[[ -z "$1" ]] && echo "Missing working directory argument" && exit 1
+
+echo "Installing root pnpm"
+pnpm -C $1 i

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ dist
 
 # vitepress
 **/.vitepress/cache
+apps/docs/src/_source
 
 # misc
 .DS_Store

--- a/apps/docs/.vitepress/config.hub.ts
+++ b/apps/docs/.vitepress/config.hub.ts
@@ -25,12 +25,12 @@ export default (original, {
     // they should work in the context of the DevHub and Frontend docs
     original.vite.plugins.push(...[
         ReadmeBasedReference({ projectRootDir, relativeDir: 'packages' }),
-        CmsBaseReference(),
+        CmsBaseReference({ projectRootDir, relativeDir: 'packages/cms-base/components/public/cms' }),
         ReadmeLoader(),
         ComposablesBuilder({ projectRootDir, mountPoint, relativeDir: 'packages/composables/src' }),
     ]);
 
-    console.log('Extending', projectRootDir, mountPoint)
+    console.log('Extending', projectRootDir, mountPoint);
 
     return original;
 }

--- a/apps/docs/.vitepress/config.hub.ts
+++ b/apps/docs/.vitepress/config.hub.ts
@@ -9,7 +9,10 @@ import { ComposablesBuilder } from "./theme/typer/composables-builder";
  *  - DevHub - /apps/docs/src/ is mounted to /src/frontends/ in DevHub, root-source is available under /src/frontends/_source/
  *  - Frontend (standalone) docs
  */
-export default (original) => {
+export default (original, {
+    projectRootDir,
+    mountPoint,
+}: { projectRootDir: string, mountPoint: string }) => {
     if (!original.vite) {
         original.vite = {};
     }
@@ -21,11 +24,13 @@ export default (original) => {
     // add custom plugins
     // they should work in the context of the DevHub and Frontend docs
     original.vite.plugins.push(...[
-        ReadmeBasedReference(),
+        ReadmeBasedReference({ projectRootDir, relativeDir: 'packages' }),
         CmsBaseReference(),
         ReadmeLoader(),
-        ComposablesBuilder(),
+        ComposablesBuilder({ projectRootDir, mountPoint, relativeDir: 'packages/composables/src' }),
     ]);
+
+    console.log('Extending', projectRootDir, mountPoint)
 
     return original;
 }

--- a/apps/docs/.vitepress/config.hub.ts
+++ b/apps/docs/.vitepress/config.hub.ts
@@ -1,0 +1,31 @@
+import { CmsBaseReference } from "./theme/typer/cms-base-plugin";
+import { ReadmeBasedReference } from "./theme/typer/plugin";
+import { ReadmeLoader } from "./theme/typer/readme-loader";
+import { ComposablesBuilder } from "./theme/typer/composables-builder";
+
+/**
+ * This file extends the DevHub VitePress configuration.
+ * All plugins should work in both contexts:
+ *  - DevHub - /apps/docs/src/ is mounted to /src/frontends/ in DevHub, root-source is available under /src/frontends/_source/
+ *  - Frontend (standalone) docs
+ */
+export default (original) => {
+    if (!original.vite) {
+        original.vite = {};
+    }
+
+    if (!original.vite.plugins) {
+        original.vite.plugins = [];
+    }
+
+    // add custom plugins
+    // they should work in the context of the DevHub and Frontend docs
+    original.vite.plugins.push(...[
+        ReadmeBasedReference(),
+        CmsBaseReference(),
+        ReadmeLoader(),
+        ComposablesBuilder(),
+    ]);
+
+    return original;
+}

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -2,13 +2,10 @@ import { defineConfigWithTheme } from "vitepress";
 import type { Config as ThemeConfig } from "vitepress-shopware-docs";
 import { baseConfig } from "@shopware-docs/vitepress";
 import nav from "./navigation";
-import { SearchPlugin } from "vitepress-plugin-search";
-import { CmsBaseReference } from "./theme/typer/cms-base-plugin";
-import { ReadmeBasedReference } from "./theme/typer/plugin";
-import { ReadmeLoader } from "./theme/typer/readme-loader";
-import { ComposablesBuilder } from "./theme/typer/composables-builder";
 import { resolve } from "path";
 import { sidebar } from "./sidebar";
+import sharedConfig from "./config.hub";
+import { SearchPlugin } from "vitepress-plugin-search";
 
 interface ThemeConfigExtended extends ThemeConfig {
   ai: {
@@ -16,11 +13,15 @@ interface ThemeConfigExtended extends ThemeConfig {
   };
 }
 
-export default defineConfigWithTheme<ThemeConfigExtended>({
+export default defineConfigWithTheme<ThemeConfigExtended>(sharedConfig({
   extends: baseConfig.default,
   title: "Shopware Frontends",
   description: "Documentation for Shopware developers",
   srcDir: "src",
+  srcExclude: [
+    // when symlinked to DevHub
+    "**/_source/**",
+  ],
   ignoreDeadLinks: true, // remove once MR #294 is merged
   head: [
     [
@@ -118,11 +119,15 @@ export default defineConfigWithTheme<ThemeConfigExtended>({
     },
     plugins: [
       SearchPlugin(),
-      ReadmeBasedReference(),
-      CmsBaseReference(),
-      ReadmeLoader(),
-      ComposablesBuilder(),
     ],
+    server: {
+      watch: {
+        ignored: (p) => {
+          // added to next version of baseConfig
+          return p.includes('_source') || p.includes('node_modules');
+        }
+      }
+    },
     resolve: {
       alias: {
         "@node_modules": resolve(process.cwd(), "node_modules"),
@@ -149,4 +154,4 @@ export default defineConfigWithTheme<ThemeConfigExtended>({
       },
     },
   },
-});
+}));

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -154,4 +154,7 @@ export default defineConfigWithTheme<ThemeConfigExtended>(sharedConfig({
       },
     },
   },
+}, {
+  projectRootDir: `${process.cwd()}/../..`,
+  mountPoint: '',
 }));

--- a/apps/docs/.vitepress/data/composables.data.ts
+++ b/apps/docs/.vitepress/data/composables.data.ts
@@ -1,7 +1,8 @@
 import { defineLoader } from "vitepress";
-import { resolve } from "path";
+import { resolve, dirname } from "path";
 import { extract } from "ts-dox";
 import { readdirSync } from "fs";
+import { fileURLToPath } from "url";
 export interface Data {
   composablesList: { text: string; link: string; category: string }[];
 }
@@ -11,7 +12,11 @@ export { data };
 
 export default defineLoader({
   async load(): Promise<Data> {
-    const composablesList = readdirSync("../../packages/composables/src/", {
+    // support multiple contexts
+    const projectRootDir = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../packages/composables/src");
+    console.log(projectRootDir)
+
+    const composablesList = readdirSync(projectRootDir, {
       withFileTypes: true,
     })
       .filter(
@@ -20,7 +25,7 @@ export default defineLoader({
       .map((element) => {
         const file = extract(
           resolve(
-            `../../packages/composables/src/${element.name}/${element.name}.ts`,
+            `${projectRootDir}/${element.name}/${element.name}.ts`,
           ),
         );
         return {

--- a/apps/docs/.vitepress/data/composables.data.ts
+++ b/apps/docs/.vitepress/data/composables.data.ts
@@ -15,7 +15,6 @@ export default defineLoader({
     const projectRootDir = cwd.endsWith('/apps/docs')
       ? `${cwd}/../..`
       : `${cwd}/src/frontends/_source`;
-    const mountPoint = cwd.endsWith('/apps/docs') ? '' : '/frontends';
 
     const composablesList = readdirSync(`${projectRootDir}/packages/composables/src`, {
       withFileTypes: true,
@@ -31,7 +30,7 @@ export default defineLoader({
         );
         return {
           text: element.name,
-          link: `${mountPoint}/packages/composables/${element.name}`,
+          link: `/packages/composables/${element.name}`,
           category:
             (file?.functions[element.name]?.docs.category ||
               file?.functions[`${element.name}Function`]?.docs.category) ??

--- a/apps/docs/.vitepress/data/composables.data.ts
+++ b/apps/docs/.vitepress/data/composables.data.ts
@@ -14,7 +14,6 @@ export default defineLoader({
   async load(): Promise<Data> {
     // support multiple contexts
     const projectRootDir = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../packages/composables/src");
-    console.log(projectRootDir)
 
     const composablesList = readdirSync(projectRootDir, {
       withFileTypes: true,

--- a/apps/docs/.vitepress/data/composables.data.ts
+++ b/apps/docs/.vitepress/data/composables.data.ts
@@ -2,7 +2,6 @@ import { defineLoader } from "vitepress";
 import { resolve, dirname } from "path";
 import { extract } from "ts-dox";
 import { readdirSync } from "fs";
-import { fileURLToPath } from "url";
 export interface Data {
   composablesList: { text: string; link: string; category: string }[];
 }
@@ -12,10 +11,13 @@ export { data };
 
 export default defineLoader({
   async load(): Promise<Data> {
-    // support multiple contexts
-    const projectRootDir = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../packages/composables/src");
+    const cwd = process.cwd();
+    const projectRootDir = cwd.endsWith('/apps/docs')
+      ? `${cwd}/../..`
+      : `${cwd}/src/frontends/_source`;
+    const mountPoint = cwd.endsWith('/apps/docs') ? '' : '/frontends';
 
-    const composablesList = readdirSync(projectRootDir, {
+    const composablesList = readdirSync(`${projectRootDir}/packages/composables/src`, {
       withFileTypes: true,
     })
       .filter(
@@ -24,12 +26,12 @@ export default defineLoader({
       .map((element) => {
         const file = extract(
           resolve(
-            `${projectRootDir}/${element.name}/${element.name}.ts`,
+            `${projectRootDir}/packages/composables/src/${element.name}/${element.name}.ts`,
           ),
         );
         return {
           text: element.name,
-          link: `/packages/composables/${element.name}`,
+          link: `${mountPoint}/packages/composables/${element.name}`,
           category:
             (file?.functions[element.name]?.docs.category ||
               file?.functions[`${element.name}Function`]?.docs.category) ??

--- a/apps/docs/.vitepress/theme.hub.ts
+++ b/apps/docs/.vitepress/theme.hub.ts
@@ -1,0 +1,5 @@
+import ComposablesList from "./theme/components/ComposablesList.vue";
+
+export default ({ app }) => {
+    app.component('ComposablesList', ComposablesList);
+}

--- a/apps/docs/.vitepress/theme/components/ComposablesList.vue
+++ b/apps/docs/.vitepress/theme/components/ComposablesList.vue
@@ -18,7 +18,7 @@
         class="list-none !m-0 bg-gray-100 rounded-sm leading-4"
       >
         <a
-          :href="`/packages/composables/${composable}.html`"
+          :href="`${composable}.html`"
           class="text-sm p-2 !no-underline !text-gray-800"
           >{{ composable }}</a
         >

--- a/apps/docs/.vitepress/theme/index.ts
+++ b/apps/docs/.vitepress/theme/index.ts
@@ -1,9 +1,6 @@
 // import './styles/index.css'
 import { App } from "vue";
 import { SWAGTheme } from "vitepress-shopware-docs";
-import PageRef from "./components/PageRef.vue";
-import DemoBlock from "./components/DemoBlock.vue";
-import ComposablesList from "./components/ComposablesList.vue";
 // Ai component
 // import AI from "./components/AI.vue";
 import "./custom.css";
@@ -14,9 +11,6 @@ export default Object.assign(
   },
   {
     enhanceApp({ app }: { app: App }) {
-      app.component("PageRef", PageRef);
-      app.component("DemoBlock", DemoBlock);
-      app.component("ComposablesList", ComposablesList);
       // app.component("AI", AI);
       // app.provide('some-injection-key-if-needed', VALUE)
     },

--- a/apps/docs/.vitepress/theme/typer/cms-base-plugin.ts
+++ b/apps/docs/.vitepress/theme/typer/cms-base-plugin.ts
@@ -11,7 +11,7 @@ import {
 } from "./utils";
 import { readdirSync, readFileSync } from "node:fs";
 
-export async function CmsBaseReference(): Promise<Plugin> {
+export async function CmsBaseReference({ projectRootDir, relativeDir }: { projectRootDir: string, relativeDir: string }): Promise<Plugin> {
   return {
     name: "cms-base-reference-md-transform",
     enforce: "pre",
@@ -27,7 +27,7 @@ export async function CmsBaseReference(): Promise<Plugin> {
       let API = "\n\n## Available components\n\n";
 
       const files = readdirSync(
-        resolve("../../packages/cms-base/components/public/cms"),
+        resolve(`${projectRootDir}/${relativeDir}`),
         {
           withFileTypes: true,
           recursive: true,

--- a/apps/docs/.vitepress/theme/typer/composables-builder.ts
+++ b/apps/docs/.vitepress/theme/typer/composables-builder.ts
@@ -14,7 +14,7 @@ import {
 import { readdirSync, readFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "url";
 
-export async function ComposablesBuilder(): Promise<Plugin> {
+export async function ComposablesBuilder({ projectRootDir, relativeDir, mountPoint }: { projectRootDir: string, relativeDir: string, mountPoint: string }): Promise<Plugin> {
   return {
     name: "composables-builder",
     enforce: "pre",
@@ -29,15 +29,12 @@ export async function ComposablesBuilder(): Promise<Plugin> {
         return code;
       }
 
-      // support multiple contexts
-      const projectRootDir = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../../packages/composables/src");
-
       if (composableName === "index") {
         code = code.replace(
           "{{INTRO}}",
           normalizeString(
             readFileSync(
-              resolve(`${projectRootDir}/../README.md`),
+              resolve(`${projectRootDir}/${relativeDir}/../README.md`),
               "utf8",
             ),
           ),
@@ -53,10 +50,11 @@ export async function ComposablesBuilder(): Promise<Plugin> {
       try {
         astJson = extract(
           resolve(
-            `${projectRootDir}/${composableName}/${composableName}.ts`,
+            `${projectRootDir}/${relativeDir}/${composableName}/${composableName}.ts`,
           ),
         );
       } catch (e) {
+        console.error(e)
         return code;
       }
 
@@ -72,7 +70,7 @@ export async function ComposablesBuilder(): Promise<Plugin> {
       if (category) {
         code = code.replace(
           "{{META}}",
-          `<div>Category:</div> <a href="/packages/composables/#${normalizeAnchorText(category)}"><div class="bg-red">${category}</div></a>`,
+          `<div>Category:</div> <a href="${mountPoint}/packages/composables/#${normalizeAnchorText(category)}"><div class="bg-red">${category}</div></a>`,
         );
       }
 
@@ -86,7 +84,7 @@ export async function ComposablesBuilder(): Promise<Plugin> {
 
         interfacesBlock += prepareGithubPermalink({
           label: `source code`,
-          path: `packages/composables/src/${composableName}/${composableName}.ts`,
+          path: `${relativeDir}/${composableName}/${composableName}.ts`,
           project: "shopware/frontends",
           line: astJson?.functions[key]?.location?.line + 1,
         });
@@ -101,7 +99,7 @@ export async function ComposablesBuilder(): Promise<Plugin> {
 
         typesBlock += prepareGithubPermalink({
           label: `source code`,
-          path: `packages/composables/src/${composableName}/${composableName}.ts`,
+          path: `${relativeDir}/${composableName}/${composableName}.ts`,
           project: "shopware/frontends",
           line: astJson?.types[key]?.location?.line + 1,
         });
@@ -116,7 +114,7 @@ export async function ComposablesBuilder(): Promise<Plugin> {
       try {
         const additionalMd = readFileSync(
           resolve(
-            `${projectRootDir}/${composableName}/${composableName}.md`,
+            `${projectRootDir}/${relativeDir}/${composableName}/${composableName}.md`,
           ),
           "utf8",
         );
@@ -129,7 +127,7 @@ export async function ComposablesBuilder(): Promise<Plugin> {
       try {
         const codeBlock = readFileSync(
           resolve(
-            `${projectRootDir}/${composableName}/${composableName}.demo.vue`,
+            `${projectRootDir}/${relativeDir}/${composableName}/${composableName}.demo.vue`,
           ),
           "utf8",
         );

--- a/apps/docs/.vitepress/theme/typer/composables-builder.ts
+++ b/apps/docs/.vitepress/theme/typer/composables-builder.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import type { Plugin } from "vite";
-import { resolve } from "path";
+import { resolve, dirname } from "path";
 import { findSync } from "find-in-files";
 import { extract } from "ts-dox";
 import {
@@ -12,6 +12,7 @@ import {
   normalizeAnchorText,
 } from "./utils";
 import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "url";
 
 export async function ComposablesBuilder(): Promise<Plugin> {
   return {
@@ -28,12 +29,15 @@ export async function ComposablesBuilder(): Promise<Plugin> {
         return code;
       }
 
+      // support multiple contexts
+      const projectRootDir = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../../packages/composables/src");
+
       if (composableName === "index") {
         code = code.replace(
           "{{INTRO}}",
           normalizeString(
             readFileSync(
-              resolve(`../../packages/composables/README.md`),
+              resolve(`${projectRootDir}/../README.md`),
               "utf8",
             ),
           ),
@@ -49,7 +53,7 @@ export async function ComposablesBuilder(): Promise<Plugin> {
       try {
         astJson = extract(
           resolve(
-            `../../packages/composables/src/${composableName}/${composableName}.ts`,
+            `${projectRootDir}/${composableName}/${composableName}.ts`,
           ),
         );
       } catch (e) {
@@ -112,7 +116,7 @@ export async function ComposablesBuilder(): Promise<Plugin> {
       try {
         const additionalMd = readFileSync(
           resolve(
-            `../../packages/composables/src/${composableName}/${composableName}.md`,
+            `${projectRootDir}/${composableName}/${composableName}.md`,
           ),
           "utf8",
         );
@@ -125,7 +129,7 @@ export async function ComposablesBuilder(): Promise<Plugin> {
       try {
         const codeBlock = readFileSync(
           resolve(
-            `../../packages/composables/src/${composableName}/${composableName}.demo.vue`,
+            `${projectRootDir}/${composableName}/${composableName}.demo.vue`,
           ),
           "utf8",
         );

--- a/apps/docs/.vitepress/theme/typer/plugin.ts
+++ b/apps/docs/.vitepress/theme/typer/plugin.ts
@@ -18,7 +18,7 @@ const packagesMap = {
   // "api-client": "api-client-next",
 };
 
-export async function ReadmeBasedReference(): Promise<Plugin> {
+export async function ReadmeBasedReference({ projectRootDir, relativeDir }: { projectRootDir: string, relativeDir: string }): Promise<Plugin> {
   return {
     name: "packages-reference-md-transform",
     enforce: "pre",
@@ -31,7 +31,7 @@ export async function ReadmeBasedReference(): Promise<Plugin> {
       if (
         pkg !== "packages" ||
         packageName === "composables" ||
-        !existsSync(resolve(`../../packages/${packageName}/README.md`))
+        !existsSync(resolve(`${projectRootDir}/${relativeDir}/${packageName}/README.md`))
       ) {
         return code;
       }
@@ -40,7 +40,7 @@ export async function ReadmeBasedReference(): Promise<Plugin> {
         code,
         normalizeString(
           readFileSync(
-            resolve(`../../packages/${packageName}/README.md`),
+            resolve(`${projectRootDir}/${relativeDir}/${packageName}/README.md`),
             "utf8",
           ),
         ),
@@ -49,11 +49,11 @@ export async function ReadmeBasedReference(): Promise<Plugin> {
       );
 
       const indexAstJson = extract(
-        resolve(`../../packages/${packageName}/src/index.ts`),
+        resolve(`${projectRootDir}/${relativeDir}/${packageName}/src/index.ts`),
       );
 
       let exportedList: string[] = await expCollector(
-        resolve(`../../packages/${packageName}/src/index.ts`),
+        resolve(`${projectRootDir}/${relativeDir}/${packageName}/src/index.ts`),
       );
 
       if (!exportedList.length) {
@@ -68,14 +68,14 @@ export async function ReadmeBasedReference(): Promise<Plugin> {
           try {
             astJson = extract(
               resolve(
-                `../../packages/${packageName}/src/${exportedOne.replace("Function", "")}.ts`,
+                `${projectRootDir}/${relativeDir}/${packageName}/src/${exportedOne.replace("Function", "")}.ts`,
               ),
             );
           } catch (error) {
             try {
               const definitionFound = await findSync(
                 `function\ ${exportedOne}`,
-                resolve(`../../packages/${packageName}/src`),
+                resolve(`${projectRootDir}/${relativeDir}/${packageName}/src`),
                 ".ts$",
               );
               if (Object.keys(definitionFound)?.length) {

--- a/apps/docs/src/packages/composables/[composable].paths.ts
+++ b/apps/docs/src/packages/composables/[composable].paths.ts
@@ -4,10 +4,12 @@ import { fileURLToPath } from "url";
 
 export default {
   paths() {
-    // support multiple contexts
-    const projectRootDir = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../../packages/composables/src");
+    const cwd = process.cwd();
+    const projectRootDir = cwd.endsWith('/apps/docs')
+      ? `${cwd}/../..`
+      : `${cwd}/src/frontends/_source`;
 
-    return readdirSync(projectRootDir, {
+    return readdirSync(`${projectRootDir}/packages/composables/src`, {
       withFileTypes: true,
     })
       .filter((element) => {

--- a/apps/docs/src/packages/composables/[composable].paths.ts
+++ b/apps/docs/src/packages/composables/[composable].paths.ts
@@ -1,9 +1,13 @@
 import { readdirSync } from "fs";
-import { resolve } from "path";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
 
 export default {
   paths() {
-    return readdirSync(resolve("../../packages/composables/src"), {
+    // support multiple contexts
+    const projectRootDir = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../../packages/composables/src");
+
+    return readdirSync(projectRootDir, {
       withFileTypes: true,
     })
       .filter((element) => {

--- a/apps/docs/src/packages/composables/index.md
+++ b/apps/docs/src/packages/composables/index.md
@@ -2,8 +2,4 @@
 
 ## Composables list
 
-<script setup>
-import ComposablesList from "../../../.vitepress/theme/components/ComposablesList.vue";
-</script>
-
 <ComposablesList />

--- a/apps/docs/src/packages/composables/index.md
+++ b/apps/docs/src/packages/composables/index.md
@@ -2,4 +2,8 @@
 
 ## Composables list
 
+<script setup>
+import ComposablesList from "../../../.vitepress/theme/components/ComposablesList.vue";
+</script>
+
 <ComposablesList />

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "generateDependencyChangelog": "esno ./scripts/generateDependencyChangelog.ts",
     "docs:env": "[ -d \"../developer-portal\" ] && ../developer-portal/docs-cli.cjs pull || (git clone git@github.com:shopware/developer-portal.git ../developer-portal && pnpm i -C ../developer-portal)",
     "docs:link": "../developer-portal/docs-cli.cjs link --src apps/docs/src --dst frontends --symlink --keep",
-    "docs:preview": "../developer-portal/docs-cli.cjs preview"
+    "docs:preview": "../developer-portal/docs-cli.cjs preview",
+    "docs:cli": "../developer-portal/docs-cli.cjs"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
     "versionReadme": "pnpx ts-node scripts/addChangelogBodyToReadmeFile.ts",
     "prepare": "husky",
     "generate-types": "turbo run generate-types",
-    "generateDependencyChangelog": "esno ./scripts/generateDependencyChangelog.ts"
+    "generateDependencyChangelog": "esno ./scripts/generateDependencyChangelog.ts",
+    "docs:env": "[ -d \"../developer-portal\" ] && ../developer-portal/docs-cli.cjs pull || (git clone git@github.com:shopware/developer-portal.git ../developer-portal && pnpm i -C ../developer-portal)",
+    "docs:link": "../developer-portal/docs-cli.cjs link --src apps/docs/src --dst frontends --symlink --keep",
+    "docs:preview": "../developer-portal/docs-cli.cjs preview"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",


### PR DESCRIPTION
### Description

This PR is a continuation of https://github.com/shopware/frontends/pull/1313:
 - [X] adds support for different contexts (project dirs) in Frontends-specific vite plugins (`projectRootDir`, `mountPoint` and `relativeDir`), making them less-Frontends-specific
 - [X] adds root shortcuts for setting up (`pnpm docs:env`), linking (`pnpm docs:link`) and previewing (`pnpm docs:preview`) the docs from DevHub context
 - [X] extracts Frontends-specific (but still global) Vitepress config to `config.hub.ts` so DevHub can pick it up
 - [x] WIP - extracts Frontends-specific theme config to `theme.hub.ts`
 - [X] adds `docs-after-clone.sh` hook script used in DevHub context during cloning

### Type of change

Docs-only change.

### ToDo's

- [ ] GitHub workflows (healthcheck and build-trigger) - next PR
- [ ] (TBD) redirect `frontends.shopware.com/` -> `developer.shopware.com/frontends/`
- [ ] (TBD) cleanup local `.vitepress` folder (remove standalone checkout)

### Additional context

https://developer.shopware.com/frontends/packages/composables/#composables-list