### PR TITLE
fix: undefined content type in headers multipart/form-data

### DIFF
--- a/.changeset/modern-cows-cross.md
+++ b/.changeset/modern-cows-cross.md
@@ -1,0 +1,5 @@
+---
+"@shopware/api-client": patch
+---
+
+fix: Undefined mergedHeaders["content-type"] when content-type is multipart/form-data

--- a/packages/api-client/src/createAPIClient.ts
+++ b/packages/api-client/src/createAPIClient.ts
@@ -175,15 +175,15 @@ export function createAPIClient<
       ...(currentParams.fetchOptions || {}),
     };
 
-    const mergedHeaders = defu(currentParams.headers, defaultHeaders);
+    let mergedHeaders = defu(currentParams.headers, defaultHeaders);
 
     if (
       mergedHeaders?.["Content-Type"]?.includes("multipart/form-data") &&
       typeof window !== "undefined"
     ) {
       // multipart/form-data must not be set manually when it's used by the browser
-      // biome-ignore lint/performance/noDelete: Delete is necessary to set the content type in the browser
-      delete mergedHeaders["Content-Type"];
+      const { "Content-Type": _, ...headersWithoutContentType } = mergedHeaders;
+      mergedHeaders = headersWithoutContentType;
     }
 
     const resp = await apiFetch.raw<

--- a/packages/api-client/src/createAPIClient.ts
+++ b/packages/api-client/src/createAPIClient.ts
@@ -182,7 +182,8 @@ export function createAPIClient<
       typeof window !== "undefined"
     ) {
       // multipart/form-data must not be set manually when it's used by the browser
-      mergedHeaders["Content-Type"] = undefined;
+      // biome-ignore lint/performance/noDelete: Delete is necessary to set the content type in the browser
+      delete mergedHeaders["Content-Type"];
     }
 
     const resp = await apiFetch.raw<

--- a/packages/api-client/src/createApiClient.test.ts
+++ b/packages/api-client/src/createApiClient.test.ts
@@ -342,11 +342,24 @@ describe("createAPIClient", () => {
       },
     });
 
-    expect(contentTypeSpy).toHaveBeenCalledWith(
-      expect.not.objectContaining({
-        "content-type": "multipart/form-data",
-      }),
-    );
+    expect(contentTypeSpy.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "accept": "application/json",
+            "accept-encoding": "gzip, deflate",
+            "accept-language": "*",
+            "connection": "keep-alive",
+            "content-length": "0",
+            "host": "localhost:3610",
+            "sec-fetch-mode": "cors",
+            "sw-access-key": "123",
+            "sw-context-token": "456",
+            "user-agent": "node",
+          },
+        ],
+      ]
+    `);
   });
 
   it("should trigger success callback", async () => {


### PR DESCRIPTION
### Description

After setting the content type in the api client headers like this:
```
headers: {
    "Content-Type": "multipart/form-data", // <-- set this one
},
```
the actual content type is set to undefined. This fix ensures that the content type is removed in the API client and correctly set by the browser.

### Type of change


### ToDo's


### Screenshots (if applicable)


### Additional context


