### PR TITLE
feat: DevHub workflows

### DIFF
--- a/.github/workflows/deploy-developer-portal.yml
+++ b/.github/workflows/deploy-developer-portal.yml
@@ -1,0 +1,25 @@
+# This workflow triggers DevHub production test-build-deploy workflow in the developer-portal repository.
+
+name: Deploy to DevHub
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  trigger-deployment:
+    name: Trigger deployment
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: octokit/request-action@v2.x
+        name: Trigger deployment
+        with:
+          route: POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches
+          owner: shopware
+          repo: developer-portal
+          ref: main
+          workflow_id: checkout-test-build-deploy.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEV_HUB_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/developer-portal-healthcheck.yml
+++ b/.github/workflows/developer-portal-healthcheck.yml
@@ -1,0 +1,22 @@
+# This workflow creates a new status check for a pull request and triggers DevHub staging deployment.
+# The developer-portal repository updates the status check by calling the update-healthcheck.yml workflow in this repo.
+
+name: Healthcheck
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+
+  create-healthcheck:
+    uses: shopware/developer-portal/.github/workflows/healthcheck.yml@main
+    with:
+      owner: ${{ github.repository_owner }}
+      repo: ${{ github.event.repository.name }}
+      branch: ${{ github.event.pull_request.head.ref }}
+      sha: ${{ github.event.pull_request.head.sha }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PERSONAL_TOKEN: ${{ secrets.DEV_HUB_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/update-healthcheck.yml
+++ b/.github/workflows/update-healthcheck.yml
@@ -1,0 +1,41 @@
+# This workflow is triggered from developer-portal.
+# It updates the status check for the pull request based on the result of the staging build.
+
+name: Update healthcheck
+
+on:
+  workflow_dispatch:
+    inputs:
+      owner:
+        description: "Owner to checkout"
+        required: true
+        type: string
+      repo:
+        description: "Repo to checkout"
+        required: true
+        type: string
+      check:
+        description: "Check ID"
+        required: true
+        type: string
+      conclusion:
+        description: "Healthcheck conclusion"
+        required: true
+        type: string
+      run_id:
+        description: "Workflow run ID"
+        required: true
+        type: string
+
+jobs:
+
+  update-healthcheck:
+    uses: shopware/developer-portal/.github/workflows/update-healthcheck.yml@main
+    with:
+      owner: ${{ inputs.owner }}
+      repo: ${{ inputs.repo }}
+      check: ${{ inputs.check }}
+      conclusion: ${{ inputs.conclusion }}
+      run_id: ${{ inputs.run_id }}
+    secrets:
+      TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/docs/.vitepress/theme/index.ts
+++ b/apps/docs/.vitepress/theme/index.ts
@@ -5,14 +5,9 @@ import { SWAGTheme } from "vitepress-shopware-docs";
 // import AI from "./components/AI.vue";
 import "./custom.css";
 
-export default Object.assign(
-  {
-    ...SWAGTheme(),
+export default SWAGTheme({
+  enhanceApp: ({ app }: { app: App }) => {
+    // app.component("AI", AI);
+    // app.provide('some-injection-key-if-needed', VALUE)
   },
-  {
-    enhanceApp({ app }: { app: App }) {
-      // app.component("AI", AI);
-      // app.provide('some-injection-key-if-needed', VALUE)
-    },
-  },
-);
+})


### PR DESCRIPTION
### Description

This PR adds 3 standard workflows for communicating with DevHub:
 - `deploy-developer-portal.yml` - triggers production build when `main` branch is changed
 - `developer-portal-healthcheck.yml` - creates a status check and triggers staging build when a PR targeting the `main` branch is created/updated
 - `update-healthcheck.yml` - updates status check result in the PR

### Type of change

New GitHub workflows.

### ToDo's

- [ ] New secret `DEV_HUB_PERSONAL_ACCESS_TOKEN` is required for cross-repo update of the status check.

### Screenshots (if applicable)

### Additional context

Tested with `meteor`, `docs` and `release-notes` repos.

- [ ] (TBD) redirect `frontends.shopware.com/` -> `developer.shopware.com/frontends/`
- [ ] (TBD) cleanup local `.vitepress` folder (remove standalone checkout)