### PR TITLE
fix(e2e): fix flaky category tests

### DIFF
--- a/apps/e2e-tests/page-objects/CategoryPage.ts
+++ b/apps/e2e-tests/page-objects/CategoryPage.ts
@@ -40,23 +40,28 @@ export class CategoryPage {
     await this.selectedColourFiltersCategory.click();
     const colourCheckboxes = await this.colourCheckboxes.all();
     const countColourCheckboxes = (await this.colourCheckboxes.all()).length;
+
     const randomCheckboxSelctor = Math.floor(
       Math.random() * countColourCheckboxes,
     );
     const randomCheckbox = colourCheckboxes[randomCheckboxSelctor];
     await randomCheckbox.check();
+    await this.page.waitForLoadState();
   }
 
   async selectLimitOneProductPerPage() {
     await this.limitSelect.selectOption({ value: "1" });
+    await this.page.waitForLoadState();
   }
 
   async goToSecondPage() {
     await this.page.getByRole("button", { name: /2/i }).click();
+    await this.page.waitForLoadState();
   }
 
   async selectSortingPriceAsc() {
     await this.page.getByRole("button", { name: "Sort" }).click();
     await this.page.getByRole("menuitem", { name: "Price ascending" }).click();
+    await this.page.waitForLoadState();
   }
 }

--- a/apps/e2e-tests/tests/checkCategory.spec.ts
+++ b/apps/e2e-tests/tests/checkCategory.spec.ts
@@ -39,8 +39,9 @@ test.describe.only("Check category page", () => {
   test("Check sorting", async ({ page }) => {
     await homePage.openCategoryPage();
     await categoryPage.selectSortingPriceAsc();
-    await expect(page.getByTestId("loading")).toHaveCount(0);
+    await page.waitForLoadState();
     await expect(page).toHaveURL(new RegExp(".*order=price-asc.*"));
+    await expect(page.getByTestId("loading")).toHaveCount(0);
     expect(await page.getByTestId("product-box-img").count()).toBeGreaterThan(
       0,
     );

--- a/apps/e2e-tests/tests/checkCategory.spec.ts
+++ b/apps/e2e-tests/tests/checkCategory.spec.ts
@@ -39,7 +39,6 @@ test.describe.only("Check category page", () => {
   test("Check sorting", async ({ page }) => {
     await homePage.openCategoryPage();
     await categoryPage.selectSortingPriceAsc();
-    await page.waitForLoadState();
     await expect(page).toHaveURL(new RegExp(".*order=price-asc.*"));
     await expect(page.getByTestId("loading")).toHaveCount(0);
     expect(await page.getByTestId("product-box-img").count()).toBeGreaterThan(


### PR DESCRIPTION
### Description

Fixes for flaky category tests 

Failed and flaky tests mainly concerned the sorting scenario
<img width="768" alt="image" src="https://github.com/user-attachments/assets/7c57bf0e-5325-44d9-b212-00af43961e2f">


Before creating MR, I ran the tests locally about 80 times and had no further problems.



### Type of change

<!-- Comment out the type of change your PR is making -->

<!-- Bug fix (non-breaking change that fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

<!-- Add the todo's that need to be done before merge -->
<!-- Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. -->

<!-- - [ ] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) -->
<!-- - [ ] Documentation added/updated -->
<!-- - [ ] Unit-Tests added/updated -->
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
