### PR TITLE
fix: price formatting

### DIFF
--- a/.changeset/fix-currency-display.md
+++ b/.changeset/fix-currency-display.md
@@ -1,0 +1,7 @@
+---
+"@shopware/composables": patch
+---
+
+ensure consistent currency symbol display across environments
+
+The `Intl.NumberFormat` was displaying currency symbols inconsistently between local and CI environments. Added `currencyDisplay: "symbol"` option to ensure consistent currency symbol display (e.g., "$" instead of "US$").

--- a/packages/composables/src/usePrice/usePrice.ts
+++ b/packages/composables/src/usePrice/usePrice.ts
@@ -76,6 +76,7 @@ function _usePrice(params?: {
     return new Intl.NumberFormat(currencyLocale.value, {
       style: "currency",
       currency: currencyCode.value,
+      currencyDisplay: "symbol",
     }).format(+value);
   }
 


### PR DESCRIPTION
Fixes failing tests


This pull request addresses an issue with inconsistent currency symbol display across environments by ensuring uniform formatting using the `Intl.NumberFormat` API. The changes include documentation updates and modifications to the `usePrice` composable.

### Fixes for currency symbol display:


* [`packages/composables/src/usePrice/usePrice.ts`](diffhunk://#diff-0b0d1374a7008c111fd14bd851c82fa9608b31f6d59432439624f9092a8a30a5R79): Updated the `Intl.NumberFormat` configuration in the `_usePrice` function to include the `currencyDisplay: "symbol"` option, ensuring consistent formatting of currency symbols.
