### PR TITLE
fix(cms): cms text blocks responsiveness

### DIFF
--- a/.changeset/ten-numbers-tie.md
+++ b/.changeset/ten-numbers-tie.md
@@ -1,0 +1,5 @@
+---
+"@shopware/cms-base-layer": patch
+---
+
+Fix cms blocks TextTeaserSection and TextTwoColumn responsivity so the elements stack from md breakpoint and under.

--- a/packages/cms-base-layer/components/public/cms/block/CmsBlockTextTeaserSection.vue
+++ b/packages/cms-base-layer/components/public/cms/block/CmsBlockTextTeaserSection.vue
@@ -6,15 +6,15 @@ defineProps<{
 }>();
 </script>
 <template>
-  <div class="mx-auto grid sm:grid-cols-3 gap-4 py-6">
+  <div class="mx-auto grid md:grid-cols-3 gap-4 py-6">
     <CmsGenericElement
       v-for="(slot, i) in content.slots"
       :key="slot.id"
       :content="slot"
       class="cms-block-text-teaser-section"
       :class="{
-        'sm:col-span-1': i === 0,
-        'sm:col-span-2': i === 1,
+        'md:col-span-1': i === 0,
+        'md:col-span-2': i === 1,
       }"
     />
   </div>

--- a/packages/cms-base-layer/components/public/cms/block/CmsBlockTextTeaserSection.vue
+++ b/packages/cms-base-layer/components/public/cms/block/CmsBlockTextTeaserSection.vue
@@ -6,15 +6,15 @@ defineProps<{
 }>();
 </script>
 <template>
-  <div class="container mx-auto flex pt-6 pb-6">
+  <div class="mx-auto grid sm:grid-cols-3 gap-4 py-6">
     <CmsGenericElement
       v-for="(slot, i) in content.slots"
       :key="slot.id"
       :content="slot"
-      class="cms-block-text-teaser-section flex"
+      class="cms-block-text-teaser-section"
       :class="{
-        'flex-basis-1/3 flex-col ': i == 0,
-        'pl-4 flex-basis-2/3': i == 1,
+        'sm:col-span-1': i === 0,
+        'sm:col-span-2': i === 1,
       }"
     />
   </div>

--- a/packages/cms-base-layer/components/public/cms/block/CmsBlockTextTwoColumn.vue
+++ b/packages/cms-base-layer/components/public/cms/block/CmsBlockTextTwoColumn.vue
@@ -13,7 +13,7 @@ const rightContent = getSlotContent("right");
 </script>
 
 <template>
-  <article class="cms-block-text-two-column grid sm:grid-cols-2 gap-5 md:gap-20">
+  <article class="cms-block-text-two-column grid md:grid-cols-2 gap-5 md:gap-20">
     <CmsGenericElement
       :content="leftContent"
       class="cms-block-text-two-column__text"

--- a/packages/cms-base-layer/components/public/cms/block/CmsBlockTextTwoColumn.vue
+++ b/packages/cms-base-layer/components/public/cms/block/CmsBlockTextTwoColumn.vue
@@ -13,16 +13,14 @@ const rightContent = getSlotContent("right");
 </script>
 
 <template>
-  <article
-    class="cms-block-text-two-column flex justify-center gap-5 md:gap-20"
-  >
+  <article class="cms-block-text-two-column grid sm:grid-cols-2 gap-5 md:gap-20">
     <CmsGenericElement
       :content="leftContent"
-      class="w-1/2 cms-block-text-two-column__text"
+      class="cms-block-text-two-column__text"
     />
     <CmsGenericElement
       :content="rightContent"
-      class="w-1/2 cms-block-text-two-column__text"
+      class="cms-block-text-two-column__text"
     />
   </article>
 </template>


### PR DESCRIPTION
### Description

This update introduces responsiveness for the CMS blocks TextTeaserSection and TextTwoColumn. Previously, the columns would shrink on smaller screens but never stack. 
- The elements will now stack vertically from the `md` breakpoint, consistent with the behavior in the old storefront.
- Grid utilities are used for the layout change instead of flexbox to improve code readability.
- The `.container` class was removed in TextTeaserSection as it was constraining the block width.

### Type of change

<!-- Comment out the type of change your PR is making -->

Bug fix (non-breaking change that fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

<!-- Add the todo's that need to be done before merge -->
<!-- Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. -->

- [x] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation)
<!-- - [ ] Documentation added/updated -->
<!-- - [ ] Unit-Tests added/updated -->
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->

### Screenshots

Before:
![Screenshot 2025-06-10 at 11 13 09](https://github.com/user-attachments/assets/ce51bbe6-c383-46fa-82d0-ec575ef58f9d)

After:
![Screenshot 2025-06-10 at 11 13 27](https://github.com/user-attachments/assets/6fa7999d-7d64-44aa-9a74-ceb6966cf3e9)
