### PR TITLE
fix(api-gen): merge json overrides

### DIFF
--- a/.changeset/khaki-ideas-clean.md
+++ b/.changeset/khaki-ideas-clean.md
@@ -1,0 +1,5 @@
+---
+"@shopware/api-gen": patch
+---
+
+Merging JSON overrides allows to have multiple pverrides as objects and arrays - combining them into arrays.

--- a/examples/b2b-employee-management/api-types/storeApiTypes.d.ts
+++ b/examples/b2b-employee-management/api-types/storeApiTypes.d.ts
@@ -11118,7 +11118,6 @@ export type operations = {
   "readRoles get /role": {
     contentType?: "application/json";
     accept?: "application/json";
-    body?: components["schemas"]["Criteria"];
     response: {
       elements?: components["schemas"]["B2bComponentsRole"][];
     } & components["schemas"]["EntitySearchResult"];

--- a/examples/b2b-quote-management/api-types/storeApiTypes.d.ts
+++ b/examples/b2b-quote-management/api-types/storeApiTypes.d.ts
@@ -11118,7 +11118,6 @@ export type operations = {
   "readRoles get /role": {
     contentType?: "application/json";
     accept?: "application/json";
-    body?: components["schemas"]["Criteria"];
     response: {
       elements?: components["schemas"]["B2bComponentsRole"][];
     } & components["schemas"]["EntitySearchResult"];

--- a/packages/api-gen/src/jsonOverrideUtils.ts
+++ b/packages/api-gen/src/jsonOverrideUtils.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { createDefu } from "defu";
 import json5 from "json5";
 import { ofetch } from "ofetch";
 import c from "picocolors";
@@ -149,7 +150,7 @@ export async function loadJsonOverrides({
       patchesToResolve.map(resolveSinglePath),
     );
     // merge results from correctly settled promises
-    return extendedDefu(
+    return mergeJsonOverrides(
       {},
       ...results
         .filter((result) => result.status === "fulfilled")
@@ -165,6 +166,32 @@ export async function loadJsonOverrides({
     return {};
   }
 }
+
+export const mergeJsonOverrides = createDefu((obj, key, value) => {
+  if (Array.isArray(obj[key]) && Array.isArray(value)) {
+    // concat arrays but skip duplicates
+    // @ts-expect-error - we know that obj[key] is an array as we're inside this if statement
+    obj[key] = [...new Set([...obj[key], ...value])].sort();
+    return true;
+  }
+
+  // if one is array and the second not combine them in array
+  if (Array.isArray(obj[key]) && !Array.isArray(value) && value) {
+    // @ts-expect-error - we know that obj[key] is an array as we're inside this if statement
+    obj[key] = [...new Set([value, ...obj[key]])].sort();
+    return true;
+  }
+  if (obj[key] && !Array.isArray(obj[key]) && Array.isArray(value)) {
+    // @ts-expect-error - we know that obj[key] is an array as we're inside this if statement
+    obj[key] = [...new Set([...value, obj[key]])].sort();
+    return true;
+  }
+
+  // if there is no key in object, add it
+  if (obj[key] === undefined) {
+    obj[key] = extendedDefu(value, value);
+  }
+});
 
 export function displayPatchingSummary({
   todosToFix,

--- a/packages/api-gen/src/mergeJsonOverrides.test.ts
+++ b/packages/api-gen/src/mergeJsonOverrides.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { mergeJsonOverrides } from "./jsonOverrideUtils";
+import type { OverridesSchema } from "./patchJsonSchema";
+
+describe("mergeJsonOverrides", () => {
+  it("should merge both object types", () => {
+    const jsonObjects = [
+      // api-types/storeApiTypes1.overrides.json
+      {
+        components: {
+          Product: {
+            required: ["weight"],
+          },
+        },
+      },
+      // api-types/storeApiTypes2.overrides.json
+      {
+        components: {
+          Product: {
+            required: ["versionId"],
+          },
+        },
+      },
+    ] as unknown as OverridesSchema[];
+
+    const result = mergeJsonOverrides({}, ...jsonObjects);
+
+    expect(result).toEqual({
+      components: { Product: { required: ["versionId", "weight"] } },
+    });
+  });
+
+  it("should merge both array types", () => {
+    const jsonObjects = [
+      // api-types/storeApiTypes1.overrides.json
+      {
+        components: {
+          Product: [
+            {
+              required: ["weight"],
+            },
+          ],
+        },
+      },
+      // api-types/storeApiTypes2.overrides.json
+      {
+        components: {
+          Product: [
+            {
+              required: ["versionId"],
+            },
+          ],
+        },
+      },
+    ] as unknown as OverridesSchema[];
+
+    const result = mergeJsonOverrides({}, ...jsonObjects);
+
+    expect(result).toEqual({
+      components: {
+        Product: [{ required: ["versionId"] }, { required: ["weight"] }],
+      },
+    });
+  });
+
+  it("should merge object and array types", () => {
+    const jsonObjects = [
+      // api-types/storeApiTypes1.overrides.json
+      {
+        components: {
+          Product: {
+            required: ["weight"],
+          },
+        },
+      },
+      // api-types/storeApiTypes2.overrides.json
+      {
+        components: {
+          Product: [
+            {
+              required: ["versionId"],
+            },
+          ],
+        },
+      },
+    ] as unknown as OverridesSchema[];
+
+    const result = mergeJsonOverrides({}, ...jsonObjects);
+
+    expect(result).toEqual({
+      components: {
+        Product: [{ required: ["weight"] }, { required: ["versionId"] }],
+      },
+    });
+  });
+
+  it("should merge array and object type", () => {
+    const jsonObjects = [
+      // api-types/storeApiTypes1.overrides.json
+      {
+        components: {
+          Product: [
+            {
+              required: ["weight"],
+            },
+          ],
+        },
+      },
+      // api-types/storeApiTypes2.overrides.json
+      {
+        components: {
+          Product: {
+            required: ["versionId"],
+          },
+        },
+      },
+    ] as unknown as OverridesSchema[];
+
+    const result = mergeJsonOverrides({}, ...jsonObjects);
+
+    expect(result).toEqual({
+      components: {
+        Product: [{ required: ["weight"] }, { required: ["versionId"] }],
+      },
+    });
+  });
+});


### PR DESCRIPTION
### Description
closes #1746 

related to #1755 which still can be merged after slight adjustmets

Fixing problem with multiple overrides, when one of them is using object as types. In further work we should encourage only arrays
