### PR TITLE
chore: deprecate packages

### DIFF
--- a/.changeset/brown-dingos-suffer.md
+++ b/.changeset/brown-dingos-suffer.md
@@ -1,0 +1,5 @@
+---
+"@shopware-pwa/cms-base": minor
+---
+
+Package `@shopware-pwa/cms-base` is deprecated. Use [@shopware/cms-base-layer](https://www.npmjs.com/package/@shopware/cms-base-layer) instead.

--- a/.changeset/chilled-seas-juggle.md
+++ b/.changeset/chilled-seas-juggle.md
@@ -1,0 +1,5 @@
+---
+"@shopware-pwa/nuxt3-module": minor
+---
+
+Package `@shopware-pwa/nuxt3-module` is deprecated. Use [@shopware/nuxt-module](https://www.npmjs.com/package/@shopware/nuxt-module) instead.

--- a/.changeset/rare-bulldogs-cross.md
+++ b/.changeset/rare-bulldogs-cross.md
@@ -1,0 +1,5 @@
+---
+"@shopware-pwa/helpers-next": minor
+---
+
+Package `@shopware-pwa/helpers-next` is deprecated. Use [@shopware/helpers](https://www.npmjs.com/package/@shopware/helpers) instead.

--- a/packages/cms-base/README.md
+++ b/packages/cms-base/README.md
@@ -5,6 +5,10 @@
 [![](https://img.shields.io/github/issues/shopware/frontends/cms-base?label=cms-base%20issues&logo=github)](https://github.com/shopware/frontends/issues?q=is%3Aopen+is%3Aissue+label%3Acms-base)
 [![](https://img.shields.io/github/license/shopware/frontends?color=blue)](#)
 
+> [!WARNING]
+>
+> This package is deprecated and will be removed in the future. Use [@shopware/cms-base-layer](https://www.npmjs.com/package/@shopware/cms-base-layer) instead.
+
 Nuxt [layer](https://nuxt.com/docs/getting-started/layers) that provides an implementation of all CMS components in Shopware [based on utility-classes](https://frontends.shopware.com/framework/styling.html) using atomic css syntax (UnoCss / Tailwind).
 
 It is useful for projects that want to use the CMS components but design their own layout.

--- a/packages/cms-base/package.json
+++ b/packages/cms-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopware-pwa/cms-base",
   "version": "1.2.2",
-  "description": "Vue CMS support for Shopware",
+  "description": "[DEPRECATED] Use @shopware/cms-base-layer instead. Vue CMS support for Shopware",
   "author": "Shopware",
   "repository": {
     "type": "git",

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -1,5 +1,9 @@
 # shopware/frontends - helpers
 
+> [!WARNING]
+>
+> This package is deprecated and will be removed in the future. Use [@shopware/helpers](https://www.npmjs.com/package/@shopware/helpers) instead.
+
 Welcome to `@shopware-pwa/helpers-next` package.
 
 For getting started documentation visit [https://frontends.shopware.com/](https://frontends.shopware.com/)

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopware-pwa/helpers-next",
   "version": "1.2.0",
-  "description": "Shopware helpers for accessing API data",
+  "description": "[DEPRECATED] Use @shopware/helpers instead. Shopware helpers for accessing API data",
   "author": "Shopware",
   "type": "module",
   "repository": {

--- a/packages/nuxt3-module/README.md
+++ b/packages/nuxt3-module/README.md
@@ -5,6 +5,10 @@
 [![](https://img.shields.io/github/issues/shopware/frontends/nuxt3-module?label=nuxt3-module%20issues&logo=github)](https://github.com/shopware/frontends/issues?q=is%3Aopen+is%3Aissue+label%3Anuxt3-module)
 [![](https://img.shields.io/github/license/shopware/frontends?color=blue)](#)
 
+> [!WARNING]
+>
+> This package is deprecated and will be removed in the future. Use [@shopware/nuxt-module](https://www.npmjs.com/package/@shopware/nuxt-module) instead.
+
 Nuxt [module](https://nuxt.com/docs/guide/going-further/modules) that allows you to set up a Nuxt 3 project with Shopware Frontends. It provides the composables and api-client packages.
 
 If you want to use these packages with a different Vue.js framework, see [the guide](https://frontends.shopware.com/getting-started/templates/custom-vue-project.html) for using Shopware Frontends in a custom project.

--- a/packages/nuxt3-module/package.json
+++ b/packages/nuxt3-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopware-pwa/nuxt3-module",
   "version": "1.1.2",
-  "description": "Nuxt 3 module for Shopware Frontends",
+  "description": "[DEPRECATED] Use @shopware/nuxt-module instead. Nuxt 3 module for Shopware Frontends",
   "author": "Shopware",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description
part of #1406 

deprecating packages:
- `@shopware-pwa/nuxt3-module` ->`@shopware/nuxt-module`
- `@shopware-pwa/cms-base` -> `@shopware/cms-base-layer`
- `@shopware-pwa/helpers-next` -> `@shopware/helpers`