### PR TITLE
feat: add pkg-pr-new to prepublish packages for testing

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -79,6 +79,9 @@ jobs:
           DO_NOT_TRACK: 1
         run: pnpm lint
 
+      - name: Publish package previews
+        run: npx pkg-pr-new publish './packages/api-client' './packages/api-gen' './packages/cms-base' './packages/composables' './packages/helpers' './packages/nuxt3-module'
+
   test:
     name: Test
     timeout-minutes: 15


### PR DESCRIPTION
### Description

ability to leverage pkg-pr-new, which will publish packages preview for PRs. More info: https://blog.stackblitz.com/posts/pkg-pr-new/