### PR TITLE
fix: wrong price component

### DIFF
--- a/.changeset/large-garlics-say.md
+++ b/.changeset/large-garlics-say.md
@@ -1,0 +1,5 @@
+---
+"@shopware/cms-base-layer": patch
+---
+
+Fix wrong `SharedPrice` component in `SwListingProductPrice.vue` file

--- a/packages/cms-base-layer/components/SwListingProductPrice.vue
+++ b/packages/cms-base-layer/components/SwListingProductPrice.vue
@@ -79,7 +79,7 @@ const {
     <template v-if="regulationPrice">
       <div class="flex gap-2 justify-end text-gray-500 text-3.5 mb-2">
         {{ translations.listing.previously }}
-        <SharedPrice :value="regulationPrice" />
+        <SwSharedPrice :value="regulationPrice" />
       </div>
     </template>
     <template v-if="!regulationPrice">


### PR DESCRIPTION
### Description

This pull request addresses a bug fix in the `SwListingProductPrice.vue` file by correcting the usage of the wrong price component. The changes ensure that the correct component is used for displaying the price.

Bug fix:

* [`packages/cms-base-layer/components/SwListingProductPrice.vue`](diffhunk://#diff-338ccd6f8fa2a398ee28a6ef3d204276b322185419afcd22970e38d7ecc2fc60L82-R82): Replaced the incorrect `SharedPrice` component with the correct `SwSharedPrice` component for rendering the regulation price.

 closes #1856 

### Type of change

<!-- Comment out the type of change your PR is making -->

<!-- Bug fix (non-breaking change that fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

<!-- Add the todo's that need to be done before merge -->
<!-- Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. -->

<!-- - [ ] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) -->
<!-- - [ ] Documentation added/updated -->
<!-- - [ ] Unit-Tests added/updated -->
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
