### PR TITLE
chore: deprecate composables-next package for @shopware/composables

### DIFF
--- a/.changeset/smart-mails-arrive.md
+++ b/.changeset/smart-mails-arrive.md
@@ -1,0 +1,5 @@
+---
+"@shopware-pwa/composables-next": patch
+---
+
+Deprecating package `@shopware-pwa/composables-next` and publishing it under `@shopware/composables`

--- a/packages/composables/README.md
+++ b/packages/composables/README.md
@@ -5,6 +5,10 @@
 [![](https://img.shields.io/github/issues/shopware/frontends/composables?label=package%20issues&logo=github)](https://github.com/shopware/frontends/issues?q=is%3Aopen+is%3Aissue+label%3Acomposables)
 [![](https://img.shields.io/github/license/shopware/frontends?color=blue)](#)
 
+> [!WARNING]
+>
+> This package is deprecated. Please use [@shopware/composables](https://www.npmjs.com/package/@shopware/composables) instead.
+
 Set of Vue.js composition functions that can be used in any Vue.js project. They provide state management, UI logic and data fetching and are the base for all guides in our [building section](https://frontends.shopware.com/getting-started/page-elements/navigation.html).
 
 ## Features

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopware-pwa/composables-next",
   "version": "1.6.0",
-  "description": "Shopware Frontends composables for Vue",
+  "description": "[DEPRECATED] Use @shopware/composables instead! Shopware Frontends composables for Vue",
   "author": "Shopware",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description

<!-- Describe the changes you did and which issue you're closing -->

<!-- example: closes #007 -->

related #1406 

This PR marks package `@shopware-pwa/composables-next` as deprecated, further updates will be published under `@shopware/composables`