### PR TITLE
fix: Youtube player control display and usage of advanced privacy mod…

### DIFF
--- a/.changeset/little-forks-fix.md
+++ b/.changeset/little-forks-fix.md
@@ -1,0 +1,5 @@
+---
+"@shopware/cms-base-layer": patch
+---
+
+Fix youtube player control display and usage of advanced privacy mode setting.

--- a/packages/cms-base-layer/components/public/cms/element/CmsElementYoutubeVideo.vue
+++ b/packages/cms-base-layer/components/public/cms/element/CmsElementYoutubeVideo.vue
@@ -15,7 +15,7 @@ const config = computed(() => ({
   loop: getConfigValue("loop")
     ? `loop=1&playlist=${getConfigValue("videoID")}&`
     : "",
-  showControls: getConfigValue("showControls") ? "controls=1&" : "",
+  showControls: getConfigValue("showControls") ? "controls=1&" : "controls=0&",
   start:
     Number.parseInt(getConfigValue("start")) !== 0
       ? `start=${getConfigValue("start")}&`

--- a/packages/cms-base-layer/components/public/cms/element/CmsElementYoutubeVideo.vue
+++ b/packages/cms-base-layer/components/public/cms/element/CmsElementYoutubeVideo.vue
@@ -29,7 +29,7 @@ const config = computed(() => ({
 
 const YOUTUBE_URL = "https://www.youtube.com/embed/";
 const YOUTUBE_NOCOOKIE_URL = "https://www.youtube-nocookie.com/embed/";
-const videoDomain = getConfigValue("advancePrivacyMode")
+const videoDomain = getConfigValue("advancedPrivacyMode")
   ? YOUTUBE_NOCOOKIE_URL
   : YOUTUBE_URL;
 

--- a/packages/cms-base-layer/components/public/cms/element/CmsElementYoutubeVideo.vue
+++ b/packages/cms-base-layer/components/public/cms/element/CmsElementYoutubeVideo.vue
@@ -15,7 +15,7 @@ const config = computed(() => ({
   loop: getConfigValue("loop")
     ? `loop=1&playlist=${getConfigValue("videoID")}&`
     : "",
-  showControls: getConfigValue("showControls") ? "controls=0&" : "",
+  showControls: getConfigValue("showControls") ? "controls=1&" : "",
   start:
     Number.parseInt(getConfigValue("start")) !== 0
       ? `start=${getConfigValue("start")}&`
@@ -27,7 +27,13 @@ const config = computed(() => ({
   disableKeyboard: "disablekb=1",
 }));
 
-const videoUrl = `https://www.youtube-nocookie.com/embed/\
+const YOUTUBE_URL = "https://www.youtube.com/embed/";
+const YOUTUBE_NOCOOKIE_URL = "https://www.youtube-nocookie.com/embed/";
+const videoDomain = getConfigValue("advancePrivacyMode")
+  ? YOUTUBE_NOCOOKIE_URL
+  : YOUTUBE_URL;
+
+const videoUrl = `${videoDomain}\
             ${config.value.videoID}?\
             ${config.value.relatedVideos}\
             ${config.value.loop}\

--- a/packages/composables/src/types/cmsElementTypes.ts
+++ b/packages/composables/src/types/cmsElementTypes.ts
@@ -159,7 +159,7 @@ type YouTubeVideoElementConfig = {
   previewMedia: ElementConfig<string>;
   showControls: ElementConfig<boolean>;
   needsConfirmation: ElementConfig<boolean>;
-  advancePrivacyMode: ElementConfig<boolean>;
+  advancedPrivacyMode: ElementConfig<boolean>;
 };
 export type CmsElementYoutubeVideo = Schemas["CmsSlot"] & {
   type: "youtube-video";


### PR DESCRIPTION
### Description

This update refactors the YouTube embed URL selection logic to correctly toggle between the standard YouTube URL and the privacy-enhanced no-cookie URL based on the advancePrivacyMode configuration and also fixes the toggle of the control display.

### Type of change
Bug fix (non-breaking change that fixes an issue)


### ToDo's

<!-- - [x] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) -->
