### PR TITLE
ci: publish on pkg-pr-new only when label is added

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -85,9 +85,6 @@ jobs:
           DO_NOT_TRACK: 1
         run: pnpm typecheck
 
-      - name: Publish package previews
-        run: npx pkg-pr-new publish './packages/api-client' './packages/api-gen' './packages/cms-base-layer' './packages/composables' './packages/helpers' './packages/nuxt-module'
-
   test:
     name: Test
     timeout-minutes: 15

--- a/.github/workflows/package-preview.yml
+++ b/.github/workflows/package-preview.yml
@@ -14,6 +14,9 @@ jobs:
     if: github.event.pull_request.labels.*.name == 'pkg-pr-publish'
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}

--- a/.github/workflows/package-preview.yml
+++ b/.github/workflows/package-preview.yml
@@ -1,0 +1,42 @@
+name: Package Preview Publishing
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+    paths:
+      - "packages/**"
+      - "pnpm-lock.yaml"
+      - "package.json"
+
+jobs:
+  publish-preview:
+    name: Publish Package Previews
+    if: github.event.pull_request.labels.*.name == 'pkg-pr-publish'
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - run: pnpm --version
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+          cache-dependency-path: "**/pnpm-lock.yaml"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Publish package previews
+        run: npx pkg-pr-new publish './packages/api-client' './packages/api-gen' './packages/cms-base-layer' './packages/composables' './packages/helpers' './packages/nuxt-module' 

--- a/.github/workflows/package-preview.yml
+++ b/.github/workflows/package-preview.yml
@@ -2,7 +2,9 @@ name: Package Preview Publishing
 
 on:
   pull_request:
-    types: [labeled, synchronize]
+    types: [labeled]
+  pull_request_target:
+    types: [synchronize]
     paths:
       - "packages/**"
       - "pnpm-lock.yaml"


### PR DESCRIPTION
save the time of every PR and publish PR preview packages only when label is added

This pull request reorganizes the workflows for package preview publishing by removing the related job from the `code-check.yml` workflow and creating a dedicated `package-preview.yml` workflow. The new workflow is triggered by specific pull request events and includes improved configuration for dependency management and environment setup.

Workflow reorganization:

* [`.github/workflows/code-check.yml`](diffhunk://#diff-d3ce92b8bc71a38c41f52db366723f0b4caed49f652682c086237b2657e726c1L88-L90): Removed the "Publish package previews" job from the code-check workflow to streamline its focus on type checking.
* [`.github/workflows/package-preview.yml`](diffhunk://#diff-994917dcfab7836943a62cd1196e9e7b1258f21499ab736fc4d4dcdf2102bfa7R1-R42): Added a new dedicated workflow for publishing package previews. This workflow is triggered by pull request events with specific labels and paths, ensuring better separation of concerns and improved maintainability.