### PR TITLE
fix: account missing attributes for icons

### DIFF
--- a/templates/vue-demo-store/layouts/account.vue
+++ b/templates/vue-demo-store/layouts/account.vue
@@ -60,7 +60,7 @@ provide("swNavigation-footer-navigation", footerData);
                       :to="formatLink(`/account`)"
                       class="flex items-center px-0 md:px-2 py-2 rounded-lg hover:text-primary hover:bg-secondary-100 is-active"
                     >
-                      <div i-carbon-dashboard text-xl inline-block />
+                      <div class="i-carbon-dashboard text-xl inline-block" />
                       <span class="ml-3">
                         {{ $t("account.menu.accountOverviewHeader") }}</span
                       >
@@ -71,7 +71,7 @@ provide("swNavigation-footer-navigation", footerData);
                       :to="formatLink(`/account/profile`)"
                       class="flex items-center px-0 md:px-2 py-2 rounded-lg hover:text-primary hover:bg-secondary-100 is-active"
                     >
-                      <div i-carbon-user text-xl inline-block />
+                      <div class="i-carbon-user text-xl inline-block" />
                       <span class="ml-3">{{ $t("account.yourProfile") }}</span>
                     </NuxtLink>
                   </li>
@@ -80,7 +80,7 @@ provide("swNavigation-footer-navigation", footerData);
                       :to="formatLink(`/account/address`)"
                       class="flex items-center px-0 md:px-2 py-2 rounded-lg hover:text-primary hover:bg-secondary-100"
                     >
-                      <div i-carbon-home text-xl inline-block />
+                      <div class="i-carbon-home text-xl inline-block" />
                       <span class="ml-3">{{ $t("account.yourAddress") }}</span>
                     </NuxtLink>
                   </li>
@@ -93,7 +93,7 @@ provide("swNavigation-footer-navigation", footerData);
                       :to="formatLink(`/account/order`)"
                       class="flex items-center px-0 md:px-2 py-2 rounded-lg hover:text-primary hover:bg-secondary-100"
                     >
-                      <div i-carbon-order-details text-xl inline-block />
+                      <div class="i-carbon-order-details text-xl inline-block" />
                       <span class="ml-3">{{
                         $t("account.orderHistoryHeader")
                       }}</span>
@@ -104,7 +104,7 @@ provide("swNavigation-footer-navigation", footerData);
                       class="flex items-center rounded-lg px-0 md:px-2 py-2 hover:text-primary hover:bg-secondary-100 w-full"
                       @click="invokeLogout()"
                     >
-                      <div i-carbon-logout text-xl inline-block />
+                      <div class="i-carbon-logout text-xl inline-block" />
                       <span class="ml-3 text-secondary-700">{{
                         $t("account.logout")
                       }}</span>


### PR DESCRIPTION
### Description

The class attributes are missing for account page navigation items in the left side

<!-- example: closes #007 -->

### Type of change

Adding class attribute for making the icons visible in front-end
Bug fix (non-breaking change that fixes an issue) 

<!-- - [ ] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) -->
<!-- - [ ] Documentation added/updated -->
<!-- - [ ] Unit-Tests added/updated -->
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->
