### PR TITLE
fix: remove category related code from CmsSectionSidebar

### DIFF
--- a/.changeset/open-adults-rush.md
+++ b/.changeset/open-adults-rush.md
@@ -1,0 +1,5 @@
+---
+"@shopware/cms-base-layer": patch
+---
+
+Fix CmsSectionSidebar.vue when used on a landing page by removing useCategory and related code

--- a/packages/cms-base-layer/components/public/cms/section/CmsSectionSidebar.vue
+++ b/packages/cms-base-layer/components/public/cms/section/CmsSectionSidebar.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import { useCmsSection } from "@shopware/composables";
 import type { CmsSectionSidebar } from "@shopware/composables";
-import { getTranslatedProperty } from "@shopware/helpers";
 import { computed } from "vue";
-import { useCategory } from "#imports";
 
 const props = defineProps<{
   content: CmsSectionSidebar;
@@ -13,16 +11,10 @@ const { getPositionContent } = useCmsSection(props.content);
 const sidebarBlocks = getPositionContent("sidebar");
 const mainBlocks = getPositionContent("main");
 const mobileBehavior = computed(() => props.content.mobileBehavior);
-const { category } = useCategory();
 </script>
 
 <template>
   <div class="cms-section-sidebar grid grid-cols-12 md:grid">
-    <div class="col-span-12 mx-8 md:mx-5 mt-8">
-      <h1 class="text-4xl font-extrabold tracking-tight text-gray-900">
-        {{ getTranslatedProperty(category, "name") }}
-      </h1>
-    </div>
     <div class="col-span-12 md:col-span-7 lg:col-span-9 order-1 md:order-2">
       <CmsGenericBlock
         v-for="cmsBlock in mainBlocks"


### PR DESCRIPTION
### Description
This pr fixes the CmsSectionSidebar.vue when it's used on a landing page by removing useCategory and related code (otherwise we receive an error in the useCategory composable because there is no category available on a landing page)

### Type of change
Bug fix (non-breaking change that fixes an issue)

### ToDo's

<!-- Add the todo's that need to be done before merge -->
- [x] Changeset file provided
