### PR TITLE
docs: remove dynamic markdown placeholder from non-transformed code

### DIFF
--- a/apps/docs/.vitepress/theme/typer/readme-loader.ts
+++ b/apps/docs/.vitepress/theme/typer/readme-loader.ts
@@ -37,9 +37,10 @@ export async function ReadmeLoader(): Promise<Plugin> {
         )}\n\n`;
 
         transformedCode = transformedCode.replace(pattern, content);
+        // for LLM training
+        transformedCode += '\n<div data-placeholder="dynamic-markdown"></div>\n';
       }
-      // for LLM training
-      transformedCode += '\n<div data-placeholder="dynamic-markdown"></div>\n';
+      
       return transformedCode;
     },
   };


### PR DESCRIPTION
### Description

This PR removes markdown placeholder from non-transformed pages. Other plugins work fine, see https://github.com/shopware/frontends/pull/1808 .