### PR TITLE
fix: min-height display behaviour

### DIFF
--- a/.changeset/smooth-llamas-lay.md
+++ b/.changeset/smooth-llamas-lay.md
@@ -1,0 +1,5 @@
+---
+"@shopware-pwa/composables-next": patch
+---
+
+fix: min-height display behaviour

--- a/packages/composables/src/cms/useCmsElementImage.test.ts
+++ b/packages/composables/src/cms/useCmsElementImage.test.ts
@@ -5,9 +5,12 @@ import { useCmsElementImage } from "./useCmsElementImage";
 describe("useCmsElementImage", () => {
   describe("computed", () => {
     describe("containerStyle", () => {
-      it("should return minHeight css property", () => {
+      it("should return minHeight css property when displayMode is cover", () => {
         const { containerStyle } = useCmsElementImage({
           config: {
+            displayMode: {
+              value: "cover",
+            },
             minHeight: {
               value: "100px",
             },
@@ -16,6 +19,22 @@ describe("useCmsElementImage", () => {
 
         expect(containerStyle.value).toEqual({ minHeight: "100px" });
       });
+
+      it("should not return minHeight css property when displayMode is not cover", () => {
+        const { containerStyle } = useCmsElementImage({
+          config: {
+            displayMode: {
+              value: "contain",
+            },
+            minHeight: {
+              value: "100px",
+            },
+          },
+        } as CmsElementImage);
+
+        expect(containerStyle.value).toEqual({});
+      });
+
       it("should return anchorAttrs", () => {
         const { anchorAttrs } = useCmsElementImage({
           config: {

--- a/packages/composables/src/cms/useCmsElementImage.ts
+++ b/packages/composables/src/cms/useCmsElementImage.ts
@@ -44,8 +44,16 @@ export function useCmsElementImage(
 ): UseCmsElementImage {
   const { getConfigValue } = useCmsElementConfig(element);
 
+  const displayMode = computed(
+    () => getConfigValue("displayMode") || "initial",
+  );
+
+  const minHeight = computed(() =>
+    displayMode.value === "cover" ? getConfigValue("minHeight") : undefined,
+  );
+
   const containerStyle: ComputedRef<CSSProperties> = computed(() => ({
-    minHeight: getConfigValue("minHeight"),
+    ...(minHeight.value !== undefined && { minHeight: minHeight.value }),
   }));
 
   const anchorAttrs = computed(() => ({
@@ -78,10 +86,6 @@ export function useCmsElementImage(
     srcset: getSrcSetForMedia(element.data?.media),
   }));
 
-  const displayMode = computed(
-    () => getConfigValue("displayMode") || "initial",
-  );
-
   const isVideoElement = computed(() => {
     return !!element.data?.media?.mimeType?.includes("video");
   });
@@ -91,12 +95,12 @@ export function useCmsElementImage(
   });
 
   return {
+    displayMode,
     containerStyle,
     anchorAttrs,
     imageAttrs,
     imageContainerAttrs,
     imageLink,
-    displayMode,
     isVideoElement,
     mimeType,
   };


### PR DESCRIPTION
### Description

closes shopware/shopware#6265 - fix the min-height display behaviour. Add the css property only if the images displayMode is set to cover.

### Type of change
Bug fix (non-breaking change that fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

Nothing? :)

<!-- - [X] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) -->
<!-- - [ ] Documentation added/updated -->
<!-- - [X] Unit-Tests added/updated -->
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
