### PR TITLE
docs: automatically generate automd tags, update cms-base readme

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
 pnpm run lint
+pnpm generateAutomd
 prettier $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g') --write --ignore-unknown
 git update-index --again

--- a/apps/docs/src/getting-started/features/broadcasting.md
+++ b/apps/docs/src/getting-started/features/broadcasting.md
@@ -46,7 +46,7 @@ This way:
 - cart data
   are synchronized between tabs.
 
-<!-- automd:file src="../../../../../templates/vue-demo-store/composables/useBroadcastChannelSync.ts" code -->
+<!-- automd:file src="templates/vue-demo-store/composables/useBroadcastChannelSync.ts" code -->
 
 ```ts [useBroadcastChannelSync.ts]
 import type { Schemas } from "#shopware";

--- a/apps/docs/src/getting-started/templates/custom-vue-project.md
+++ b/apps/docs/src/getting-started/templates/custom-vue-project.md
@@ -38,9 +38,26 @@ You can read more about CMS pages here:
 
 <PageRef page="../cms/content-pages.html" title="Create content pages" sub="Render a content page using components" />
 
-```bash
-pnpm add @shopware-pwa/cms-base
+<!-- automd:pm-install name="@shopware-pwa/cms-base" dev -->
+
+```sh
+# ✨ Auto-detect
+npx nypm install -D @shopware-pwa/cms-base
+
+# npm
+npm install -D @shopware-pwa/cms-base
+
+# yarn
+yarn add -D @shopware-pwa/cms-base
+
+# pnpm
+pnpm install -D @shopware-pwa/cms-base
+
+# bun
+bun install -D @shopware-pwa/cms-base
 ```
+
+<!-- /automd -->
 
 ## Configure API client
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "prepare": "husky",
     "generate-types": "turbo run generate-types",
     "generateDependencyChangelog": "esno ./scripts/generateDependencyChangelog.ts",
+    "generateAutomd": "esno ./scripts/generateAutomd.ts --update",
     "docs:env": "[ -d \"../developer-portal\" ] && ../developer-portal/docs-cli.cjs pull || (git clone git@github.com:shopware/developer-portal.git ../developer-portal && pnpm i -C ../developer-portal)",
     "docs:link": "../developer-portal/docs-cli.cjs link --src apps/docs/src --dst frontends --symlink --keep",
     "docs:preview": "../developer-portal/docs-cli.cjs preview",
@@ -37,6 +38,7 @@
     "@changesets/changelog-github": "0.5.0",
     "@changesets/cli": "2.27.9",
     "@types/changelog-parser": "2.8.4",
+    "automd": "^0.3.7",
     "changelog-parser": "3.0.1",
     "dotenv-cli": "7.4.2",
     "esno": "4.8.0",
@@ -101,7 +103,8 @@
       ]
     },
     "patchedDependencies": {
-      "@vueuse/core@11.1.0": "patches/@vueuse__core@11.1.0.patch"
+      "@vueuse/core@11.1.0": "patches/@vueuse__core@11.1.0.patch",
+      "automd": "patches/automd.patch"
     }
   }
 }

--- a/packages/api-gen/README.md
+++ b/packages/api-gen/README.md
@@ -43,7 +43,7 @@ If your instance contains inacurate or outdated OpenAPI specification, you can o
 
 Example of overrides file:
 
-<!-- automd:file src="./tests/snapshots-override/simpleOverride.example.ts" code -->
+<!-- automd:file src="packages/api-gen/tests/snapshots-override/simpleOverride.example.ts" code -->
 
 ```ts [simpleOverride.example.ts]
 import { components as mainComponents } from "./storeApiTypes";

--- a/packages/cms-base/README.md
+++ b/packages/cms-base/README.md
@@ -5,7 +5,7 @@
 [![](https://img.shields.io/github/issues/shopware/frontends/cms-base?label=cms-base%20issues&logo=github)](https://github.com/shopware/frontends/issues?q=is%3Aopen+is%3Aissue+label%3Acms-base)
 [![](https://img.shields.io/github/license/shopware/frontends?color=blue)](#)
 
-Nuxt [module](https://nuxt.com/docs/guide/going-further/modules) that provides an implementation of all CMS components in Shopware [based on utility-classes](https://frontends.shopware.com/framework/styling.html) using unocss/Tailwind.css syntax.
+Nuxt [layer](https://nuxt.com/docs/getting-started/layers) that provides an implementation of all CMS components in Shopware [based on utility-classes](https://frontends.shopware.com/framework/styling.html) using atomic css syntax (UnoCss / Tailwind).
 
 It is useful for projects that want to use the CMS components but design their own layout.
 
@@ -19,27 +19,56 @@ It is useful for projects that want to use the CMS components but design their o
 
 Install npm package:
 
-```bash
-# Using pnpm
-pnpm add -D @shopware-pwa/cms-base
+<!-- automd:pm-install name="@shopware-pwa/cms-base" dev -->
 
-# Using yarn
-yarn add --dev @shopware-pwa/cms-base
+```sh
+# ✨ Auto-detect
+npx nypm install -D @shopware-pwa/cms-base
 
-# Using npm
-npm i @shopware-pwa/cms-base --save-dev
+# npm
+npm install -D @shopware-pwa/cms-base
+
+# yarn
+yarn add -D @shopware-pwa/cms-base
+
+# pnpm
+pnpm install -D @shopware-pwa/cms-base
+
+# bun
+bun install -D @shopware-pwa/cms-base
 ```
 
-Then, register the module by editing `nuxt.config.js` or (`.ts`) file:
+<!-- /automd -->
 
-```js
-/* nuxt.config.ts */
+Then, register the Nuxt layer in `nuxt.config.ts` file:
 
+<!-- automd:file src="templates/vue-blank/nuxt.config.ts" code -->
+
+```ts [nuxt.config.ts]
+// https://v3.nuxtjs.org/api/configuration/nuxt.config
 export default defineNuxtConfig({
-  /* ... */
-+ modules: [/* ... */, "@shopware-pwa/cms-base"],
+  extends: [
+    "@shopware-pwa/composables-next/nuxt-layer",
+    "@shopware-pwa/cms-base",
+  ],
+  shopware: {
+    endpoint: "https://demo-frontends.shopware.store/store-api/",
+    accessToken: "SWSCBHFSNTVMAWNZDNFKSHLAYW",
+  },
+  modules: ["@shopware-pwa/nuxt3-module"],
+  /**
+   * Commented because of the StackBlitz error
+   * Issue: https://github.com/shopware/frontends/issues/88
+   */
+  typescript: {
+    // typeCheck: true,
+    strict: true,
+  },
+  telemetry: false,
 });
 ```
+
+<!-- /automd -->
 
 ### ⚠️ `<RouterLink/>` components used
 

--- a/packages/composables/README.md
+++ b/packages/composables/README.md
@@ -104,7 +104,7 @@ npm i js-cookie
 
 Let's get back to the step where the `api-client` was initialized:
 
-<!-- automd:file src="../../examples/b2b-quote-management/src/apiClient.ts" code -->
+<!-- automd:file src="examples/b2b-quote-management/src/apiClient.ts" code -->
 
 ```ts [apiClient.ts]
 import { createAPIClient } from "@shopware/api-client";

--- a/patches/automd.patch
+++ b/patches/automd.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/index.cjs b/dist/index.cjs
+index 754e3ac52c21f200cc8520bf77337947c57e7923..fd6e01f6376c2bdfa9a6693d191b1ec9cc4f1936 100644
+--- a/dist/index.cjs
++++ b/dist/index.cjs
+@@ -489,6 +489,7 @@ const file = defineGenerator({
+   async generate({ args, config, url }) {
+     const fullPath = resolvePath(args.src, { url, dir: config.dir });
+     let contents = await promises.readFile(fullPath, "utf8");
++    contents = contents.trim();
+     if (args.code) {
+       contents = mdbox.md.codeBlock(
+         contents,
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 5a800f1256f2ca858bd64a8e6988a86f82429064..fbd3d61f5fae9e9fc1735ab3c83f034c854fe790 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -483,6 +483,7 @@ const file = defineGenerator({
+   async generate({ args, config, url }) {
+     const fullPath = resolvePath(args.src, { url, dir: config.dir });
+     let contents = await readFile(fullPath, "utf8");
++    contents = contents.trim();
+     if (args.code) {
+       contents = md.codeBlock(
+         contents,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ patchedDependencies:
   "@vueuse/core@11.1.0":
     hash: rtnblm55jutyponlgwgfoiesem
     path: patches/@vueuse__core@11.1.0.patch
+  automd:
+    hash: c3ksiahsbkzwejj5owudg6zwym
+    path: patches/automd.patch
 
 importers:
   .:
@@ -58,6 +61,9 @@ importers:
       "@types/changelog-parser":
         specifier: 2.8.4
         version: 2.8.4
+      automd:
+        specifier: ^0.3.7
+        version: 0.3.7(patch_hash=c3ksiahsbkzwejj5owudg6zwym)(magicast@0.3.5)
       changelog-parser:
         specifier: 3.0.1
         version: 3.0.1
@@ -10672,6 +10678,13 @@ packages:
         integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==,
       }
 
+  automd@0.3.7:
+    resolution:
+      {
+        integrity: sha512-h+w7Z1xQSdIuGmgDKVVvCl6fwj7V9b7BqUs6LlelvTcrwkLzqJnxpzcK0HoiesPb0xsf1yTfngeoDgYs2NN2Tw==,
+      }
+    hasBin: true
+
   autoprefixer@10.4.20:
     resolution:
       {
@@ -12359,6 +12372,13 @@ packages:
         integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==,
       }
 
+  didyoumean2@6.0.1:
+    resolution:
+      {
+        integrity: sha512-PSy0zQwMg5O+LjT5Mz7vnKC8I7DfWLPF6M7oepqW7WP5mn2CY3hz46xZOa1GJY+KVfyXhdmz6+tdgXwrHlZc5g==,
+      }
+    engines: { node: ^16.14.0 || >=18.12.0 }
+
   diff@4.0.2:
     resolution:
       {
@@ -13578,6 +13598,13 @@ packages:
       {
         integrity: sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==,
       }
+
+  fastest-levenshtein@1.0.16:
+    resolution:
+      {
+        integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==,
+      }
+    engines: { node: ">= 4.9.1" }
 
   fastest-stable-stringify@2.0.2:
     resolution:
@@ -16266,6 +16293,12 @@ packages:
         integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==,
       }
 
+  lodash.deburr@4.1.0:
+    resolution:
+      {
+        integrity: sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==,
+      }
+
   lodash.defaults@4.2.0:
     resolution:
       {
@@ -16554,6 +16587,12 @@ packages:
         integrity: sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==,
       }
 
+  md4w@0.2.6:
+    resolution:
+      {
+        integrity: sha512-CBLQ2PxVe9WA+/nndZCx/Y+1C3DtmtSeubmXTPhMIgsXtq9gVGleikREko5FYnV6Dz4cHDWm0Ea+YMLpIjP4Kw==,
+      }
+
   mdast-util-definitions@4.0.0:
     resolution:
       {
@@ -16750,6 +16789,12 @@ packages:
     resolution:
       {
         integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==,
+      }
+
+  mdbox@0.1.0:
+    resolution:
+      {
+        integrity: sha512-eQA+6vf5XM4LqdfLsfPMxqUBSU8AMzSCSFbojWLXSDL2jZeO+xgHhxTggrG2jfGPAyyIWIukj6SuoFBd9a7XZw==,
       }
 
   mdn-data@2.0.14:
@@ -31602,6 +31647,29 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  automd@0.3.7(patch_hash=c3ksiahsbkzwejj5owudg6zwym)(magicast@0.3.5):
+    dependencies:
+      "@parcel/watcher": 2.4.1
+      c12: 1.11.2(magicast@0.3.5)
+      citty: 0.1.6
+      consola: 3.2.3
+      defu: 6.1.4
+      destr: 2.0.3
+      didyoumean2: 6.0.1
+      globby: 14.0.2
+      magic-string: 0.30.12
+      mdbox: 0.1.0
+      mlly: 1.7.1
+      ofetch: 1.4.1
+      pathe: 1.1.2
+      perfect-debounce: 1.0.0
+      pkg-types: 1.2.0
+      scule: 1.3.0
+      untyped: 1.4.2
+    transitivePeerDependencies:
+      - magicast
+      - supports-color
+
   autoprefixer@10.4.20(postcss@8.4.47):
     dependencies:
       browserslist: 4.24.0
@@ -32563,6 +32631,12 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  didyoumean2@6.0.1:
+    dependencies:
+      "@babel/runtime": 7.25.7
+      fastest-levenshtein: 1.0.16
+      lodash.deburr: 4.1.0
 
   diff@4.0.2: {}
 
@@ -33552,6 +33626,8 @@ snapshots:
   fast-shallow-equal@1.0.0: {}
 
   fast-uri@3.0.2: {}
+
+  fastest-levenshtein@1.0.16: {}
 
   fastest-stable-stringify@2.0.2: {}
 
@@ -35249,6 +35325,8 @@ snapshots:
 
   lodash.debounce@4.0.8: {}
 
+  lodash.deburr@4.1.0: {}
+
   lodash.defaults@4.2.0: {}
 
   lodash.get@4.4.2: {}
@@ -35404,6 +35482,8 @@ snapshots:
     dependencies:
       "@babel/runtime": 7.25.7
       remove-accents: 0.4.2
+
+  md4w@0.2.6: {}
 
   mdast-util-definitions@4.0.0:
     dependencies:
@@ -35674,6 +35754,10 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       "@types/mdast": 4.0.3
+
+  mdbox@0.1.0:
+    dependencies:
+      md4w: 0.2.6
 
   mdn-data@2.0.14: {}
 

--- a/scripts/generateAutomd.ts
+++ b/scripts/generateAutomd.ts
@@ -1,0 +1,111 @@
+import * as fs from "fs";
+import * as path from "path";
+import { transform, TransformResult } from "automd";
+
+/**
+ * This script will search for all markdown files in the project and check if they contain "automd:" term.
+ * If they do, it will run the automd transformation and update the file if needed.
+ */
+
+const stats: {
+  changedFiled: number;
+  filesWithIssues: Array<TransformResult & { path: string }>;
+} = {
+  changedFiled: 0,
+  filesWithIssues: [],
+};
+// read args, see if flag --update is present
+const shouldUpdate = process.argv.includes("--update");
+
+async function run() {
+  const start = performance.now();
+
+  await findInFiles({
+    term: "automd:",
+    rootPath: process.cwd(),
+    fileTypes: ["md"],
+    // exclude node_modules
+    exclude: ["node_modules"],
+  });
+
+  // display issues
+  if (stats.filesWithIssues.length) {
+    console.log(`Found ${stats.filesWithIssues.length} files with issues:`);
+    for (const resultWithIssue of stats.filesWithIssues) {
+      console.log(`- ${resultWithIssue.path}`);
+      for (const issue of resultWithIssue.updates) {
+        for (const issueMessage of issue.result.issues || []) {
+          console.log(`  - ${issueMessage}`);
+        }
+      }
+    }
+  }
+
+  // display changhed files:
+  console.log(`\nChanged ${stats.changedFiled} files.`);
+  const end = performance.now();
+  console.log(`Time: ${Math.round(end - start)}ms`);
+}
+
+run();
+
+async function findInFiles({
+  term,
+  rootPath,
+  fileTypes,
+  exclude,
+}: {
+  term: string;
+  rootPath: string;
+  fileTypes: string[];
+  exclude: string[];
+}): Promise<string[]> {
+  const filePaths: string[] = [];
+
+  async function searchDirectory(directory: string) {
+    const files = await fs.promises.readdir(directory, { withFileTypes: true });
+
+    for (const file of files) {
+      const fullPath = path.join(directory, file.name);
+
+      if (file.isDirectory()) {
+        if (!exclude.includes(file.name)) {
+          await searchDirectory(fullPath);
+        }
+      } else if (fileTypes.includes(path.extname(file.name).substring(1))) {
+        const content = await fs.promises.readFile(fullPath, "utf8");
+        if (content.includes(term)) {
+          filePaths.push(fullPath);
+          const updatedContent = await transform(content, {
+            dir: process.cwd(),
+          });
+          if (updatedContent.hasIssues) {
+            stats.filesWithIssues.push({
+              ...updatedContent,
+              path: fullPath,
+            });
+          } else {
+            if (updatedContent.hasChanged) {
+              if (shouldUpdate) {
+                await fs.promises.writeFile(
+                  fullPath,
+                  updatedContent.contents,
+                  "utf8",
+                );
+                stats.changedFiled++;
+              } else {
+                // if --update flag is not present, then it's just a check so we throw an error
+                throw new Error(
+                  `File ${fullPath} should be updated with "automd" script. Run with "pnpm generateAutomd" to fix.`,
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  await searchDirectory(rootPath);
+  return filePaths;
+}

--- a/templates/astro/README.md
+++ b/templates/astro/README.md
@@ -17,7 +17,7 @@ Go to [Documentation > Requirements](https://frontends.shopware.com/framework/re
 
 In order to have a different API connected to the app, change two lines of code in [./src/entrypoints/\_shopware.ts](./src/entrypoints/_shopware.ts):
 
-<!-- automd:file src="./src/entrypoints/_shopware.ts" code -->
+<!-- automd:file src="templates/astro/src/entrypoints/_shopware.ts" code -->
 
 ```ts [_shopware.ts]
 import type { App } from "vue";


### PR DESCRIPTION
### Description

closes #1380

- updated `cms-base` package definition, as it's a nuxt layer, not nuxt module anymore
- created script `pnpm generateAutomd` to update all automd tags
- needed to create a patch for automd to trim files content
- automd `file` generations now have path relative to the repo, not to that file to improve refactoring and finding related files
