### PR TITLE
fix(vue-demo): add missing formatLink function

### DIFF
--- a/.changeset/famous-starfishes-enjoy.md
+++ b/.changeset/famous-starfishes-enjoy.md
@@ -1,0 +1,5 @@
+---
+"vue-demo-store": patch
+---
+
+Add missing formatLink for links in checkout and my account page

--- a/templates/vue-demo-store/components/account/AccountOrder.vue
+++ b/templates/vue-demo-store/components/account/AccountOrder.vue
@@ -11,6 +11,8 @@ const props = defineProps<{
 
 const { t } = useI18n();
 const { currency } = useSessionContext();
+const localePath = useLocalePath();
+const { formatLink } = useInternationalization(localePath);
 
 const orderDate = computed(() =>
   new Date(props.order.orderDate).toLocaleDateString(
@@ -36,7 +38,7 @@ const orderDate = computed(() =>
         />
       </div>
       <div class="hidden sm:block justify-self-end text-dark cursor-pointer">
-        <NuxtLink :to="`/account/order/details/${order.id}`">
+        <NuxtLink :to="formatLink(`/account/order/details/${order.id}`)">
           {{ t("account.view") }}
         </NuxtLink>
       </div>
@@ -45,7 +47,7 @@ const orderDate = computed(() =>
       <div
         class="block sm:hidden text-center text-dark cursor-pointer bg-secondary py-2"
       >
-        <NuxtLink :to="`/account/order/details/${order.id}`">
+        <NuxtLink :to="formatLink(`/account/order/details/${order.id}`)">
           {{ t("account.view") }}
         </NuxtLink>
       </div>

--- a/templates/vue-demo-store/pages/checkout/index.vue
+++ b/templates/vue-demo-store/pages/checkout/index.vue
@@ -226,7 +226,7 @@ const placeOrder = async () => {
 
   try {
     const order = await createOrder();
-    await push(`/checkout/success/${order.id}`);
+    await push(formatLink(`/checkout/success/${order.id}`));
     refreshCart();
   } catch (error) {
     if (error instanceof ApiClientError)
@@ -277,7 +277,7 @@ const invokeSubmit = async () => {
       const response = await register(state);
       if (!response.active) {
         pushInfo(t("checkout.messages.checkoutSignInSuccess"));
-        await push("/");
+        await push(formatLink("/"));
       }
     } catch (error) {
       if (error instanceof ApiClientError) {
@@ -290,7 +290,7 @@ async function invokeLogout() {
   try {
     await logout();
   } finally {
-    await push("/");
+    await push(formatLink("/"));
   }
 }
 


### PR DESCRIPTION
### Description

This pull request includes changes to the `vue-demo-store` project to add missing formatLink functionality for links in the checkout and my account pages.

Enhancements to link formatting:

* [`templates/vue-demo-store/components/account/AccountOrder.vue`](diffhunk://#diff-fa5775e0ab731d249361f7c1d64cd6f3ada97bcf61873bd971c6308d67b63bd1R14-R15): Introduced `formatLink` function and applied it to the order details links. [[1]](diffhunk://#diff-fa5775e0ab731d249361f7c1d64cd6f3ada97bcf61873bd971c6308d67b63bd1R14-R15) [[2]](diffhunk://#diff-fa5775e0ab731d249361f7c1d64cd6f3ada97bcf61873bd971c6308d67b63bd1L39-R41) [[3]](diffhunk://#diff-fa5775e0ab731d249361f7c1d64cd6f3ada97bcf61873bd971c6308d67b63bd1L48-R50)
* [`templates/vue-demo-store/pages/checkout/index.vue`](diffhunk://#diff-0bfd10dfff54f08afcd8826405c7a5172141e848d4577f7c308899e258661a1fL229-R229): Applied `formatLink` function to various navigation links, including the checkout success page and the root path. [[1]](diffhunk://#diff-0bfd10dfff54f08afcd8826405c7a5172141e848d4577f7c308899e258661a1fL229-R229) [[2]](diffhunk://#diff-0bfd10dfff54f08afcd8826405c7a5172141e848d4577f7c308899e258661a1fL280-R280) [[3]](diffhunk://#diff-0bfd10dfff54f08afcd8826405c7a5172141e848d4577f7c308899e258661a1fL293-R293)

 closes #1647 #1646

