### PR TITLE
feat: add CmsBlockHtml and CmsElementHtml

### DIFF
--- a/.changeset/fluffy-ghosts-strive.md
+++ b/.changeset/fluffy-ghosts-strive.md
@@ -2,4 +2,5 @@
 "@shopware/cms-base-layer": minor
 ---
 
-Add CmsBlockHtml to render html blocks
+Added CmsBlockHtml to render html blocks.
+Added CmsElementHtml to render html element.

--- a/.changeset/fluffy-ghosts-strive.md
+++ b/.changeset/fluffy-ghosts-strive.md
@@ -1,0 +1,5 @@
+---
+"@shopware/cms-base-layer": minor
+---
+
+Add CmsBlockHtml to render html blocks

--- a/packages/cms-base-layer/components/public/cms/element/CmsBlockHtml.md
+++ b/packages/cms-base-layer/components/public/cms/element/CmsBlockHtml.md
@@ -1,0 +1,1 @@
+Render a HTML section

--- a/packages/cms-base-layer/components/public/cms/element/CmsBlockHtml.vue
+++ b/packages/cms-base-layer/components/public/cms/element/CmsBlockHtml.vue
@@ -2,13 +2,23 @@
 import type { CmsBlockHtml } from "@shopware/composables";
 
 import { getCmsLayoutConfiguration } from "@shopware/helpers";
+import { h } from "vue";
 
 const props = defineProps<{
   content: CmsBlockHtml;
 }>();
 
 const { cssClasses, layoutStyles } = getCmsLayoutConfiguration(props.content);
+
+const HtmlComponent = () => {
+  return h("div", {
+    class: cssClasses,
+    style: layoutStyles,
+    innerHTML: props.content.slots[0].data.content || "",
+  });
+};
 </script>
+
 <template>
-   <div :class="cssClasses" v-html="props.content.slots[0].data.content || ''" :style="layoutStyles"  > </div>
+  <HtmlComponent />
 </template>

--- a/packages/cms-base-layer/components/public/cms/element/CmsBlockHtml.vue
+++ b/packages/cms-base-layer/components/public/cms/element/CmsBlockHtml.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import type { CmsBlockHtml } from "@shopware/composables";
+
+import { getCmsLayoutConfiguration } from "@shopware/helpers";
+
+const props = defineProps<{
+  content: CmsBlockHtml;
+}>();
+
+const { cssClasses, layoutStyles } = getCmsLayoutConfiguration(props.content);
+</script>
+<template>
+   <div :class="cssClasses" v-html="props.content.slots[0].data.content || ''" :style="layoutStyles"  > </div>
+</template>

--- a/packages/cms-base-layer/components/public/cms/element/CmsBlockHtml.vue
+++ b/packages/cms-base-layer/components/public/cms/element/CmsBlockHtml.vue
@@ -1,24 +1,17 @@
 <script setup lang="ts">
 import type { CmsBlockHtml } from "@shopware/composables";
 
-import { getCmsLayoutConfiguration } from "@shopware/helpers";
-import { h } from "vue";
-
-const props = defineProps<{
+defineProps<{
   content: CmsBlockHtml;
 }>();
-
-const { cssClasses, layoutStyles } = getCmsLayoutConfiguration(props.content);
-
-const HtmlComponent = () => {
-  return h("div", {
-    class: cssClasses,
-    style: layoutStyles,
-    innerHTML: props.content.slots[0].data.content || "",
-  });
-};
 </script>
 
 <template>
-  <HtmlComponent />
+  <div>
+    <CmsGenericElement
+      v-for="slot in content.slots"
+      :key="slot.versionId"
+      :content="slot"
+    />
+  </div>
 </template>

--- a/packages/cms-base-layer/components/public/cms/element/CmsElementHtml.vue
+++ b/packages/cms-base-layer/components/public/cms/element/CmsElementHtml.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import type { CmsElementHtml } from "@shopware/composables";
+
+import { getCmsLayoutConfiguration } from "@shopware/helpers";
+import { h } from "vue";
+
+const props = defineProps<{
+  content: CmsElementHtml;
+}>();
+
+const { cssClasses, layoutStyles } = getCmsLayoutConfiguration(props.content);
+
+const HtmlComponent = () => {
+  return h("div", {
+    class: cssClasses,
+    style: layoutStyles,
+    innerHTML: props.content.data.content || "",
+  });
+};
+</script>
+
+<template>
+  <HtmlComponent />
+</template>

--- a/packages/composables/src/types/cmsBlockTypes.ts
+++ b/packages/composables/src/types/cmsBlockTypes.ts
@@ -78,3 +78,4 @@ export type CmsBlockProductDescriptionReviews = BlockType<"content">;
 export type CmsBlockCrossSelling = BlockType<"content">;
 
 export type CmsBlockForm = BlockType<"content">;
+export type CmsBlockHtml = BlockType<"content">;

--- a/packages/composables/src/types/cmsElementTypes.ts
+++ b/packages/composables/src/types/cmsElementTypes.ts
@@ -46,15 +46,12 @@ export type CmsElementText = Schemas["CmsSlot"] & {
 };
 
 // HTML
-export type CmsBlockHtml = Schemas["CmsSlot"] & {
-  slots: {
-    data: {
-      content: string;
-      apiAlias: "cms_html";
-    };
-    id: string;
-    blockId: string;
-  }[];
+export type CmsElementHtml = Schemas["CmsSlot"] & {
+  type: "html";
+  data: {
+    content: string;
+    apiAlias: "cms_html";
+  };
 };
 
 // Image

--- a/packages/composables/src/types/cmsElementTypes.ts
+++ b/packages/composables/src/types/cmsElementTypes.ts
@@ -45,6 +45,18 @@ export type CmsElementText = Schemas["CmsSlot"] & {
   };
 };
 
+// HTML
+export type CmsBlockHtml = Schemas["CmsSlot"] & {
+  slots: {
+    data: {
+      content: string;
+      apiAlias: "cms_html";
+    };
+    id: string;
+    blockId: string;
+  }[];
+};
+
 // Image
 
 type ImageElementConfig = {


### PR DESCRIPTION
### Description

This pull request introduces a new component to render HTML blocks within the CMS base layer. The most important changes include the addition of the `CmsBlockHtml` component and its associated type definition.

New component addition:

* [`packages/cms-base-layer/components/public/cms/element/CmsBlockHtml.vue`](diffhunk://#diff-94ead15d1440828b87d91af295c9188a9abf4a47cec3980b5f10dd94a4f74382R1-R14): Implemented the `CmsBlockHtml` component to render a HTML section with appropriate styles and classes.

Type definition:

* [`packages/composables/src/types/cmsElementTypes.ts`](diffhunk://#diff-7bc8af787779a065a0f70856190939e3cde9f72c2bd6c01a2d5aacda8aa22957R48-R59): Added the `CmsBlockHtml` type definition to represent the structure of HTML blocks in the CMS.

 closes #1528 

### Type of change

<!-- Comment out the type of change your PR is making -->

<!-- Bug fix (non-breaking change that fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

<!-- Add the todo's that need to be done before merge -->
<!-- Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. -->

<!-- - [ ] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) -->
<!-- - [ ] Documentation added/updated -->
<!-- - [ ] Unit-Tests added/updated -->
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
