### PR TITLE
fix(nuxt-module): skip reading private runtime config in csr

### DIFF
--- a/packages/nuxt-module/plugin.ts
+++ b/packages/nuxt-module/plugin.ts
@@ -32,7 +32,8 @@ export default defineNuxtPlugin((NuxtApp) => {
     runtimeConfig.public?.shopware?.shopwareEndpoint;
 
   const shopwareEndpointSSR =
-    runtimeConfig.shopware?.endpoint ?? shopwareEndpointCSR;
+    (NuxtApp.ssrContext && runtimeConfig.shopware?.endpoint) ||
+    shopwareEndpointCSR;
 
   const shopwareEndpoint = import.meta.server
     ? shopwareEndpointSSR
@@ -63,10 +64,9 @@ export default defineNuxtPlugin((NuxtApp) => {
     contextToken: shouldUseSessionContextInServerRender
       ? contextTokenFromCookie
       : "",
-    defaultHeaders: defu(
-      runtimeConfig.apiClientConfig?.headers,
+    defaultHeaders:
+      (NuxtApp.ssrContext && runtimeConfig.apiClientConfig?.headers) ||
       runtimeConfig.public?.apiClientConfig?.headers,
-    ),
   });
 
   apiClient.hook("onContextChanged", (newContextToken) => {


### PR DESCRIPTION
### Description

closes: #1454 

the nuxt-modules uses the same plugin plugin which is being ran in both client and server. 

there is no need in reading ssr runtime config as well as merging it with csr config as it's unaccessible from csr context. however I've left the csr config as a fallback in those cases because it doesn't seem sensitive and it's always used by default in not advanced setup.

### Type of change

<!-- Comment out the type of change your PR is making -->

Bug fix (non-breaking change that fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

- changeset



<!-- - [ ] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) -->
<!-- - [ ] Documentation added/updated -->
<!-- - [ ] Unit-Tests added/updated -->
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->

### Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/213cd5e6-4728-4416-aec8-c8f22f914473)

### Additional context

<!-- Add any other context about the pull request here. -->
