### PR TITLE
feat(api-client): add `accountType` and `vatIds` properties to `changeProfile` operation

### DIFF
--- a/examples/adyen-dropin-component/api-types/storeApiTypes.d.ts
+++ b/examples/adyen-dropin-component/api-types/storeApiTypes.d.ts
@@ -1751,7 +1751,6 @@ export type Schemas = {
     readonly updatedAt?: string;
   };
   Customer: {
-    accountType?: string;
     active?: boolean;
     activeBillingAddress: components["schemas"]["CustomerAddress"];
     activeShippingAddress: components["schemas"]["CustomerAddress"];
@@ -1761,7 +1760,6 @@ export type Schemas = {
     apiAlias: "customer";
     birthday?: string;
     campaignCode?: string;
-    company?: string;
     /** Format: date-time */
     readonly createdAt?: string;
     createdById?: string;
@@ -1828,8 +1826,18 @@ export type Schemas = {
     /** Format: date-time */
     readonly updatedAt?: string;
     updatedById?: string;
-    vatIds?: string[];
-  };
+  } & (
+    | {
+        /** @enum {string} */
+        accountType: "private";
+      }
+    | {
+        /** @enum {string} */
+        accountType: "business";
+        company: string;
+        vatIds: [string, ...string[]];
+      }
+  );
   CustomerAddress: {
     additionalAddressLine1?: string;
     additionalAddressLine2?: string;
@@ -7637,8 +7645,6 @@ export type operations = {
       birthdayMonth?: number;
       /** Birthday year */
       birthdayYear?: number;
-      /** Company of the customer. Only required when `accountType` is `business`. */
-      company?: string;
       /** Customer first name. Value will be reused for shipping and billing address if not provided explicitly. */
       firstName: string;
       /** Customer last name. Value will be reused for shipping and billing address if not provided explicitly. */
@@ -7647,7 +7653,29 @@ export type operations = {
       salutationId: string;
       /** (Academic) title of the customer */
       title?: string;
-    };
+    } & (
+      | {
+          /**
+           * Type of the customer account. Default value is 'private'.
+           * @default private
+           * @enum {string}
+           */
+          accountType?: "private";
+          company?: null;
+          vatIds?: null;
+        }
+      | {
+          /**
+           * Type of the customer account. Can be `private` or `business`.
+           * @enum {string}
+           */
+          accountType: "business";
+          /** Company of the customer. Only required when `accountType` is `business`. */
+          company: string;
+          /** VAT IDs of the customer's company. Only valid when `accountType` is `business`. */
+          vatIds: [string, ...string[]];
+        }
+    );
     response: components["schemas"]["SuccessResponse"];
     responseCode: 200;
   };
@@ -7769,17 +7797,9 @@ export type operations = {
     body: {
       /** Flag indicating accepted data protection */
       acceptedDataProtection: boolean;
-      /**
-       * Account type of the customer which can be either `private` or `business`.
-       * @default private
-       */
-      accountType?: string;
       /** Field can be used to store an affiliate tracking code */
       affiliateCode?: string;
-      billingAddress: Omit<
-        components["schemas"]["CustomerAddress"],
-        "createdAt" | "id" | "customerId" | "firstName" | "lastName"
-      >; // TODO: [OpenAPI][register] - omit id, createdAt, customerId, firstName, lastName while creating address (or better to reverse and pick required fields)
+      billingAddress: components["schemas"]["CustomerAddress"];
       /** Birthday day */
       birthdayDay?: number;
       /** Birthday month */
@@ -7808,7 +7828,29 @@ export type operations = {
       storefrontUrl: string;
       /** (Academic) title of the customer */
       title?: string;
-    };
+    } & (
+      | {
+          /**
+           * Type of the customer account. Default value is 'private'.
+           * @default private
+           * @enum {string}
+           */
+          accountType?: "private";
+          company?: null;
+          vatIds?: null;
+        }
+      | {
+          /**
+           * Type of the customer account. Can be `private` or `business`.
+           * @enum {string}
+           */
+          accountType: "business";
+          /** Company of the customer. Only required when `accountType` is `business`. */
+          company: string;
+          /** VAT IDs of the customer's company. Only valid when `accountType` is `business`. */
+          vatIds: [string, ...string[]];
+        }
+    );
     response: components["schemas"]["Customer"];
     responseCode: 200;
   };

--- a/examples/amazon-pay-button-example/src/runtime/composables/useAmazonPayCheckout.ts
+++ b/examples/amazon-pay-button-example/src/runtime/composables/useAmazonPayCheckout.ts
@@ -103,6 +103,13 @@ export function useAmazonPayCheckout(amazonSessionId?: string) {
       accountType: "private",
       salutationId: getNotSpecifiedSalutation(),
       billingAddress: {
+        customerId: "",
+        firstName: sessionData.billingAddress.name?.split(" ")[0],
+        lastName:
+          sessionData.billingAddress.name?.split(" ")[
+            sessionData.billingAddress.name?.split(" ").length - 1
+          ] || "",
+        id: "",
         salutationId: getNotSpecifiedSalutation(),
         countryId: mapCountryId(sessionData.billingAddress.countryCode),
         street:

--- a/examples/b2b-quote-management/api-types/storeApiTypes.d.ts
+++ b/examples/b2b-quote-management/api-types/storeApiTypes.d.ts
@@ -1704,7 +1704,6 @@ export type Schemas = {
     readonly updatedAt?: string;
   };
   Customer: {
-    accountType?: string;
     active?: boolean;
     activeBillingAddress: components["schemas"]["CustomerAddress"];
     activeShippingAddress: components["schemas"]["CustomerAddress"];
@@ -1714,7 +1713,6 @@ export type Schemas = {
     apiAlias: "customer";
     birthday?: string;
     campaignCode?: string;
-    company?: string;
     /** Format: date-time */
     readonly createdAt?: string;
     createdById?: string;
@@ -1781,8 +1779,18 @@ export type Schemas = {
     /** Format: date-time */
     readonly updatedAt?: string;
     updatedById?: string;
-    vatIds?: string[];
-  };
+  } & (
+    | {
+        /** @enum {string} */
+        accountType: "private";
+      }
+    | {
+        /** @enum {string} */
+        accountType: "business";
+        company: string;
+        vatIds: [string, ...string[]];
+      }
+  );
   CustomerAddress: {
     additionalAddressLine1?: string;
     additionalAddressLine2?: string;
@@ -7547,8 +7555,6 @@ export type operations = {
       birthdayMonth?: number;
       /** Birthday year */
       birthdayYear?: number;
-      /** Company of the customer. Only required when `accountType` is `business`. */
-      company?: string;
       /** Customer first name. Value will be reused for shipping and billing address if not provided explicitly. */
       firstName: string;
       /** Customer last name. Value will be reused for shipping and billing address if not provided explicitly. */
@@ -7557,7 +7563,29 @@ export type operations = {
       salutationId: string;
       /** (Academic) title of the customer */
       title?: string;
-    };
+    } & (
+      | {
+          /**
+           * Type of the customer account. Default value is 'private'.
+           * @default private
+           * @enum {string}
+           */
+          accountType?: "private";
+          company?: null;
+          vatIds?: null;
+        }
+      | {
+          /**
+           * Type of the customer account. Can be `private` or `business`.
+           * @enum {string}
+           */
+          accountType: "business";
+          /** Company of the customer. Only required when `accountType` is `business`. */
+          company: string;
+          /** VAT IDs of the customer's company. Only valid when `accountType` is `business`. */
+          vatIds: [string, ...string[]];
+        }
+    );
     response: components["schemas"]["SuccessResponse"];
     responseCode: 200;
   };
@@ -7679,17 +7707,9 @@ export type operations = {
     body: {
       /** Flag indicating accepted data protection */
       acceptedDataProtection: boolean;
-      /**
-       * Account type of the customer which can be either `private` or `business`.
-       * @default private
-       */
-      accountType?: string;
       /** Field can be used to store an affiliate tracking code */
       affiliateCode?: string;
-      billingAddress: Omit<
-        components["schemas"]["CustomerAddress"],
-        "createdAt" | "id" | "customerId" | "firstName" | "lastName"
-      >; // TODO: [OpenAPI][register] - omit id, createdAt, customerId, firstName, lastName while creating address (or better to reverse and pick required fields)
+      billingAddress: components["schemas"]["CustomerAddress"];
       /** Birthday day */
       birthdayDay?: number;
       /** Birthday month */
@@ -7718,7 +7738,29 @@ export type operations = {
       storefrontUrl: string;
       /** (Academic) title of the customer */
       title?: string;
-    };
+    } & (
+      | {
+          /**
+           * Type of the customer account. Default value is 'private'.
+           * @default private
+           * @enum {string}
+           */
+          accountType?: "private";
+          company?: null;
+          vatIds?: null;
+        }
+      | {
+          /**
+           * Type of the customer account. Can be `private` or `business`.
+           * @enum {string}
+           */
+          accountType: "business";
+          /** Company of the customer. Only required when `accountType` is `business`. */
+          company: string;
+          /** VAT IDs of the customer's company. Only valid when `accountType` is `business`. */
+          vatIds: [string, ...string[]];
+        }
+    );
     response: components["schemas"]["Customer"];
     responseCode: 200;
   };

--- a/examples/commercial-customized-products/api-types/storeApiTypes.d.ts
+++ b/examples/commercial-customized-products/api-types/storeApiTypes.d.ts
@@ -1730,7 +1730,6 @@ export type Schemas = {
     readonly updatedAt?: string;
   };
   Customer: {
-    accountType?: string;
     active?: boolean;
     activeBillingAddress: components["schemas"]["CustomerAddress"];
     activeShippingAddress: components["schemas"]["CustomerAddress"];
@@ -1740,7 +1739,6 @@ export type Schemas = {
     apiAlias: "customer";
     birthday?: string;
     campaignCode?: string;
-    company?: string;
     /** Format: date-time */
     readonly createdAt?: string;
     createdById?: string;
@@ -1807,8 +1805,18 @@ export type Schemas = {
     /** Format: date-time */
     readonly updatedAt?: string;
     updatedById?: string;
-    vatIds?: string[];
-  };
+  } & (
+    | {
+        /** @enum {string} */
+        accountType: "private";
+      }
+    | {
+        /** @enum {string} */
+        accountType: "business";
+        company: string;
+        vatIds: [string, ...string[]];
+      }
+  );
   CustomerAddress: {
     additionalAddressLine1?: string;
     additionalAddressLine2?: string;
@@ -7569,8 +7577,6 @@ export type operations = {
       birthdayMonth?: number;
       /** Birthday year */
       birthdayYear?: number;
-      /** Company of the customer. Only required when `accountType` is `business`. */
-      company?: string;
       /** Customer first name. Value will be reused for shipping and billing address if not provided explicitly. */
       firstName: string;
       /** Customer last name. Value will be reused for shipping and billing address if not provided explicitly. */
@@ -7579,7 +7585,29 @@ export type operations = {
       salutationId: string;
       /** (Academic) title of the customer */
       title?: string;
-    };
+    } & (
+      | {
+          /**
+           * Type of the customer account. Default value is 'private'.
+           * @default private
+           * @enum {string}
+           */
+          accountType?: "private";
+          company?: null;
+          vatIds?: null;
+        }
+      | {
+          /**
+           * Type of the customer account. Can be `private` or `business`.
+           * @enum {string}
+           */
+          accountType: "business";
+          /** Company of the customer. Only required when `accountType` is `business`. */
+          company: string;
+          /** VAT IDs of the customer's company. Only valid when `accountType` is `business`. */
+          vatIds: [string, ...string[]];
+        }
+    );
     response: components["schemas"]["SuccessResponse"];
     responseCode: 200;
   };
@@ -7701,17 +7729,9 @@ export type operations = {
     body: {
       /** Flag indicating accepted data protection */
       acceptedDataProtection: boolean;
-      /**
-       * Account type of the customer which can be either `private` or `business`.
-       * @default private
-       */
-      accountType?: string;
       /** Field can be used to store an affiliate tracking code */
       affiliateCode?: string;
-      billingAddress: Omit<
-        components["schemas"]["CustomerAddress"],
-        "createdAt" | "id" | "customerId" | "firstName" | "lastName"
-      >; // TODO: [OpenAPI][register] - omit id, createdAt, customerId, firstName, lastName while creating address (or better to reverse and pick required fields)
+      billingAddress: components["schemas"]["CustomerAddress"];
       /** Birthday day */
       birthdayDay?: number;
       /** Birthday month */
@@ -7740,7 +7760,29 @@ export type operations = {
       storefrontUrl: string;
       /** (Academic) title of the customer */
       title?: string;
-    };
+    } & (
+      | {
+          /**
+           * Type of the customer account. Default value is 'private'.
+           * @default private
+           * @enum {string}
+           */
+          accountType?: "private";
+          company?: null;
+          vatIds?: null;
+        }
+      | {
+          /**
+           * Type of the customer account. Can be `private` or `business`.
+           * @enum {string}
+           */
+          accountType: "business";
+          /** Company of the customer. Only required when `accountType` is `business`. */
+          company: string;
+          /** VAT IDs of the customer's company. Only valid when `accountType` is `business`. */
+          vatIds: [string, ...string[]];
+        }
+    );
     response: components["schemas"]["Customer"];
     responseCode: 200;
   };

--- a/examples/commercial-quick-order/api-types/storeApiTypes.d.ts
+++ b/examples/commercial-quick-order/api-types/storeApiTypes.d.ts
@@ -1728,7 +1728,6 @@ export type Schemas = {
     readonly updatedAt?: string;
   };
   Customer: {
-    accountType?: string;
     active?: boolean;
     activeBillingAddress: components["schemas"]["CustomerAddress"];
     activeShippingAddress: components["schemas"]["CustomerAddress"];
@@ -1738,7 +1737,6 @@ export type Schemas = {
     apiAlias: "customer";
     birthday?: string;
     campaignCode?: string;
-    company?: string;
     /** Format: date-time */
     readonly createdAt?: string;
     createdById?: string;
@@ -1805,8 +1803,18 @@ export type Schemas = {
     /** Format: date-time */
     readonly updatedAt?: string;
     updatedById?: string;
-    vatIds?: string[];
-  };
+  } & (
+    | {
+        /** @enum {string} */
+        accountType: "private";
+      }
+    | {
+        /** @enum {string} */
+        accountType: "business";
+        company: string;
+        vatIds: [string, ...string[]];
+      }
+  );
   CustomerAddress: {
     additionalAddressLine1?: string;
     additionalAddressLine2?: string;
@@ -7571,8 +7579,6 @@ export type operations = {
       birthdayMonth?: number;
       /** Birthday year */
       birthdayYear?: number;
-      /** Company of the customer. Only required when `accountType` is `business`. */
-      company?: string;
       /** Customer first name. Value will be reused for shipping and billing address if not provided explicitly. */
       firstName: string;
       /** Customer last name. Value will be reused for shipping and billing address if not provided explicitly. */
@@ -7581,7 +7587,29 @@ export type operations = {
       salutationId: string;
       /** (Academic) title of the customer */
       title?: string;
-    };
+    } & (
+      | {
+          /**
+           * Type of the customer account. Default value is 'private'.
+           * @default private
+           * @enum {string}
+           */
+          accountType?: "private";
+          company?: null;
+          vatIds?: null;
+        }
+      | {
+          /**
+           * Type of the customer account. Can be `private` or `business`.
+           * @enum {string}
+           */
+          accountType: "business";
+          /** Company of the customer. Only required when `accountType` is `business`. */
+          company: string;
+          /** VAT IDs of the customer's company. Only valid when `accountType` is `business`. */
+          vatIds: [string, ...string[]];
+        }
+    );
     response: components["schemas"]["SuccessResponse"];
     responseCode: 200;
   };
@@ -7703,17 +7731,9 @@ export type operations = {
     body: {
       /** Flag indicating accepted data protection */
       acceptedDataProtection: boolean;
-      /**
-       * Account type of the customer which can be either `private` or `business`.
-       * @default private
-       */
-      accountType?: string;
       /** Field can be used to store an affiliate tracking code */
       affiliateCode?: string;
-      billingAddress: Omit<
-        components["schemas"]["CustomerAddress"],
-        "createdAt" | "id" | "customerId" | "firstName" | "lastName"
-      >; // TODO: [OpenAPI][register] - omit id, createdAt, customerId, firstName, lastName while creating address (or better to reverse and pick required fields)
+      billingAddress: components["schemas"]["CustomerAddress"];
       /** Birthday day */
       birthdayDay?: number;
       /** Birthday month */
@@ -7742,7 +7762,29 @@ export type operations = {
       storefrontUrl: string;
       /** (Academic) title of the customer */
       title?: string;
-    };
+    } & (
+      | {
+          /**
+           * Type of the customer account. Default value is 'private'.
+           * @default private
+           * @enum {string}
+           */
+          accountType?: "private";
+          company?: null;
+          vatIds?: null;
+        }
+      | {
+          /**
+           * Type of the customer account. Can be `private` or `business`.
+           * @enum {string}
+           */
+          accountType: "business";
+          /** Company of the customer. Only required when `accountType` is `business`. */
+          company: string;
+          /** VAT IDs of the customer's company. Only valid when `accountType` is `business`. */
+          vatIds: [string, ...string[]];
+        }
+    );
     response: components["schemas"]["Customer"];
     responseCode: 200;
   };

--- a/examples/express-checkout/api-types/storeApiTypes.d.ts
+++ b/examples/express-checkout/api-types/storeApiTypes.d.ts
@@ -1704,7 +1704,6 @@ export type Schemas = {
     readonly updatedAt?: string;
   };
   Customer: {
-    accountType?: string;
     active?: boolean;
     activeBillingAddress: components["schemas"]["CustomerAddress"];
     activeShippingAddress: components["schemas"]["CustomerAddress"];
@@ -1714,7 +1713,6 @@ export type Schemas = {
     apiAlias: "customer";
     birthday?: string;
     campaignCode?: string;
-    company?: string;
     /** Format: date-time */
     readonly createdAt?: string;
     createdById?: string;
@@ -1781,8 +1779,18 @@ export type Schemas = {
     /** Format: date-time */
     readonly updatedAt?: string;
     updatedById?: string;
-    vatIds?: string[];
-  };
+  } & (
+    | {
+        /** @enum {string} */
+        accountType: "private";
+      }
+    | {
+        /** @enum {string} */
+        accountType: "business";
+        company: string;
+        vatIds: [string, ...string[]];
+      }
+  );
   CustomerAddress: {
     additionalAddressLine1?: string;
     additionalAddressLine2?: string;
@@ -7547,8 +7555,6 @@ export type operations = {
       birthdayMonth?: number;
       /** Birthday year */
       birthdayYear?: number;
-      /** Company of the customer. Only required when `accountType` is `business`. */
-      company?: string;
       /** Customer first name. Value will be reused for shipping and billing address if not provided explicitly. */
       firstName: string;
       /** Customer last name. Value will be reused for shipping and billing address if not provided explicitly. */
@@ -7557,7 +7563,29 @@ export type operations = {
       salutationId: string;
       /** (Academic) title of the customer */
       title?: string;
-    };
+    } & (
+      | {
+          /**
+           * Type of the customer account. Default value is 'private'.
+           * @default private
+           * @enum {string}
+           */
+          accountType?: "private";
+          company?: null;
+          vatIds?: null;
+        }
+      | {
+          /**
+           * Type of the customer account. Can be `private` or `business`.
+           * @enum {string}
+           */
+          accountType: "business";
+          /** Company of the customer. Only required when `accountType` is `business`. */
+          company: string;
+          /** VAT IDs of the customer's company. Only valid when `accountType` is `business`. */
+          vatIds: [string, ...string[]];
+        }
+    );
     response: components["schemas"]["SuccessResponse"];
     responseCode: 200;
   };
@@ -7679,17 +7707,9 @@ export type operations = {
     body: {
       /** Flag indicating accepted data protection */
       acceptedDataProtection: boolean;
-      /**
-       * Account type of the customer which can be either `private` or `business`.
-       * @default private
-       */
-      accountType?: string;
       /** Field can be used to store an affiliate tracking code */
       affiliateCode?: string;
-      billingAddress: Omit<
-        components["schemas"]["CustomerAddress"],
-        "createdAt" | "id" | "customerId" | "firstName" | "lastName"
-      >; // TODO: [OpenAPI][register] - omit id, createdAt, customerId, firstName, lastName while creating address (or better to reverse and pick required fields)
+      billingAddress: components["schemas"]["CustomerAddress"];
       /** Birthday day */
       birthdayDay?: number;
       /** Birthday month */
@@ -7718,7 +7738,29 @@ export type operations = {
       storefrontUrl: string;
       /** (Academic) title of the customer */
       title?: string;
-    };
+    } & (
+      | {
+          /**
+           * Type of the customer account. Default value is 'private'.
+           * @default private
+           * @enum {string}
+           */
+          accountType?: "private";
+          company?: null;
+          vatIds?: null;
+        }
+      | {
+          /**
+           * Type of the customer account. Can be `private` or `business`.
+           * @enum {string}
+           */
+          accountType: "business";
+          /** Company of the customer. Only required when `accountType` is `business`. */
+          company: string;
+          /** VAT IDs of the customer's company. Only valid when `accountType` is `business`. */
+          vatIds: [string, ...string[]];
+        }
+    );
     response: components["schemas"]["Customer"];
     responseCode: 200;
   };

--- a/examples/mollie-credit-card/api-types/storeApiTypes.d.ts
+++ b/examples/mollie-credit-card/api-types/storeApiTypes.d.ts
@@ -1704,7 +1704,6 @@ export type Schemas = {
     readonly updatedAt?: string;
   };
   Customer: {
-    accountType?: string;
     active?: boolean;
     activeBillingAddress: components["schemas"]["CustomerAddress"];
     activeShippingAddress: components["schemas"]["CustomerAddress"];
@@ -1714,7 +1713,6 @@ export type Schemas = {
     apiAlias: "customer";
     birthday?: string;
     campaignCode?: string;
-    company?: string;
     /** Format: date-time */
     readonly createdAt?: string;
     createdById?: string;
@@ -1781,8 +1779,18 @@ export type Schemas = {
     /** Format: date-time */
     readonly updatedAt?: string;
     updatedById?: string;
-    vatIds?: string[];
-  };
+  } & (
+    | {
+        /** @enum {string} */
+        accountType: "private";
+      }
+    | {
+        /** @enum {string} */
+        accountType: "business";
+        company: string;
+        vatIds: [string, ...string[]];
+      }
+  );
   CustomerAddress: {
     additionalAddressLine1?: string;
     additionalAddressLine2?: string;
@@ -7547,8 +7555,6 @@ export type operations = {
       birthdayMonth?: number;
       /** Birthday year */
       birthdayYear?: number;
-      /** Company of the customer. Only required when `accountType` is `business`. */
-      company?: string;
       /** Customer first name. Value will be reused for shipping and billing address if not provided explicitly. */
       firstName: string;
       /** Customer last name. Value will be reused for shipping and billing address if not provided explicitly. */
@@ -7557,7 +7563,29 @@ export type operations = {
       salutationId: string;
       /** (Academic) title of the customer */
       title?: string;
-    };
+    } & (
+      | {
+          /**
+           * Type of the customer account. Default value is 'private'.
+           * @default private
+           * @enum {string}
+           */
+          accountType?: "private";
+          company?: null;
+          vatIds?: null;
+        }
+      | {
+          /**
+           * Type of the customer account. Can be `private` or `business`.
+           * @enum {string}
+           */
+          accountType: "business";
+          /** Company of the customer. Only required when `accountType` is `business`. */
+          company: string;
+          /** VAT IDs of the customer's company. Only valid when `accountType` is `business`. */
+          vatIds: [string, ...string[]];
+        }
+    );
     response: components["schemas"]["SuccessResponse"];
     responseCode: 200;
   };
@@ -7679,17 +7707,9 @@ export type operations = {
     body: {
       /** Flag indicating accepted data protection */
       acceptedDataProtection: boolean;
-      /**
-       * Account type of the customer which can be either `private` or `business`.
-       * @default private
-       */
-      accountType?: string;
       /** Field can be used to store an affiliate tracking code */
       affiliateCode?: string;
-      billingAddress: Omit<
-        components["schemas"]["CustomerAddress"],
-        "createdAt" | "id" | "customerId" | "firstName" | "lastName"
-      >; // TODO: [OpenAPI][register] - omit id, createdAt, customerId, firstName, lastName while creating address (or better to reverse and pick required fields)
+      billingAddress: components["schemas"]["CustomerAddress"];
       /** Birthday day */
       birthdayDay?: number;
       /** Birthday month */
@@ -7718,7 +7738,29 @@ export type operations = {
       storefrontUrl: string;
       /** (Academic) title of the customer */
       title?: string;
-    };
+    } & (
+      | {
+          /**
+           * Type of the customer account. Default value is 'private'.
+           * @default private
+           * @enum {string}
+           */
+          accountType?: "private";
+          company?: null;
+          vatIds?: null;
+        }
+      | {
+          /**
+           * Type of the customer account. Can be `private` or `business`.
+           * @enum {string}
+           */
+          accountType: "business";
+          /** Company of the customer. Only required when `accountType` is `business`. */
+          company: string;
+          /** VAT IDs of the customer's company. Only valid when `accountType` is `business`. */
+          vatIds: [string, ...string[]];
+        }
+    );
     response: components["schemas"]["Customer"];
     responseCode: 200;
   };

--- a/packages/api-client/api-types/storeApiSchema.json
+++ b/packages/api-client/api-types/storeApiSchema.json
@@ -15017,11 +15017,6 @@
               "schema": {
                 "required": ["salutationId", "firstName", "lastName"],
                 "properties": {
-                  "accountType": {
-                    "description": "Customer account type.",
-                    "type": "string",
-                    "enum": ["private", "business"]
-                  },
                   "salutationId": {
                     "description": "Id of the salutation for the customer account. Fetch options using `salutation` endpoint.",
                     "type": "string"
@@ -15041,13 +15036,6 @@
                   "company": {
                     "description": "Company of the customer. Only required when `accountType` is `business`.",
                     "type": "string"
-                  },
-                  "vatIds": {
-                    "description": "VAT IDs of the customer's company. Only valid when `accountType` is `business`.",
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
                   },
                   "birthdayDay": {
                     "description": "Birthday day",

--- a/packages/api-client/api-types/storeApiSchema.overrides.json
+++ b/packages/api-client/api-types/storeApiSchema.overrides.json
@@ -149,6 +149,47 @@
         }
       }
     ],
+    "Customer": [
+      {
+        "properties": {
+          "accountType": "_DELETE_",
+          "company": "_DELETE_",
+          "vatIds": "_DELETE_"
+        }
+      },
+      {
+        "oneOf": [
+          {
+            "required": ["accountType"],
+            "properties": {
+              "accountType": {
+                "type": "string",
+                "enum": ["private"]
+              }
+            }
+          },
+          {
+            "required": ["accountType", "vatIds", "company"],
+            "properties": {
+              "accountType": {
+                "type": "string",
+                "enum": ["business"]
+              },
+              "vatIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1
+              },
+              "company": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    ],
     "DeliveryInformation": [
       {
         "required": ["stock"]
@@ -447,6 +488,75 @@
         }
       ]
     },
+    "/account/change-profile": {
+      "post": [
+        {
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "accountType": "_DELETE_",
+                    "company": "_DELETE_",
+                    "vatIds": "_DELETE_"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "accountType": {
+                          "description": "Type of the customer account. Default value is 'private'.",
+                          "type": "string",
+                          "enum": ["private"],
+                          "default": "private"
+                        },
+                        "company": {
+                          "type": "null"
+                        },
+                        "vatIds": {
+                          "type": "null"
+                        }
+                      }
+                    },
+                    {
+                      "required": ["accountType", "company", "vatIds"],
+                      "properties": {
+                        "accountType": {
+                          "description": "Type of the customer account. Can be `private` or `business`.",
+                          "type": "string",
+                          "enum": ["business"]
+                        },
+                        "company": {
+                          "description": "Company of the customer. Only required when `accountType` is `business`.",
+                          "type": "string"
+                        },
+                        "vatIds": {
+                          "description": "VAT IDs of the customer's company. Only valid when `accountType` is `business`.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
     "/account/list-address": {
       "post": [
         {
@@ -474,6 +584,73 @@
                       { "$ref": "#/components/schemas/EntitySearchResult" }
                     ]
                   }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "/account/register": {
+      "post":[
+        {
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "accountType": "_DELETE_"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "accountType": {
+                          "description": "Type of the customer account. Default value is 'private'.",
+                          "type": "string",
+                          "enum": ["private"],
+                          "default": "private"
+                        },
+                        "company": {
+                          "type": "null"
+                        },
+                        "vatIds": {
+                          "type": "null"
+                        }
+                      }
+                    },
+                    {
+                      "required": ["accountType", "company", "vatIds"],
+                      "properties": {
+                        "accountType": {
+                          "description": "Type of the customer account. Can be `private` or `business`.",
+                          "type": "string",
+                          "enum": ["business"]
+                        },
+                        "company": {
+                          "description": "Company of the customer. Only required when `accountType` is `business`.",
+                          "type": "string"
+                        },
+                        "vatIds": {
+                          "description": "VAT IDs of the customer's company. Only valid when `accountType` is `business`.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1
+                        }
+                      }
+                    }
+                  ]
                 }
               }
             }

--- a/packages/api-client/api-types/storeApiTypes.d.ts
+++ b/packages/api-client/api-types/storeApiTypes.d.ts
@@ -1704,7 +1704,6 @@ export type Schemas = {
     readonly updatedAt?: string;
   };
   Customer: {
-    accountType?: string;
     active?: boolean;
     activeBillingAddress: components["schemas"]["CustomerAddress"];
     activeShippingAddress: components["schemas"]["CustomerAddress"];
@@ -1714,7 +1713,6 @@ export type Schemas = {
     apiAlias: "customer";
     birthday?: string;
     campaignCode?: string;
-    company?: string;
     /** Format: date-time */
     readonly createdAt?: string;
     createdById?: string;
@@ -1781,8 +1779,18 @@ export type Schemas = {
     /** Format: date-time */
     readonly updatedAt?: string;
     updatedById?: string;
-    vatIds?: string[];
-  };
+  } & (
+    | {
+        /** @enum {string} */
+        accountType: "private";
+      }
+    | {
+        /** @enum {string} */
+        accountType: "business";
+        company: string;
+        vatIds: [string, ...string[]];
+      }
+  );
   CustomerAddress: {
     additionalAddressLine1?: string;
     additionalAddressLine2?: string;
@@ -7541,19 +7549,12 @@ export type operations = {
     contentType?: "application/json";
     accept?: "application/json";
     body: {
-      /**
-       * Customer account type.
-       * @enum {string}
-       */
-      accountType?: "private" | "business";
       /** Birthday day */
       birthdayDay?: number;
       /** Birthday month */
       birthdayMonth?: number;
       /** Birthday year */
       birthdayYear?: number;
-      /** Company of the customer. Only required when `accountType` is `business`. */
-      company?: string;
       /** Customer first name. Value will be reused for shipping and billing address if not provided explicitly. */
       firstName: string;
       /** Customer last name. Value will be reused for shipping and billing address if not provided explicitly. */
@@ -7562,9 +7563,29 @@ export type operations = {
       salutationId: string;
       /** (Academic) title of the customer */
       title?: string;
-      /** VAT IDs of the customer's company. Only valid when `accountType` is `business`. */
-      vatIds?: string[];
-    };
+    } & (
+      | {
+          /**
+           * Type of the customer account. Default value is 'private'.
+           * @default private
+           * @enum {string}
+           */
+          accountType?: "private";
+          company?: null;
+          vatIds?: null;
+        }
+      | {
+          /**
+           * Type of the customer account. Can be `private` or `business`.
+           * @enum {string}
+           */
+          accountType: "business";
+          /** Company of the customer. Only required when `accountType` is `business`. */
+          company: string;
+          /** VAT IDs of the customer's company. Only valid when `accountType` is `business`. */
+          vatIds: [string, ...string[]];
+        }
+    );
     response: components["schemas"]["SuccessResponse"];
     responseCode: 200;
   };
@@ -7686,17 +7707,9 @@ export type operations = {
     body: {
       /** Flag indicating accepted data protection */
       acceptedDataProtection: boolean;
-      /**
-       * Account type of the customer which can be either `private` or `business`.
-       * @default private
-       */
-      accountType?: string;
       /** Field can be used to store an affiliate tracking code */
       affiliateCode?: string;
-      billingAddress: Omit<
-        components["schemas"]["CustomerAddress"],
-        "createdAt" | "id" | "customerId" | "firstName" | "lastName"
-      >; // TODO: [OpenAPI][register] - omit id, createdAt, customerId, firstName, lastName while creating address (or better to reverse and pick required fields)
+      billingAddress: components["schemas"]["CustomerAddress"];
       /** Birthday day */
       birthdayDay?: number;
       /** Birthday month */
@@ -7725,7 +7738,29 @@ export type operations = {
       storefrontUrl: string;
       /** (Academic) title of the customer */
       title?: string;
-    };
+    } & (
+      | {
+          /**
+           * Type of the customer account. Default value is 'private'.
+           * @default private
+           * @enum {string}
+           */
+          accountType?: "private";
+          company?: null;
+          vatIds?: null;
+        }
+      | {
+          /**
+           * Type of the customer account. Can be `private` or `business`.
+           * @enum {string}
+           */
+          accountType: "business";
+          /** Company of the customer. Only required when `accountType` is `business`. */
+          company: string;
+          /** VAT IDs of the customer's company. Only valid when `accountType` is `business`. */
+          vatIds: [string, ...string[]];
+        }
+    );
     response: components["schemas"]["Customer"];
     responseCode: 200;
   };

--- a/packages/api-client/api-types/storeApiTypes.overrides.ts
+++ b/packages/api-client/api-types/storeApiTypes.overrides.ts
@@ -60,55 +60,6 @@ export type Schemas = {
 };
 
 export type operations = {
-  "register post /account/register": {
-    contentType?: "application/json";
-    accept?: "application/json";
-    body: {
-      /** Flag indicating accepted data protection */
-      acceptedDataProtection: boolean;
-      /**
-       * Account type of the customer which can be either `private` or `business`.
-       * @default private
-       */
-      accountType?: string;
-      /** Field can be used to store an affiliate tracking code */
-      affiliateCode?: string;
-      billingAddress: Omit<
-        components["schemas"]["CustomerAddress"],
-        "createdAt" | "id" | "customerId" | "firstName" | "lastName"
-      >; // TODO: [OpenAPI][register] - omit id, createdAt, customerId, firstName, lastName while creating address (or better to reverse and pick required fields)
-      /** Birthday day */
-      birthdayDay?: number;
-      /** Birthday month */
-      birthdayMonth?: number;
-      /** Birthday year */
-      birthdayYear?: number;
-      /** Field can be used to store a campaign tracking code */
-      campaignCode?: string;
-      /** Email of the customer. Has to be unique, unless `guest` is `true` */
-      email: string;
-      /** Customer first name. Value will be reused for shipping and billing address if not provided explicitly. */
-      firstName: string;
-      /**
-       * If set, will create a guest customer. Guest customers can re-use an email address and don't need a password.
-       * @default false
-       */
-      guest?: boolean;
-      /** Customer last name. Value will be reused for shipping and billing address if not provided explicitly. */
-      lastName: string;
-      /** Password for the customer. Required, unless `guest` is `true` */
-      password: string;
-      /** Id of the salutation for the customer account. Fetch options using `salutation` endpoint. */
-      salutationId: string;
-      shippingAddress?: components["schemas"]["CustomerAddress"];
-      /** URL of the storefront for that registration. Used in confirmation emails. Has to be one of the configured domains of the sales channel. */
-      storefrontUrl: string;
-      /** (Academic) title of the customer */
-      title?: string;
-    };
-    response: components["schemas"]["Customer"];
-    responseCode: 200;
-  };
   "updateLineItem patch /checkout/cart/line-item": {
     contentType?: "application/json";
     accept?: "application/json";

--- a/packages/composables/src/useUser/useUser.test.ts
+++ b/packages/composables/src/useUser/useUser.test.ts
@@ -2,6 +2,7 @@ import { useUser } from "./useUser";
 import { describe, expect, it, vi } from "vitest";
 import { useSetup } from "../_test";
 import { ref } from "vue";
+import type { operations } from "@shopware/api-client/api-types";
 
 const refreshCartSpy = vi.fn();
 vi.mock("../useCart/useCart.ts", async () => {
@@ -26,7 +27,10 @@ vi.mock("../useSessionContext/useSessionContext.ts", async () => {
   };
 });
 
-const REGISTRATION_DATA = {
+const REGISTRATION_DATA: Omit<
+  operations["register post /account/register"]["body"],
+  "storefrontUrl"
+> = {
   acceptedDataProtection: true,
   accountType: "private",
   salutationId: "d5e543063dd642b48ef94b02d68e5785",
@@ -40,6 +44,10 @@ const REGISTRATION_DATA = {
     city: "sadasdas",
     countryId: "2de9ecc24e7b43d283302abba082b7ce",
     countryStateId: "",
+    customerId: "",
+    id: "",
+    firstName: "test",
+    lastName: "test",
   },
 };
 

--- a/packages/composables/src/useUser/useUser.ts
+++ b/packages/composables/src/useUser/useUser.ts
@@ -176,7 +176,7 @@ export function useUser(): UseUserReturn {
   ): Promise<Schemas["Customer"]> {
     const { data } = await apiClient.invoke("register post /account/register", {
       body: {
-        ...params,
+        ...(params as operations["register post /account/register"]["body"]),
         storefrontUrl: getStorefrontUrl(),
       },
     });

--- a/templates/vue-demo-store/api-types/storeApiTypes.d.ts
+++ b/templates/vue-demo-store/api-types/storeApiTypes.d.ts
@@ -1704,7 +1704,6 @@ export type Schemas = {
     readonly updatedAt?: string;
   };
   Customer: {
-    accountType?: string;
     active?: boolean;
     activeBillingAddress: components["schemas"]["CustomerAddress"];
     activeShippingAddress: components["schemas"]["CustomerAddress"];
@@ -1714,7 +1713,6 @@ export type Schemas = {
     apiAlias: "customer";
     birthday?: string;
     campaignCode?: string;
-    company?: string;
     /** Format: date-time */
     readonly createdAt?: string;
     createdById?: string;
@@ -1781,8 +1779,18 @@ export type Schemas = {
     /** Format: date-time */
     readonly updatedAt?: string;
     updatedById?: string;
-    vatIds?: string[];
-  };
+  } & (
+    | {
+        /** @enum {string} */
+        accountType: "private";
+      }
+    | {
+        /** @enum {string} */
+        accountType: "business";
+        company: string;
+        vatIds: [string, ...string[]];
+      }
+  );
   CustomerAddress: {
     additionalAddressLine1?: string;
     additionalAddressLine2?: string;
@@ -7547,8 +7555,6 @@ export type operations = {
       birthdayMonth?: number;
       /** Birthday year */
       birthdayYear?: number;
-      /** Company of the customer. Only required when `accountType` is `business`. */
-      company?: string;
       /** Customer first name. Value will be reused for shipping and billing address if not provided explicitly. */
       firstName: string;
       /** Customer last name. Value will be reused for shipping and billing address if not provided explicitly. */
@@ -7557,7 +7563,29 @@ export type operations = {
       salutationId: string;
       /** (Academic) title of the customer */
       title?: string;
-    };
+    } & (
+      | {
+          /**
+           * Type of the customer account. Default value is 'private'.
+           * @default private
+           * @enum {string}
+           */
+          accountType?: "private";
+          company?: null;
+          vatIds?: null;
+        }
+      | {
+          /**
+           * Type of the customer account. Can be `private` or `business`.
+           * @enum {string}
+           */
+          accountType: "business";
+          /** Company of the customer. Only required when `accountType` is `business`. */
+          company: string;
+          /** VAT IDs of the customer's company. Only valid when `accountType` is `business`. */
+          vatIds: [string, ...string[]];
+        }
+    );
     response: components["schemas"]["SuccessResponse"];
     responseCode: 200;
   };
@@ -7679,17 +7707,9 @@ export type operations = {
     body: {
       /** Flag indicating accepted data protection */
       acceptedDataProtection: boolean;
-      /**
-       * Account type of the customer which can be either `private` or `business`.
-       * @default private
-       */
-      accountType?: string;
       /** Field can be used to store an affiliate tracking code */
       affiliateCode?: string;
-      billingAddress: Omit<
-        components["schemas"]["CustomerAddress"],
-        "createdAt" | "id" | "customerId" | "firstName" | "lastName"
-      >; // TODO: [OpenAPI][register] - omit id, createdAt, customerId, firstName, lastName while creating address (or better to reverse and pick required fields)
+      billingAddress: components["schemas"]["CustomerAddress"];
       /** Birthday day */
       birthdayDay?: number;
       /** Birthday month */
@@ -7718,7 +7738,29 @@ export type operations = {
       storefrontUrl: string;
       /** (Academic) title of the customer */
       title?: string;
-    };
+    } & (
+      | {
+          /**
+           * Type of the customer account. Default value is 'private'.
+           * @default private
+           * @enum {string}
+           */
+          accountType?: "private";
+          company?: null;
+          vatIds?: null;
+        }
+      | {
+          /**
+           * Type of the customer account. Can be `private` or `business`.
+           * @enum {string}
+           */
+          accountType: "business";
+          /** Company of the customer. Only required when `accountType` is `business`. */
+          company: string;
+          /** VAT IDs of the customer's company. Only valid when `accountType` is `business`. */
+          vatIds: [string, ...string[]];
+        }
+    );
     response: components["schemas"]["Customer"];
     responseCode: 200;
   };


### PR DESCRIPTION
This change introduces the accountType property to specify whether a customer is a private individual or a business. Additionally, the vatIds property is added to store VAT IDs for business accounts.