### PR TITLE
fix(nuxt3-module): maintenance mode

### DIFF
--- a/.changeset/silent-cobras-sin.md
+++ b/.changeset/silent-cobras-sin.md
@@ -1,0 +1,5 @@
+---
+"@shopware-pwa/nuxt3-module": patch
+---
+
+Replace `createError` with `showError` function in the `onResponseError` hook to redirect the user to the Nuxt error page.

--- a/packages/nuxt3-module/plugin.ts
+++ b/packages/nuxt3-module/plugin.ts
@@ -3,7 +3,7 @@ import {
   useRuntimeConfig,
   useState,
   createShopwareContext,
-  createError,
+  showError,
 } from "#imports";
 import { ref } from "vue";
 import Cookies from "js-cookie";
@@ -82,7 +82,7 @@ export default defineNuxtPlugin((NuxtApp) => {
     // @ts-expect-error TODO: check maintenance mode and fix typongs here
     const error = isMaintenanceMode(response._data?.errors ?? []);
     if (error) {
-      throw createError({
+      throw showError({
         statusCode: 503,
         statusMessage: "MAINTENANCE_MODE",
       });


### PR DESCRIPTION
### Description

This pull request replaces `createError` function with `showError` to redirect the user to the Nuxt error page to display maintenance info.

![Screenshot 2024-12-06 at 10 21 31](https://github.com/user-attachments/assets/429fd938-2aea-4e5f-8cd7-c627141971fd)

More context about why we should use `showError` function can be found here https://github.com/nuxt/nuxt/issues/15432

 closes #1511 

### Type of change

<!-- Comment out the type of change your PR is making -->

<!-- Bug fix (non-breaking change that fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

<!-- Add the todo's that need to be done before merge -->
<!-- Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. -->

<!-- - [ ] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) -->
<!-- - [ ] Documentation added/updated -->
<!-- - [ ] Unit-Tests added/updated -->
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
