### PR TITLE
feat(docs): add tag for dynamically generated content

### DIFF
--- a/apps/docs/.vitepress/theme/typer/cms-base-plugin.ts
+++ b/apps/docs/.vitepress/theme/typer/cms-base-plugin.ts
@@ -28,7 +28,7 @@ export async function CmsBaseReference({
 
       let transformedCode = code;
 
-      if (pkg !== "packages" || packageName !== "cms-base") {
+      if (pkg !== "packages" || packageName !== "cms-base-layer") {
         return transformedCode;
       }
 
@@ -67,7 +67,8 @@ export async function CmsBaseReference({
 
       // place it before the changelog
       transformedCode = replacer(transformedCode, API, "", "tail");
-
+      // for LLM training
+      transformedCode += "\n<!-- dynamic-markdown -->\n";
       return transformedCode;
     },
   };

--- a/apps/docs/.vitepress/theme/typer/cms-base-plugin.ts
+++ b/apps/docs/.vitepress/theme/typer/cms-base-plugin.ts
@@ -68,7 +68,8 @@ export async function CmsBaseReference({
       // place it before the changelog
       transformedCode = replacer(transformedCode, API, "", "tail");
       // for LLM training
-      transformedCode += "\n<!-- dynamic-markdown -->\n";
+      transformedCode += '\n<div data-placeholder="dynamic-markdown"></div>\n';
+
       return transformedCode;
     },
   };

--- a/apps/docs/.vitepress/theme/typer/composables-builder.ts
+++ b/apps/docs/.vitepress/theme/typer/composables-builder.ts
@@ -157,7 +157,8 @@ ${codeBlock}
         transformedCode = transformedCode.replace("{{DEMO_BLOCK}}", "");
       }
       // for LLM training
-      transformedCode += "\n<!-- dynamic-markdown -->\n";
+      transformedCode += '\n<div data-placeholder="dynamic-markdown"></div>\n';
+
       return transformedCode;
     },
   };

--- a/apps/docs/.vitepress/theme/typer/composables-builder.ts
+++ b/apps/docs/.vitepress/theme/typer/composables-builder.ts
@@ -156,6 +156,8 @@ ${codeBlock}
       } catch (e) {
         transformedCode = transformedCode.replace("{{DEMO_BLOCK}}", "");
       }
+      // for LLM training
+      transformedCode += "\n<!-- dynamic-markdown -->\n";
       return transformedCode;
     },
   };

--- a/apps/docs/.vitepress/theme/typer/plugin.ts
+++ b/apps/docs/.vitepress/theme/typer/plugin.ts
@@ -135,7 +135,8 @@ export async function ReadmeBasedReference({
 
       // place it before the changelog
       transformedCode = replacer(transformedCode, API, "", "tail");
-
+      // for LLM training
+      transformedCode += "\n<!-- dynamic-markdown -->\n";
       return transformedCode;
     },
   };

--- a/apps/docs/.vitepress/theme/typer/plugin.ts
+++ b/apps/docs/.vitepress/theme/typer/plugin.ts
@@ -136,7 +136,8 @@ export async function ReadmeBasedReference({
       // place it before the changelog
       transformedCode = replacer(transformedCode, API, "", "tail");
       // for LLM training
-      transformedCode += "\n<!-- dynamic-markdown -->\n";
+      transformedCode += '\n<div data-placeholder="dynamic-markdown"></div>\n';
+
       return transformedCode;
     },
   };

--- a/apps/docs/.vitepress/theme/typer/readme-loader.ts
+++ b/apps/docs/.vitepress/theme/typer/readme-loader.ts
@@ -38,7 +38,8 @@ export async function ReadmeLoader(): Promise<Plugin> {
 
         transformedCode = transformedCode.replace(pattern, content);
       }
-
+      // for LLM training
+      transformedCode += "\n<!-- dynamic-markdown -->\n";
       return transformedCode;
     },
   };

--- a/apps/docs/.vitepress/theme/typer/readme-loader.ts
+++ b/apps/docs/.vitepress/theme/typer/readme-loader.ts
@@ -39,7 +39,7 @@ export async function ReadmeLoader(): Promise<Plugin> {
         transformedCode = transformedCode.replace(pattern, content);
       }
       // for LLM training
-      transformedCode += "\n<!-- dynamic-markdown -->\n";
+      transformedCode += '\n<div data-placeholder="dynamic-markdown"></div>\n';
       return transformedCode;
     },
   };


### PR DESCRIPTION
### Description

closes: #1610 


from now on, the pages containing dynamically generated content will have:

```html
<div data-placeholder="dynamic-markdown"></div>
```

the `<!-- dynamic-markdown -->` is stripped out during minification process