### PR TITLE
feat: order composables

### DIFF
--- a/packages/composables/src/index.ts
+++ b/packages/composables/src/index.ts
@@ -65,6 +65,8 @@ export * from "./useWishlist/useWishlist";
 export * from "./useB2bQuoteManagement/useB2bQuoteManagement";
 export * from "./useCartNotification/useCartNotification";
 export * from "./useCartErrorParamsResolver/useCartErrorParamsResolver";
+export * from "./useOrder/useOrder";
+export * from "./useOrderDataProvider/useOrderDataProvider";
 
 export function resolveCmsComponent(
   content: Schemas["CmsSection"] | Schemas["CmsBlock"] | Schemas["CmsSlot"],

--- a/packages/composables/src/useOrder/useOrder.test.ts
+++ b/packages/composables/src/useOrder/useOrder.test.ts
@@ -84,23 +84,6 @@ describe("useOrder", () => {
     );
   });
 
-  it("getPaymentMethods", async () => {
-    const { vm, injections } = useSetup(() =>
-      useOrder(Order.orders.elements[0] as unknown as Schemas["Order"]),
-    );
-    injections.apiClient.invoke.mockResolvedValue({ data: {} });
-    await vm.getPaymentMethods();
-
-    expect(injections.apiClient.invoke).toHaveBeenCalledWith(
-      expect.stringContaining("readPaymentMethod"),
-      expect.objectContaining({
-        body: {
-          onlyAvailable: true,
-        },
-      }),
-    );
-  });
-
   it("should set order data", async () => {
     const { vm } = useSetup(() => useOrder());
     vm.asyncSetData(Order.orders.elements[0] as unknown as Schemas["Order"]);

--- a/packages/composables/src/useOrder/useOrder.test.ts
+++ b/packages/composables/src/useOrder/useOrder.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import { useOrder } from "./useOrder";
+import { useSetup } from "../_test";
+import { useOrderDataProvider } from "../useOrderDataProvider/useOrderDataProvider";
+import type { Schemas } from "#shopware";
+import Order from "../mocks/Order";
+
+vi.mock("../useOrderDataProvider/useOrderDataProvider.ts");
+
+describe("useOrder", () => {
+  vi.mocked(useOrderDataProvider).mockReturnValue({
+    loadOrderDetails: async () => Order as unknown as Schemas["Order"],
+  } as unknown as ReturnType<typeof useOrderDataProvider>);
+  it("init details", async () => {
+    const { vm } = useSetup(() =>
+      useOrder(Order.orders.elements[0] as unknown as Schemas["Order"]),
+    );
+
+    expect(vm.personalDetails).toEqual({
+      email: Order.orders.elements[0].orderCustomer.email,
+      firstName: Order.orders.elements[0].orderCustomer.firstName,
+      lastName: Order.orders.elements[0].orderCustomer.lastName,
+    });
+
+    expect(vm.billingAddress).toEqual(
+      Order.orders.elements[0].addresses.find(
+        ({ id }: { id: string }) =>
+          id === Order.orders.elements[0].billingAddressId,
+      ),
+    );
+  });
+
+  it("should handle setting the order payment", async () => {
+    const { vm, injections } = useSetup(() =>
+      useOrder(Order.orders.elements[0] as unknown as Schemas["Order"]),
+    );
+    injections.apiClient.invoke.mockResolvedValue({ data: {} });
+    await vm.handlePayment();
+
+    expect(injections.apiClient.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("handlePaymentMethod"),
+      expect.objectContaining({
+        body: {
+          errorUrl: undefined,
+          finishUrl: undefined,
+          orderId: Order.orders.elements[0].id,
+        },
+      }),
+    );
+  });
+
+  it("should cancel the order", async () => {
+    const { vm, injections } = useSetup(() =>
+      useOrder(Order.orders.elements[0] as unknown as Schemas["Order"]),
+    );
+    injections.apiClient.invoke.mockResolvedValue({ data: {} });
+    await vm.cancel();
+
+    expect(injections.apiClient.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("cancelOrder"),
+      expect.objectContaining({
+        body: {
+          orderId: Order.orders.elements[0].id,
+        },
+      }),
+    );
+  });
+
+  it("changePaymentMethod", async () => {
+    const { vm, injections } = useSetup(() =>
+      useOrder(Order.orders.elements[0] as unknown as Schemas["Order"]),
+    );
+    injections.apiClient.invoke.mockResolvedValue({ data: {} });
+    await vm.changePaymentMethod("test");
+
+    expect(injections.apiClient.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("orderSetPayment"),
+      expect.objectContaining({
+        body: {
+          orderId: Order.orders.elements[0].id,
+          paymentMethodId: "test",
+        },
+      }),
+    );
+  });
+
+  it("getPaymentMethods", async () => {
+    const { vm, injections } = useSetup(() =>
+      useOrder(Order.orders.elements[0] as unknown as Schemas["Order"]),
+    );
+    injections.apiClient.invoke.mockResolvedValue({ data: {} });
+    await vm.getPaymentMethods();
+
+    expect(injections.apiClient.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("readPaymentMethod"),
+      expect.objectContaining({
+        body: {
+          onlyAvailable: true,
+        },
+      }),
+    );
+  });
+
+  it("should set order data", async () => {
+    const { vm } = useSetup(() => useOrder());
+    vm.asyncSetData(Order.orders.elements[0] as unknown as Schemas["Order"]);
+
+    expect(vm.order).toEqual(Order.orders.elements[0]);
+  });
+});

--- a/packages/composables/src/useOrder/useOrder.ts
+++ b/packages/composables/src/useOrder/useOrder.ts
@@ -90,10 +90,6 @@ export type UseOrderReturn = {
    * Get order documents
    */
   documents: ComputedRef<Schemas["Document"][]>;
-  /**
-   * Fetches all available payment methods
-   */
-  getPaymentMethods(): Promise<Schemas["PaymentMethod"][]>;
 
   //   paymentChangeable: ComputedRef<boolean>;
   asyncSetData(order: Schemas["Order"]): void;
@@ -201,16 +197,6 @@ export function useOrder(order?: Schemas["Order"]): UseOrderReturn {
   const hasDocuments = computed(() => !!_sharedOrder.value?.documents.length);
   const documents = computed(() => _sharedOrder.value?.documents || []);
 
-  const getPaymentMethods = async () => {
-    const response = await apiClient.invoke(
-      "readPaymentMethod post /payment-method",
-      {
-        body: { onlyAvailable: true },
-      },
-    );
-    return response.data.elements || [];
-  };
-
   const updateOrder = async () => {
     const order = await loadOrderDetails({
       keyValue: orderId.value,
@@ -239,7 +225,6 @@ export function useOrder(order?: Schemas["Order"]): UseOrderReturn {
     handlePayment,
     cancel,
     changePaymentMethod,
-    getPaymentMethods,
     asyncSetData,
   };
 }

--- a/packages/composables/src/useOrderDataProvider/useOrderDataProvider.test.ts
+++ b/packages/composables/src/useOrderDataProvider/useOrderDataProvider.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { useOrderDataProvider } from "./useOrderDataProvider";
+import { useDefaultOrderAssociations } from "../useDefaultOrderAssociations/useDefaultOrderAssociations";
+import { useSetup } from "../_test";
+import Order from "../mocks/Order";
+
+describe("useOrderDataProvider", () => {
+  const orderAssociations = useDefaultOrderAssociations();
+  it("should load order details", async () => {
+    const { vm, injections } = useSetup(() => useOrderDataProvider());
+    injections.apiClient.invoke.mockResolvedValue({
+      data: Order,
+    });
+    vm.loadOrderDetails({ keyValue: "123" });
+
+    expect(injections.apiClient.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("readOrder"),
+      expect.objectContaining({
+        body: {
+          ...orderAssociations,
+          filter: [{ field: "id", type: "equals", value: "123" }],
+        },
+      }),
+    );
+  });
+
+  it("should load order details with custom associations", async () => {
+    const { vm, injections } = useSetup(() => useOrderDataProvider());
+    injections.apiClient.invoke.mockResolvedValue({ data: {} });
+    vm.loadOrderDetails({ keyValue: "123", field: "deepCode" }, { custom: {} });
+
+    expect(injections.apiClient.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("readOrder"),
+      expect.objectContaining({
+        body: {
+          ...orderAssociations,
+          filter: [{ field: "deepCode", type: "equals", value: "123" }],
+        },
+      }),
+    );
+  });
+
+  it("should get the order document file", async () => {
+    const { vm, injections } = useSetup(() => useOrderDataProvider());
+    injections.apiClient.invoke.mockResolvedValue({ data: {} });
+    await vm.getDocumentFile("file-123", "code-123");
+
+    expect(injections.apiClient.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("download"),
+      expect.objectContaining({
+        pathParams: {
+          documentId: "file-123",
+          deepLinkCode: "code-123",
+        },
+      }),
+    );
+  });
+
+  it("getMediaFile", async () => {
+    const { vm, injections } = useSetup(() => useOrderDataProvider());
+    injections.apiClient.invoke.mockResolvedValue({ data: {} });
+    await vm.getMediaFile(Order.orders.elements[0].id, "file-123");
+
+    expect(injections.apiClient.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("orderDownloadFile"),
+      expect.objectContaining({
+        accept: "application/octet-stream",
+        pathParams: {
+          orderId: Order.orders.elements[0].id,
+          downloadId: "file-123",
+        },
+      }),
+    );
+  });
+});

--- a/packages/composables/src/useOrderDataProvider/useOrderDataProvider.ts
+++ b/packages/composables/src/useOrderDataProvider/useOrderDataProvider.ts
@@ -1,0 +1,99 @@
+import { defu } from "defu";
+import { useDefaultOrderAssociations, useShopwareContext } from "#imports";
+
+import type { Schemas } from "#shopware";
+
+export type UseOrderDataProviderReturn = {
+  /**
+   * Get order object including additional associations.
+   * useDefaults describes what order object should look like.
+   */
+  loadOrderDetails(
+    orderSearchData: { keyValue: string; field?: string },
+    associations?: Schemas["Criteria"]["associations"],
+  ): Promise<Schemas["Order"] | null>;
+
+  /**
+   * Get media content
+   *
+   * @param {string} downloadId
+   * @returns {Blob}
+   */
+  getMediaFile: (orderId: string, downloadId: string) => Promise<Blob>;
+
+  /**
+   * Get order documents
+   * @param {string} documentId
+   * @param {string} deepLinkCode
+   * @returns
+   */
+  getDocumentFile: (
+    documentId: string,
+    deepLinkCode: string,
+  ) => Promise<Schemas["Document"]>;
+};
+
+export function useOrderDataProvider(): UseOrderDataProviderReturn {
+  const { apiClient } = useShopwareContext();
+  const orderAssociations = useDefaultOrderAssociations();
+
+  async function loadOrderDetails(
+    orderSearchData: { keyValue: string; field?: string },
+    associations?: Schemas["Criteria"]["associations"],
+  ) {
+    const mergedAssociations = defu(
+      orderAssociations,
+      associations ? associations : {},
+    );
+    const params = {
+      filter: [
+        {
+          type: "equals",
+          field: orderSearchData.field ?? "id",
+          value: orderSearchData.keyValue,
+        },
+      ],
+      associations: mergedAssociations.associations,
+      checkPromotion: true,
+    } as Schemas["Criteria"];
+
+    const orderDetailsResponse = await apiClient.invoke(
+      "readOrder post /order",
+      {
+        body: params,
+      },
+    );
+    return orderDetailsResponse.data.orders?.elements?.[0] ?? null;
+  }
+
+  async function getMediaFile(orderId: string, downloadId: string) {
+    const response = await apiClient.invoke(
+      "orderDownloadFile get /order/download/{orderId}/{downloadId}",
+      {
+        accept: "application/octet-stream",
+        pathParams: {
+          orderId,
+          downloadId,
+        },
+      },
+    );
+
+    return response.data;
+  }
+
+  async function getDocumentFile(documentId: string, deepLinkCode: string) {
+    const response = await apiClient.invoke(
+      "download post /document/download/{documentId}/{deepLinkCode}",
+      {
+        pathParams: {
+          documentId,
+          deepLinkCode,
+        },
+      },
+    );
+
+    return response.data;
+  }
+
+  return { loadOrderDetails, getMediaFile, getDocumentFile };
+}

--- a/templates/vue-demo-store/components/account/AccountOrderDetails.vue
+++ b/templates/vue-demo-store/components/account/AccountOrderDetails.vue
@@ -12,21 +12,28 @@ const isLoading = ref(false);
 const { getErrorsCodes } = useCartNotification();
 const { pushSuccess, pushError } = useNotifications();
 const { t } = useI18n();
+
 const {
-  loadOrderDetails,
   order,
   hasDocuments,
   documents,
   paymentMethod,
-  paymentChangeable,
+  // paymentChangeable,
   getPaymentMethods,
   changePaymentMethod,
   statusTechnicalName,
-} = await useOrderDetails(props.orderId);
+  asyncSetData,
+} = await useOrder();
+
+const { loadOrderDetails } = useOrderDataProvider();
+
 const { addProducts, count } = useCart();
 const addingProducts = ref(false);
-onMounted(() => {
-  loadOrderDetails();
+onMounted(async () => {
+  const order = await loadOrderDetails({
+    keyValue: props.orderId,
+  });
+  if (order) asyncSetData(order);
 });
 
 const lineItems = computed<Array<Schemas["OrderLineItem"]>>(
@@ -50,6 +57,7 @@ const selectedPaymentMethod = computed({
     }
   },
 });
+
 const paymentMethods = await getPaymentMethods();
 
 const handleReorder = async () => {
@@ -95,7 +103,7 @@ const handleReorder = async () => {
 </script>
 
 <template>
-  <div
+  <!-- <div
     v-if="paymentChangeable && statusTechnicalName === 'open'"
     class="px-2 py-4"
   >
@@ -139,7 +147,7 @@ const handleReorder = async () => {
         </label>
       </li>
     </ul>
-  </div>
+  </div> -->
   <div v-if="lineItems.length" class="px-2 py-4">
     <div
       class="hidden sm:grid grid-cols-5 gap-y-10 gap-x-6 pb-4 text-secondary-400"

--- a/templates/vue-demo-store/components/account/AccountOrderDetails.vue
+++ b/templates/vue-demo-store/components/account/AccountOrderDetails.vue
@@ -19,17 +19,19 @@ const {
   documents,
   paymentMethod,
   // paymentChangeable,
-  getPaymentMethods,
   changePaymentMethod,
   statusTechnicalName,
   asyncSetData,
 } = await useOrder();
+
+const { paymentMethods, getPaymentMethods } = useCheckout();
 
 const { loadOrderDetails } = useOrderDataProvider();
 
 const { addProducts, count } = useCart();
 const addingProducts = ref(false);
 onMounted(async () => {
+  getPaymentMethods();
   const order = await loadOrderDetails({
     keyValue: props.orderId,
   });
@@ -57,8 +59,6 @@ const selectedPaymentMethod = computed({
     }
   },
 });
-
-const paymentMethods = await getPaymentMethods();
 
 const handleReorder = async () => {
   if (!order.value?.lineItems) {

--- a/templates/vue-demo-store/components/account/AccountOrderDownloads.vue
+++ b/templates/vue-demo-store/components/account/AccountOrderDownloads.vue
@@ -6,7 +6,7 @@ const props = defineProps<{
   documents: Schemas["Document"][];
 }>();
 
-const { getDocumentFile } = useOrderDetails(props.documents[0].orderId);
+const { getDocumentFile } = useOrderDataProvider();
 
 const getMediaFileHandler = async (documentObject: Schemas["Document"]) => {
   const response = await getDocumentFile(

--- a/templates/vue-demo-store/components/account/order/LineItemProduct.vue
+++ b/templates/vue-demo-store/components/account/order/LineItemProduct.vue
@@ -9,14 +9,14 @@ const props = defineProps<{
   lineItem: Schemas["OrderLineItem"];
 }>();
 
-const { getMediaFile } = useOrderDetails(props.lineItem.orderId);
+const { getMediaFile } = useOrderDataProvider();
 
 const isDigital = computed(
   () => !!props.lineItem.states?.includes("is-download"),
 );
 
 const getMediaFileHandler = async (mediaId: string, fileName: string) => {
-  const response = await getMediaFile(mediaId);
+  const response = await getMediaFile(props.lineItem.id, mediaId);
   downloadFile(response, fileName);
 };
 </script>

--- a/templates/vue-demo-store/pages/checkout/success/[id]/index.vue
+++ b/templates/vue-demo-store/pages/checkout/success/[id]/index.vue
@@ -12,8 +12,9 @@ const { isLoggedIn, isGuestSession } = useUser();
 if (!isLoggedIn.value && !isGuestSession.value) {
   router.push("/");
 }
+
 const {
-  loadOrderDetails,
+  asyncSetData,
   shippingAddress,
   billingAddress,
   shippingMethod,
@@ -22,7 +23,9 @@ const {
   subtotal,
   total,
   shippingCosts,
-} = useOrderDetails(orderId);
+} = useOrder();
+
+const { loadOrderDetails } = useOrderDataProvider();
 
 const { paymentUrl, handlePayment, isAsynchronous, state, paymentMethod } =
   useOrderPayment(order);
@@ -31,7 +34,11 @@ onMounted(async () => {
   const SUCCESS_PAYMENT_URL = `${window?.location?.origin}/checkout/success/${orderId}/paid`;
   const FAILURE_PAYMENT_URL = `${window?.location?.origin}/checkout/success/${orderId}/unpaid`;
 
-  await loadOrderDetails();
+  const order = await loadOrderDetails({
+    keyValue: orderId,
+  });
+  if (order) asyncSetData(order);
+
   handlePayment(SUCCESS_PAYMENT_URL, FAILURE_PAYMENT_URL);
 });
 


### PR DESCRIPTION
### Description

The idea of this MR is to split useOrderDetails composable to smaller composables

<!-- example: closes #007 -->

### Type of change

<!-- Comment out the type of change your PR is making -->

<!-- Bug fix (non-breaking change that fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

<!-- Add the todo's that need to be done before merge -->
<!-- Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. -->

<!-- - [ ] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) -->
<!-- - [ ] Documentation added/updated -->
<!-- - [ ] Unit-Tests added/updated -->
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
