### PR TITLE
feat(cms-base-layer): add default uno config support

### DIFF
--- a/.changeset/sad-trams-kneel.md
+++ b/.changeset/sad-trams-kneel.md
@@ -1,0 +1,52 @@
+---
+"@shopware/cms-base-layer": major
+---
+
+Updates the `@shopware/cms-base-layer` package with the following changes:
+- Adds support for the new `SwQuantitySelect` component
+- Updates the `SwProductAddToCart` component to use the new `SwQuantitySelect` component
+- Fixes the `Status` component to use the new state classes
+- Updates the `uno.config.ts` file to include default styling that can be used and extended in the end-project:
+
+
+## Nuxt UnoCSS Configuration Example
+```ts
+// nuxt.config.ts in your end-project
+{
+  unocss: {
+    nuxtLayers: true // enable Nuxt layers support in order to merge UnoCSS configurations
+  }
+}
+```
+
+## UnoCSS Configuration Example
+```ts
+// uno.config.ts in your end-project
+import { mergeConfigs } from '@unocss/core'
+import baseConfig from './.nuxt/uno.config.mjs'
+
+export default mergeConfigs(baseConfig, {
+  // will be merged with the base config - all optional
+  theme: {
+    colors: { 
+      'brand-primary': '#ff3e00',
+      'brand-secondary': '#ff6a00',
+    }
+  },
+  safelist: [
+    'states-success',
+  ],
+  preflights: [
+    {
+      getCSS: () => `
+        body {
+            font-family: 'Inter', sans-serif;
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased; 
+        }
+        `,
+    },
+  ],
+})
+```
+

--- a/packages/cms-base-layer/README.md
+++ b/packages/cms-base-layer/README.md
@@ -87,9 +87,52 @@ Since all CMS components are registered in your Nuxt application, you can now st
 
 See a [short guide](https://frontends.shopware.com/getting-started/cms/content-pages.html#use-the-cms-base-package) how to use `cms-base` package in your project based on Nuxt v3.
 
+## Default styling
+
+The components are styled using [Tailwind CSS](https://tailwindcss.com/) utility classes, so you can use them in your project without any additional configuration if your project uses Tailwind CSS. 
+
+This layer provides a default Tailwind CSS configuration (see [uno.config.ts](./uno.config.ts) for details), which is used to style the components. If you want to customize the styling, you can do so by creating your own Tailwind CSS configuration file and extending the default one:
+
+```ts [nuxt.config.ts]
+// nuxt.config.ts
+export default defineNuxtConfig({
+  // ...
+  unocss: {
+    nuxtLayers: true, // enable Nuxt layers for UnoCSS
+  },
+})
+```
+
+```ts [uno.config.ts]
+// uno.config.ts
+import config from './.nuxt/uno.config.mjs'
+
+export default config
+```
+
+Thanks to this, you can **use the default configuration** provided by this layer, or **extend/overwrite** it with your own customizations in your end-project:
+
+```ts [uno.config.ts]
+// uno.config.ts
+import { mergeConfigs } from '@unocss/core'
+import config from './.nuxt/uno.config.mjs'
+
+export default mergeConfigs([config, {
+  theme: {
+    colors: {
+      primary: '#ff3e00',
+      secondary: '#1c1c1c',
+    },
+  },
+}])
+
+```
+
+See the [UnoCSS reference](https://unocss.dev/integrations/nuxt#configuration) for more information on how to configure UnoCSS in Nuxt when work with layers.
+
 ## 📘 Available components
 
-The list of available blocks and elements is [here](https://frontends.shopware.com/packages/cms-base.html#available-components).
+The list of available blocks and elements is [here](https://frontends.shopware.com/packages/cms-base-layer.html#available-components).
 
 ## 🔄 Overwriting components
 

--- a/packages/cms-base-layer/app/components/SwButton.vue
+++ b/packages/cms-base-layer/app/components/SwButton.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+export interface SwButtonProps {
+  variant?: "primary" | "secondary" | "success" | "warning" | "outline";
+  size?: "small" | "medium" | "large";
+  disabled?: boolean;
+  loading?: boolean;
+  type?: "button" | "submit" | "reset";
+  block?: boolean;
+}
+
+const props = withDefaults(defineProps<SwButtonProps>(), {
+  variant: "primary",
+  size: "medium",
+  disabled: false,
+  loading: false,
+  type: "button",
+  block: false,
+});
+
+const emit = defineEmits<{
+  click: [event: MouseEvent];
+}>();
+
+const buttonClasses = computed(() => {
+  const classes = [
+    "inline-flex justify-center items-center gap-2 rounded font-bold transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2",
+  ];
+
+  const sizeClasses = {
+    small: "px-3 py-2 text-sm",
+    medium: "px-4 py-3 text-base",
+    large: "px-6 py-4 text-lg",
+  };
+  classes.push(sizeClasses[props.size]);
+
+  const variantClasses = {
+    primary:
+      "bg-brand-primary hover:bg-brand-primary-hover text-white focus:ring-brand-primary",
+    secondary:
+      "bg-brand-secondary hover:bg-brand-secondary-hover text-white focus:ring-brand-secondary",
+    success: "bg-success hover:bg-success-600 text-white focus:ring-success",
+    warning: "bg-warning hover:bg-warning-600 text-white focus:ring-warning",
+    outline:
+      "border-2 border-brand-primary text-brand-primary hover:bg-brand-primary hover:text-white focus:ring-brand-primary",
+  };
+
+  if (props.disabled || props.loading) {
+    classes.push(
+      "bg-surface-surface text-surface-on-surface cursor-not-allowed opacity-50",
+    );
+  } else {
+    classes.push(variantClasses[props.variant]);
+  }
+
+  if (props.block) {
+    classes.push("w-full");
+  }
+
+  return classes.join(" ");
+});
+
+const handleClick = (event: MouseEvent) => {
+  if (!props.disabled && !props.loading) {
+    emit("click", event);
+  }
+};
+</script>
+
+<template>
+  <button
+    :type="type"
+    :class="buttonClasses"
+    :disabled="disabled || loading"
+    @click="handleClick"
+  >
+    <div v-if="loading" class="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin"></div>
+    
+    <span :class="{ 'opacity-0': loading }">
+      <slot />
+    </span>
+  </button>
+</template>

--- a/packages/cms-base-layer/app/components/SwProductAddToCart.vue
+++ b/packages/cms-base-layer/app/components/SwProductAddToCart.vue
@@ -2,7 +2,7 @@
 import { useCmsTranslations } from "@shopware/composables";
 import { getCmsTranslate } from "@shopware/helpers";
 import { defu } from "defu";
-import { toRefs } from "vue";
+import { computed, toRefs } from "vue";
 import {
   useAddToCart,
   useCartErrorParamsResolver,
@@ -23,6 +23,7 @@ type Translations = {
     addedToCart: string;
     qty: string;
     addToCart: string;
+    productNumber: string;
   };
   errors: {
     [key: string]: string;
@@ -34,6 +35,7 @@ let translations: Translations = {
     addedToCart: "has been added to cart.",
     qty: "Qty",
     addToCart: "Add to cart",
+    productNumber: "Product number",
   },
   errors: {
     "product-stock-reached":
@@ -45,6 +47,12 @@ translations = defu(useCmsTranslations(), translations) as Translations;
 
 const { product } = toRefs(props);
 const { addToCart, quantity } = useAddToCart(product);
+
+const availableStock = computed(() => product.value?.availableStock ?? 0);
+const minPurchase = computed(() => product.value?.minPurchase ?? 0);
+const deliveryTime = computed(() => product.value?.deliveryTime);
+const restockTime = computed(() => product.value?.restockTime);
+const productNumber = computed(() => product.value?.productNumber ?? "");
 
 const addToCartProxy = async () => {
   await addToCart();
@@ -63,32 +71,19 @@ const addToCartProxy = async () => {
 </script>
 
 <template>
-  <div class="flex flex-row mt-10">
-    <div class="basis-1/4 relative -top-6">
-      <label for="qty" class="text-sm">{{ translations.product.qty }}</label>
-      <input
-        id="qty"
-        v-model="quantity"
-        type="number"
-        :min="product.minPurchase || 1"
-        :max="product.calculatedMaxPurchase"
-        :step="product.purchaseSteps || 1"
-        class="border rounded-md py-2 px-4 border-solid border-1 border-cyan-600 w-full mt-4"
-        data-testid="product-quantity"
-      />
-    </div>
-    <div class="basis-3/4 ml-4">
-      <button
-        :disabled="!product.available"
-        class="py-2 px-6 w-full mt-4 bg-gradient-to-r from-cyan-500 to-blue-500 transition ease-in-out hover:bg-gradient-to-l duration-300 cursor-pointer border border-transparent rounded-md flex items-center justify-center text-base font-medium text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-        :class="{
-          'opacity-50 cursor-not-allowed': !product.available,
-        }"
-        data-testid="add-to-cart-button"
-        @click="addToCartProxy"
-      >
-        🛍 {{ translations.product.addToCart }}
-      </button>
+  <div class="w-full inline-flex flex-col justify-start items-start gap-8">
+    <SwQuantitySelect v-model="quantity" :min="product.minPurchase" :max="product.maxPurchase"
+      :steps="product.purchaseSteps" />
+    <SwStockInfo :availableStock="availableStock" :minPurchase="minPurchase" :deliveryTime="deliveryTime"
+      :restockTime="restockTime" />
+    <div class="self-stretch flex flex-col justify-start items-start gap-1">
+      <SwButton variant="primary" size="medium" :disabled="!product?.available" block data-testid="add-to-cart-button"
+        @click="addToCartProxy">
+        {{ translations.product.addToCart }}
+      </SwButton>
+      <div class="self-stretch justify-start text-surface-on-surface text-xs font-normal font-['Inter'] leading-none">
+        {{ translations.product.productNumber }}: {{ productNumber }}
+      </div>
     </div>
   </div>
 </template>

--- a/packages/cms-base-layer/app/components/SwQuantitySelect.vue
+++ b/packages/cms-base-layer/app/components/SwQuantitySelect.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+const quantity = defineModel<number>({
+  required: true,
+});
+
+const {
+  size = "large",
+  steps,
+  max,
+  min,
+} = defineProps<{
+  size?: "small" | "large";
+  steps?: number;
+  min?: number;
+  max?: number;
+}>();
+
+function increaseQty() {
+  quantity.value++;
+}
+
+function decreaseQty() {
+  if (quantity.value > 1) {
+    quantity.value--;
+  }
+}
+
+const sizeClasses = {
+  small: "w-8 h-8",
+  large: "w-10 h-10",
+};
+</script>
+<template>
+  <div class="rounded outline outline-1 outline-offset-[-1px] outline-outline-outline inline-flex">
+    <button :class="sizeClasses[size]"
+      class="bg-surface-surface border-0 border-r-1 cursor-pointer hover:bg-brand-tertiary-hover font-semibold"
+      @click="decreaseQty">
+      -
+    </button>
+    <div class="bg-white border-l border-r border-outline-outline inline-flex flex-col justify-center items-center">
+      <input v-model="quantity" type="number" :min="min" :max="max" :step="steps" data-testid="product-quantity"
+        :class="sizeClasses[size]"
+        class="self-stretch text-center justify-start text-surface-on-surface text-xs font-bold leading-[18px] appearance-none [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" />
+    </div>
+    <button :class="sizeClasses[size]"
+      class="w-10 bg-surface-surface border-0 border-l-1 cursor-pointer hover:bg-brand-tertiary-hover font-semibold"
+      @click="increaseQty">
+      +
+    </button>
+  </div>
+</template>

--- a/packages/cms-base-layer/app/components/SwStockInfo.vue
+++ b/packages/cms-base-layer/app/components/SwStockInfo.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { defu } from "defu";
+
+import { useCmsTranslations } from "#imports";
+import type { Schemas } from "#shopware";
+
+defineProps<{
+  availableStock: number;
+  minPurchase: number;
+  deliveryTime?: Schemas["DeliveryTime"];
+  restockTime?: number;
+}>();
+
+type Translations = {
+  product: {
+    deliveryTime: string;
+    days: string;
+    noAvailable: string;
+  };
+};
+
+let translations: Translations = {
+  product: {
+    deliveryTime: "Available, delivery time",
+    days: "days",
+    noAvailable: "No longer available",
+  },
+};
+
+translations = defu(useCmsTranslations(), translations) as Translations;
+</script>
+<template>
+  <div class="w-[588px] inline-flex justify-start items-center gap-2">
+    <div class="w-2 h-2 bg-states-success rounded-full" v-if="availableStock > 0"></div>
+    <div class="w-2 h-2 bg-states-error rounded-full" v-else></div>
+    <span v-if="availableStock >= minPurchase && deliveryTime">{{ translations.product.deliveryTime }} {{
+      deliveryTime?.name }}
+    </span>
+    <span v-else-if="availableStock < minPurchase && deliveryTime && restockTime">
+      {{ translations.product.deliveryTime }} {{ restockTime }}
+      {{ translations.product.days }} {{ deliveryTime?.name }}</span>
+    <span v-else>{{ translations.product.noAvailable }}</span>
+  </div>
+</template>

--- a/packages/cms-base-layer/app/components/SwStockInfo.vue
+++ b/packages/cms-base-layer/app/components/SwStockInfo.vue
@@ -30,7 +30,7 @@ let translations: Translations = {
 translations = defu(useCmsTranslations(), translations) as Translations;
 </script>
 <template>
-  <div class="w-[588px] inline-flex justify-start items-center gap-2">
+  <div class="inline-flex justify-start items-center gap-2">
     <div class="w-2 h-2 bg-states-success rounded-full" v-if="availableStock > 0"></div>
     <div class="w-2 h-2 bg-states-error rounded-full" v-else></div>
     <span v-if="availableStock >= minPurchase && deliveryTime">{{ translations.product.deliveryTime }} {{

--- a/packages/cms-base-layer/app/components/public/cms/block/CmsBlockGalleryBuybox.vue
+++ b/packages/cms-base-layer/app/components/public/cms/block/CmsBlockGalleryBuybox.vue
@@ -12,13 +12,13 @@ const leftContent = getSlotContent("left");
 </script>
 
 <template>
-  <div class="w-full flex flex-col md:flex-row justify-start items-stretch gap-4 md:gap-10 md:px-0">
+  <div class="w-full flex flex-col lg:flex-row justify-center items-stretch gap-4 lg:gap-10 lg:px-0">
     <!-- Gallery Section -->
-    <div class="w-full md:w-[708px] flex-1 md:flex-initial md:flex-shrink-0">
+    <div class="w-full lg:w-3/5">
       <CmsGenericElement :content="leftContent" />
     </div>
     <!-- Buybox Section -->
-    <div class="w-full md:w-[572px] flex-1 md:flex-initial md:flex-shrink-0">
+    <div class="w-full lg:w-2/5">
       <CmsGenericElement :content="rightContent" />
     </div>
   </div>

--- a/packages/cms-base-layer/app/components/public/cms/block/CmsBlockGalleryBuybox.vue
+++ b/packages/cms-base-layer/app/components/public/cms/block/CmsBlockGalleryBuybox.vue
@@ -12,7 +12,7 @@ const leftContent = getSlotContent("left");
 </script>
 
 <template>
-  <div class="w-full flex flex-col lg:flex-row justify-center items-stretch gap-4 lg:gap-10 lg:px-0">
+  <div class="w-full flex flex-col lg:flex-row justify-center items-stretch gap-4 lg:gap-10 lg:px-0 overflow-hidden">
     <!-- Gallery Section -->
     <div class="w-full lg:w-3/5">
       <CmsGenericElement :content="leftContent" />

--- a/packages/cms-base-layer/app/components/public/cms/block/CmsBlockGalleryBuybox.vue
+++ b/packages/cms-base-layer/app/components/public/cms/block/CmsBlockGalleryBuybox.vue
@@ -12,13 +12,13 @@ const leftContent = getSlotContent("left");
 </script>
 
 <template>
-  <div
-    class="lg:container mx-auto flex flex-col lg:flex-row gap-10 justify-center"
-  >
-    <div class="overflow-hidden basis-4/6">
+  <div class="w-full flex flex-col md:flex-row justify-start items-stretch gap-4 md:gap-10 md:px-0">
+    <!-- Gallery Section -->
+    <div class="w-full md:w-[708px] flex-1 md:flex-initial md:flex-shrink-0">
       <CmsGenericElement :content="leftContent" />
     </div>
-    <div class="basis-2/6">
+    <!-- Buybox Section -->
+    <div class="w-full md:w-[572px] flex-1 md:flex-initial md:flex-shrink-0">
       <CmsGenericElement :content="rightContent" />
     </div>
   </div>

--- a/packages/cms-base-layer/app/components/public/cms/block/CmsBlockProductHeading.vue
+++ b/packages/cms-base-layer/app/components/public/cms/block/CmsBlockProductHeading.vue
@@ -13,7 +13,7 @@ const rightContent = getSlotContent("right");
 </script>
 
 <template>
-  <div class="cms-block-product-heading flex justify-between">
+  <div class="cms-block-product-heading flex justify-between pt-4">
     <CmsGenericElement :content="leftContent" />
     <CmsGenericElement :content="rightContent" />
   </div>

--- a/packages/cms-base-layer/app/components/public/cms/element/CmsElementBuyBox.vue
+++ b/packages/cms-base-layer/app/components/public/cms/element/CmsElementBuyBox.vue
@@ -68,12 +68,12 @@ const productName = computed(() => product.value?.translated?.name || "");
 </script>
 <template>
     <div v-if="product" :class="{
-        'h-full w-full flex flex-col md:w-[36rem]': true,
+        'h-full w-full flex flex-col': true,
         'justify-start': alignment === 'flex-start',
         'justify-end': alignment === 'flex-end',
         'justify-center': alignment === 'center',
     }">
-        <div class="w-full inline-flex flex-col justify-start items-start gap-8 mt-4">
+        <div class="self-stretch inline-flex flex-col justify-start items-start gap-8 mt-4 min-w-0">
             <div
                 class="md:hidden self-stretch justify-start text-surface-on-surface text-4xl font-normal font-['Noto_Serif'] leading-[60px]">
                 {{ productName }}</div>

--- a/packages/cms-base-layer/app/components/public/cms/element/CmsElementBuyBox.vue
+++ b/packages/cms-base-layer/app/components/public/cms/element/CmsElementBuyBox.vue
@@ -27,10 +27,6 @@ type Translations = {
     content: string;
     pricesIncl: string;
     pricesExcl: string;
-    deliveryTime: string;
-    days: string;
-    noAvailable: string;
-    productNumber: string;
   };
 };
 
@@ -48,10 +44,6 @@ let translations: Translations = {
     content: "Content",
     pricesIncl: "Prices incl. VAT plus shipping costs",
     pricesExcl: "Prices excl. VAT plus shipping costs",
-    deliveryTime: "Available, delivery time",
-    days: "days",
-    noAvailable: "No longer available",
-    productNumber: "Product number",
   },
 };
 
@@ -59,132 +51,95 @@ translations = defu(useCmsTranslations(), translations) as Translations;
 
 const { getConfigValue } = useCmsElementConfig(props.content);
 const alignment = computed(() => getConfigValue("alignment"));
-
 const { taxState, currency } = useSessionContext();
-
 const { product, changeVariant } = useProduct(
   props.content.data.product,
   props.content.data.configuratorSettings || [],
 );
-
 const { unitPrice, price, tierPrices, isListPrice } = useProductPrice(product);
 const regulationPrice = computed(() => price.value?.regulationPrice?.price);
 const { getFormattedPrice } = usePrice();
-
 const referencePrice = computed(
   () => product.value?.calculatedPrice?.referencePrice,
 );
-const productNumber = computed(() => product.value?.productNumber);
 const purchaseUnit = computed(() => product.value?.purchaseUnit);
 const unitName = computed(() => product.value?.unit?.name);
-const availableStock = computed(() => product.value?.availableStock ?? 0);
-const minPurchase = computed(() => product.value?.minPurchase ?? 0);
-const deliveryTime = computed(() => product.value?.deliveryTime);
-const restockTime = computed(() => product.value?.restockTime);
+const productName = computed(() => product.value?.translated?.name || "");
 </script>
 <template>
-  <div
-    v-if="product"
-    :class="{
-      'h-full flex flex-col': true,
-      'justify-start': alignment === 'flex-start',
-      'justify-end': alignment === 'flex-end',
-      'justify-center': alignment === 'center',
-    }"
-  >
-    <div>
-      <div v-if="tierPrices.length <= 1">
-        <SwSharedPrice
-          v-if="isListPrice"
-          class="text-1xl text-secondary-900 basis-2/6 justify-start line-through"
-          :value="price?.listPrice?.price"
-        />
-        <SwSharedPrice
-          v-if="unitPrice"
-          class="text-3xl text-secondary-900 basis-2/6 justify-start"
-          :class="{
-            'text-red': isListPrice,
-          }"
-          :value="unitPrice"
-        />
-        <div v-if="regulationPrice" class="text-xs flex text-secondary-500">
-          {{ translations.product.previously }}
-          <SwSharedPrice class="ml-1" :value="regulationPrice" />
-        </div>
-      </div>
-      <div v-else>
-        <table class="border-collapse table-auto w-full text-sm mb-8">
-          <thead>
-            <tr>
-              <th
-                class="border-b dark:border-secondary-600 font-medium p-4 pl-8 pt-0 pb-3 text-secondary-600 dark:text-secondary-200 text-left"
-              >
-                {{ translations.product.amount }}
-              </th>
+    <div v-if="product" :class="{
+        'h-full w-full flex flex-col md:w-[36rem]': true,
+        'justify-start': alignment === 'flex-start',
+        'justify-end': alignment === 'flex-end',
+        'justify-center': alignment === 'center',
+    }">
+        <div class="w-full inline-flex flex-col justify-start items-start gap-8 mt-4">
+            <div
+                class="md:hidden self-stretch justify-start text-surface-on-surface text-4xl font-normal font-['Noto_Serif'] leading-[60px]">
+                {{ productName }}</div>
 
-              <th
-                class="border-b dark:border-secondary-600 font-medium p-4 pr-8 pt-0 pb-3 text-secondary-600 dark:text-secondary-200 text-left"
-              >
-                {{ translations.product.price.label }}
-              </th>
-            </tr>
-          </thead>
-          <tbody class="bg-white dark:bg-secondary-800">
-            <tr v-for="(tierPrice, index) in tierPrices" :key="tierPrice.label">
-              <td
-                class="border-b border-secondary-100 dark:border-secondary-700 p-4 pl-8 font-medium text-secondary-500 dark:text-secondary-400"
-              >
-                <span v-if="index < tierPrices.length - 1">{{
-                  translations.product.to
-                }}</span
-                ><span v-else>{{ translations.product.from }}</span>
-                {{ tierPrice.quantity }}
-              </td>
-              <td
-                class="border-b border-secondary-100 dark:border-secondary-700 p-4 pr-8 font-medium text-current-500 dark:text-secondary-400"
-              >
-                {{ getFormattedPrice(tierPrice.unitPrice) }}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <div v-if="purchaseUnit && unitName" class="mt-1">
-        <span class="font-light"> {{ translations.product.content }}: </span>
-        <span class="font-light"> {{ purchaseUnit }} {{ unitName }} </span>
-        <span v-if="referencePrice" class="font-light">
-          {{ currency?.symbol }} {{ referencePrice?.price }} / /
-          {{ referencePrice?.referenceUnit }} {{ referencePrice?.unitName }}
-        </span>
-      </div>
-      <span class="text-indigo-600">
-        <template v-if="taxState === 'gross'">
-          {{ translations.product.pricesIncl }}
-        </template>
-        <template v-else> {{ translations.product.pricesExcl }} </template>
-      </span>
+            <div v-if="tierPrices.length <= 1">
+                <SwSharedPrice v-if="isListPrice"
+                    class="text-1xl text-secondary-900 basis-2/6 justify-start line-through"
+                    :value="price?.listPrice?.price" />
+                <SwSharedPrice v-if="unitPrice"
+                    class="justify-start text-surface-on-surface text-base font-bold font-['Inter'] leading-normal"
+                    :class="{
+                        'text-red': isListPrice,
+                    }" :value="unitPrice" />
+                <div v-if="regulationPrice" class="text-xs flex text-secondary-500">
+                    {{ translations.product.previously }}
+                    <SwSharedPrice class="ml-1" :value="regulationPrice" />
+                </div>
+            </div>
+            <div v-else>
+                <table class="border-collapse table-auto w-full text-sm mb-8">
+                    <thead>
+                        <tr>
+                            <th
+                                class="border-b dark:border-secondary-600 font-medium p-4 pl-8 pt-0 pb-3 text-secondary-600 dark:text-secondary-200 text-left">
+                                {{ translations.product.amount }}
+                            </th>
+
+                            <th
+                                class="border-b dark:border-secondary-600 font-medium p-4 pr-8 pt-0 pb-3 text-secondary-600 dark:text-secondary-200 text-left">
+                                {{ translations.product.price.label }}
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white dark:bg-secondary-800">
+                        <tr v-for="(tierPrice, index) in tierPrices" :key="tierPrice.label">
+                            <td
+                                class="border-b border-secondary-100 dark:border-secondary-700 p-4 pl-8 font-medium text-secondary-500 dark:text-secondary-400">
+                                <span v-if="index < tierPrices.length - 1">{{
+                                    translations.product.to
+                                    }}</span><span v-else>{{ translations.product.from }}</span>
+                                {{ tierPrice.quantity }}
+                            </td>
+                            <td
+                                class="border-b border-secondary-100 dark:border-secondary-700 p-4 pr-8 font-medium text-current-500 dark:text-secondary-400">
+                                {{ getFormattedPrice(tierPrice.unitPrice) }}
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <div v-if="purchaseUnit && unitName" class="mt-1">
+                <span class="font-light"> {{ translations.product.content }}: </span>
+                <span class="font-light"> {{ purchaseUnit }} {{ unitName }} </span>
+                <span v-if="referencePrice" class="font-light">
+                    {{ currency?.symbol }} {{ referencePrice?.price }} / /
+                    {{ referencePrice?.referenceUnit }} {{ referencePrice?.unitName }}
+                </span>
+            </div>
+            <span class="text-indigo-600">
+                <template v-if="taxState === 'gross'">
+                    {{ translations.product.pricesIncl }}
+                </template>
+                <template v-else> {{ translations.product.pricesExcl }} </template>
+            </span>
+            <SwVariantConfigurator @change="changeVariant" />
+            <SwProductAddToCart :product="product" />
+        </div>
     </div>
-    <div class="mt-4">
-      <span v-if="availableStock >= minPurchase && deliveryTime"
-        >{{ translations.product.deliveryTime }} {{ deliveryTime?.name }}
-      </span>
-      <span
-        v-else-if="availableStock < minPurchase && deliveryTime && restockTime"
-      >
-        {{ translations.product.deliveryTime }} {{ restockTime }}
-        {{ translations.product.days }} {{ deliveryTime?.name }}</span
-      >
-      <span v-else>{{ translations.product.noAvailable }}</span>
-    </div>
-    <SwVariantConfigurator @change="changeVariant" />
-    <SwProductAddToCart :product="product" />
-    <div class="mt-3 product-detail-ordernumber-container">
-      <span class="font-bold text-secondary-900">
-        {{ translations.product.productNumber }}:
-      </span>
-      <span>
-        {{ productNumber }}
-      </span>
-    </div>
-  </div>
 </template>

--- a/packages/cms-base-layer/app/components/public/cms/element/CmsElementImageGallery.vue
+++ b/packages/cms-base-layer/app/components/public/cms/element/CmsElementImageGallery.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { CmsElementImageGallery } from "@shopware/composables";
-import { computed, onMounted, ref, useTemplateRef } from "vue";
+import { computed, ref } from "vue";
 import { useCmsElementConfig } from "#imports";
 import { isSpatial } from "../../../../helpers/media/isSpatial";
 
@@ -18,232 +18,83 @@ const props = withDefaults(
 
 const { getConfigValue } = useCmsElementConfig(props.content);
 
-const speed = ref<number>(300);
 const currentIndex = ref(0);
-const currentThumb = ref(0);
-const imageSlider = useTemplateRef("imageSlider");
-const imageThumbsTrack = useTemplateRef("imageThumbsTrack");
-const isLoading = ref(true);
-const imageThumbsTrackStyle = ref({});
-const imageThumbs = useTemplateRef("imageThumbs");
-const imageThumbsStyle = ref({});
 const mediaGallery = computed(() => props.content.data?.sliderItems ?? []);
-const galleryPosition = computed<string>(
-  () => getConfigValue("galleryPosition") ?? "left",
-);
-const scrollPx = ref(0);
 
-onMounted(() => {
-  initThumbs();
-});
-
-function initThumbs() {
-  if (imageThumbsTrack.value) {
-    setTimeout(() => {
-      if (galleryPosition.value === "left") {
-        const clientHeight = imageThumbsTrack.value?.clientHeight ?? 0;
-        scrollPx.value = clientHeight / mediaGallery.value.length;
-        imageThumbsStyle.value = {
-          height: `${scrollPx.value * +props.slidesToShow}px`,
-        };
-      } else {
-        const clientWidth = imageThumbs.value?.clientWidth ?? 0;
-        scrollPx.value = clientWidth / props.slidesToShow;
-        imageThumbsTrackStyle.value = {
-          width: `${scrollPx.value * mediaGallery.value.length}px`,
-        };
-      }
-      isLoading.value = false;
-    }, 100);
+function goToSlide(index: number) {
+  if (index >= 0 && index < mediaGallery.value.length) {
+    currentIndex.value = index;
   }
-}
-
-function changeCover(i: number) {
-  if (i === currentIndex.value) return;
-  imageSlider.value?.goToSlide(i);
-}
-
-function handleChangeSlide(e: number) {
-  currentIndex.value = e;
-  if (currentIndex.value > currentThumb.value + props.slidesToShow - 1) {
-    move("next", currentIndex.value);
-    return;
-  }
-  if (currentIndex.value < currentThumb.value) {
-    move("previous", currentIndex.value);
-    return;
-  }
-}
-
-function move(type: "next" | "previous", specificIndex?: number | string) {
-  let step: number;
-  const index =
-    typeof specificIndex !== "number"
-      ? Number.parseInt(specificIndex as string)
-      : specificIndex;
-  if (index >= 0) {
-    if (type === "next") {
-      step =
-        index + props.slidesToScroll < mediaGallery.value.length
-          ? index
-          : mediaGallery.value.length - props.slidesToShow;
-    } else {
-      step =
-        index - props.slidesToScroll > 0 ? index - props.slidesToScroll : 0;
-    }
-  } else {
-    if (type === "next") {
-      step =
-        currentThumb.value + props.slidesToShow - 1 + props.slidesToScroll <
-        mediaGallery.value.length
-          ? currentThumb.value + props.slidesToScroll
-          : mediaGallery.value.length - props.slidesToShow;
-    } else {
-      step =
-        currentThumb.value - props.slidesToScroll > 0
-          ? currentThumb.value - props.slidesToScroll
-          : 0;
-    }
-  }
-  currentThumb.value = step;
-  let xAxis = 0;
-  let yAxis = 0;
-  if (galleryPosition.value === "left") {
-    yAxis = scrollPx.value * currentThumb.value;
-  } else {
-    xAxis = scrollPx.value * currentThumb.value;
-  }
-  imageThumbsTrackStyle.value = {
-    ...imageThumbsTrackStyle.value,
-    transform: `translate3d(-${xAxis}px, -${yAxis}px, 0px)`,
-    transition: `transform ${speed.value}ms ease 0s`,
-  };
 }
 
 function previous() {
-  if (currentThumb.value <= 0) {
-    return;
+  if (currentIndex.value > 0) {
+    currentIndex.value--;
   }
-  move("previous");
 }
 
 function next() {
-  if (currentThumb.value + props.slidesToShow >= mediaGallery.value.length) {
-    return;
+  if (currentIndex.value < mediaGallery.value.length - 1) {
+    currentIndex.value++;
   }
-  move("next");
 }
+
+const currentImage = computed(() => {
+  return mediaGallery.value[currentIndex.value]?.media;
+});
 </script>
 
 <template>
-  <div
-    :class="{
-      'opacity-0': isLoading,
-      'flex gap-10': true,
-      'flex-col-reverse': galleryPosition === 'underneath',
-    }"
-  >
-    <div
-      :class="{
-        'hidden lg:flex basis-20 relative flex-col items-center':
-          galleryPosition === 'left',
-        'flex relative w-full': galleryPosition === 'underneath',
-      }"
-    >
-      <button
-        v-if="mediaGallery.length > slidesToShow"
-        class="disabled:opacity-10 p-1"
-        aria-label="Previous image"
-        @click="previous"
-      >
-        <div
-          class="h-7 w-7"
-          :class="{
-            'i-carbon-chevron-up': galleryPosition === 'left',
-            'i-carbon-chevron-left': galleryPosition !== 'left',
-          }"
-        />
-      </button>
-      <span class="sr-only">Previous image</span>
-      <div
-        ref="imageThumbs"
-        class="overflow-hidden -my-2.5"
-        :style="imageThumbsStyle"
-      >
-        <div
-          ref="imageThumbsTrack"
-          :class="{
-            flex: true,
-            'flex-col': galleryPosition === 'left',
-          }"
-          :style="imageThumbsTrackStyle"
-        >
-          <div
-            v-for="(image, i) in mediaGallery"
-            :key="image.media.url"
-            :class="{
-              'py-2.5': galleryPosition === 'left',
-              'flex-1 px-2.5': galleryPosition === 'underneath',
-            }"
-          >
-            <div
-              class="w-20 h-20 overflow-hidden cursor-pointer p-1 border-secondary-200 rounded transition duration-150 ease-in-out"
-              :class="{
-                border: i !== currentIndex,
-                'border-indigo-500 border-3': i === currentIndex,
-              }"
-              @click="() => changeCover(i)"
-            >
-              <div v-if="isSpatial(image.media)" class="h-full relative">
-                <CmsElementImageGallery3dPlaceholder
-                  class="w-full h-full object-center"
-                />
-                <span
-                  class="absolute bottom-0 text-sm bg-gray rounded px-1 text-white"
-                >
-                  3D</span
-                >
-              </div>
-              <img
-                v-else
-                loading="lazy"
-                :src="image.media.url"
-                class="w-full h-full object-center object-cover"
-                alt="Product image"
-              />
-            </div>
+  <div class="w-full md:w-[44rem] relative inline-flex flex-col justify-center items-center gap-2">
+    <!-- Main Image Display -->
+    <div data-option="1" class="self-stretch h-[700px] relative overflow-hidden">
+      <div v-if="currentImage && isSpatial(currentImage)" class="w-full h-full relative">
+        <CmsElementImageGallery3dPlaceholder
+          class="w-[712.50px] h-[704.44px] left-[-2.25px] top-[-2.22px] absolute object-cover" />
+        <span class="absolute bottom-4 right-4 text-sm bg-gray-800 rounded px-2 py-1 text-white">
+          3D
+        </span>
+      </div>
+      <img v-else-if="currentImage"
+        class="w-full md:w-[712.50px] h-[704.44px] left-[-2.25px] top-[-2.22px] absolute object-cover"
+        :src="currentImage.url" :alt="currentImage.alt || 'Product image'" />
+      <img v-else class="w-[712.50px] h-[704.44px] left-[-2.25px] top-[-2.22px] absolute object-cover"
+        src="https://placehold.co/712x704" alt="Placeholder image" />
+    </div>
+
+    <!-- Navigation Arrows -->
+    <div v-if="mediaGallery.length > 1"
+      class="w-full md:w-[708px] px-2 left-0 top-[338px] absolute inline-flex justify-between items-center">
+      <!-- Previous Button -->
+      <button data-state="Default" data-variant="Tertiary"
+        class="w-10 h-10 relative bg-brand-tertiary rounded-full hover:bg-brand-tertiary-hover transition-colors disabled:opacity-50"
+        :disabled="currentIndex === 0" @click="previous" aria-label="Previous image">
+        <div class="w-6 h-6 left-[8px] top-[8px] absolute">
+          <div class="w-4 h-4 left-[4px] top-[4px] absolute origin-top-left">
+            <div class="i-carbon-chevron-left w-full h-full font-bold"></div>
           </div>
         </div>
-      </div>
-      <button
-        v-if="mediaGallery.length > slidesToShow"
-        class="disabled:opacity-10 p-1"
-        aria-label="Next image"
-        @click="next"
-      >
-        <span class="sr-only">Next image</span>
-        <div
-          class="h-7 w-7"
-          :class="{
-            'i-carbon-chevron-down': galleryPosition === 'left',
-            'i-carbon-chevron-right': galleryPosition !== 'left',
-          }"
-        />
+      </button>
+
+      <!-- Next Button -->
+      <button data-state="Default" data-variant="Tertiary"
+        class="w-10 h-10 relative bg-brand-tertiary rounded-full hover:bg-brand-tertiary-hover transition-colors disabled:opacity-50"
+        :disabled="currentIndex === mediaGallery.length - 1" @click="next" aria-label="Next image">
+        <div class="w-6 h-6 left-[8px] top-[8px] absolute">
+          <div class="w-4 h-4 right-[4px] bottom-[-12px] absolute origin-top-left -rotate-90">
+            <div class="i-carbon-chevron-down w-full h-full font-bold"></div>
+          </div>
+        </div>
       </button>
     </div>
-    <div class="flex-1 overflow-hidden">
-      <SwSlider
-        ref="imageSlider"
-        :config="props.content.config"
-        @change-slide="handleChangeSlide"
-      >
-        <CmsElementImage
-          v-for="image of mediaGallery"
-          :key="image.media.url"
-          :image-gallery="true"
-          :content="{ data: image, config: props.content.config } as any"
-        />
-      </SwSlider>
+
+    <!-- Dot Indicators -->
+    <div v-if="mediaGallery.length > 1" class="inline-flex justify-center items-center gap-2">
+      <button v-for="(image, index) in mediaGallery" :key="image.media.url"
+        class="relative rounded-full transition-all duration-200 hover:scale-110" :class="{
+          'w-6 h-2 bg-surface-on-surface-variant': index === currentIndex,
+          'w-2 h-2 bg-surface-surface-container-highest': index !== currentIndex
+        }" @click="goToSlide(index)" :aria-label="`Go to image ${index + 1}`" />
     </div>
   </div>
 </template>

--- a/packages/cms-base-layer/app/components/public/cms/element/CmsElementImageGallery.vue
+++ b/packages/cms-base-layer/app/components/public/cms/element/CmsElementImageGallery.vue
@@ -42,59 +42,116 @@ function next() {
 const currentImage = computed(() => {
   return mediaGallery.value[currentIndex.value]?.media;
 });
+
+// Touch event handling for mobile swipe gestures - mobile
+const touchStartX = ref(0);
+const touchEndX = ref(0);
+
+function onTouchStart(event: TouchEvent) {
+  touchStartX.value = event.touches?.[0]?.clientX || 0;
+}
+
+function onTouchMove(event: TouchEvent) {
+  touchEndX.value = event?.touches?.[0]?.clientX || 0;
+}
+
+function onTouchEnd() {
+  const deltaX = touchEndX.value - touchStartX.value;
+
+  // Define a threshold for swipe detection
+  const threshold = 50; // pixels
+
+  if (Math.abs(deltaX) > threshold) {
+    if (deltaX < 0) {
+      // Swipe Left
+      next();
+    } else {
+      // Swipe Right
+      previous();
+    }
+  }
+
+  // Reset values
+  touchStartX.value = 0;
+  touchEndX.value = 0;
+}
 </script>
 
 <template>
-  <div class="w-full md:w-[44rem] relative inline-flex flex-col justify-center items-center gap-2">
-    <!-- Main Image Display -->
-    <div data-option="1" class="self-stretch h-[700px] relative overflow-hidden">
-      <div v-if="currentImage && isSpatial(currentImage)" class="w-full h-full relative">
-        <CmsElementImageGallery3dPlaceholder
-          class="w-[712.50px] h-[704.44px] left-[-2.25px] top-[-2.22px] absolute object-cover" />
-        <span class="absolute bottom-4 right-4 text-sm bg-gray-800 rounded px-2 py-1 text-white">
-          3D
-        </span>
+  <div class="w-full max-w-full relative inline-flex flex-col justify-center items-center gap-2 mx-auto">
+    <div class="w-full lg:max-w-[600px] xl:max-w-[708px]">
+      <!-- Main Image Display -->
+
+      <div class="w-full h-[400px] sm:h-[500px] lg:h-[600px] xl:h-[700px] relative overflow-hidden rounded-lg"
+        @touchstart="onTouchStart" @touchmove="onTouchMove" @touchend="onTouchEnd">
+        <Transition name="gallery-fade" mode="out-in">
+          <div v-if="currentImage && isSpatial(currentImage)" class="w-full h-full relative">
+            <CmsElementImageGallery3dPlaceholder class="w-full h-full absolute inset-0 object-cover" />
+            <span class="absolute bottom-4 right-4 text-sm bg-gray-800 rounded px-2 py-1 text-white">
+              3D
+            </span>
+          </div>
+          <img v-else-if="currentImage" class="w-full h-full absolute inset-0 object-cover" :src="currentImage.url"
+            :key="currentImage.url" :alt="currentImage.alt || 'Product image'" />
+          <img v-else class="w-full h-full absolute inset-0 object-cover" src="https://placehold.co/600x500"
+            alt="Placeholder image" />
+        </Transition>
+
       </div>
-      <img v-else-if="currentImage"
-        class="w-full md:w-[712.50px] h-[704.44px] left-[-2.25px] top-[-2.22px] absolute object-cover"
-        :src="currentImage.url" :alt="currentImage.alt || 'Product image'" />
-      <img v-else class="w-[712.50px] h-[704.44px] left-[-2.25px] top-[-2.22px] absolute object-cover"
-        src="https://placehold.co/712x704" alt="Placeholder image" />
-    </div>
-
-    <!-- Navigation Arrows -->
-    <div v-if="mediaGallery.length > 1"
-      class="w-full md:w-[708px] px-2 left-0 top-[338px] absolute inline-flex justify-between items-center">
-      <!-- Previous Button -->
-      <button data-state="Default" data-variant="Tertiary"
-        class="w-10 h-10 relative bg-brand-tertiary rounded-full hover:bg-brand-tertiary-hover transition-colors disabled:opacity-50"
-        :disabled="currentIndex === 0" @click="previous" aria-label="Previous image">
-        <div class="w-6 h-6 left-[8px] top-[8px] absolute">
-          <div class="w-4 h-4 left-[4px] top-[4px] absolute origin-top-left">
-            <div class="i-carbon-chevron-left w-full h-full font-bold"></div>
+      <!-- Navigation Arrows -->
+      <div v-if="mediaGallery.length > 1"
+        class="absolute inset-0 flex items-center justify-between px-2 sm:px-4 pointer-events-none">
+        <!-- Previous Button -->
+        <button
+          class="w-10 h-10 bg-brand-tertiary rounded-full hover:bg-brand-tertiary-hover transition-colors disabled:opacity-50 pointer-events-auto shadow-lg"
+          :disabled="currentIndex === 0" @click="previous" aria-label="Previous image">
+          <div class="flex items-center justify-center w-full h-full">
+            <div class="i-carbon-chevron-left w-5 h-5 text-brand-on-tertiary"></div>
           </div>
-        </div>
-      </button>
+        </button>
 
-      <!-- Next Button -->
-      <button data-state="Default" data-variant="Tertiary"
-        class="w-10 h-10 relative bg-brand-tertiary rounded-full hover:bg-brand-tertiary-hover transition-colors disabled:opacity-50"
-        :disabled="currentIndex === mediaGallery.length - 1" @click="next" aria-label="Next image">
-        <div class="w-6 h-6 left-[8px] top-[8px] absolute">
-          <div class="w-4 h-4 right-[4px] bottom-[-12px] absolute origin-top-left -rotate-90">
-            <div class="i-carbon-chevron-down w-full h-full font-bold"></div>
+        <!-- Next Button -->
+        <button
+          class="w-10 h-10 bg-brand-tertiary rounded-full hover:bg-brand-tertiary-hover transition-colors disabled:opacity-50 pointer-events-auto shadow-lg"
+          :disabled="currentIndex === mediaGallery.length - 1" @click="next" aria-label="Next image">
+          <div class="flex items-center justify-center w-full h-full">
+            <div class="i-carbon-chevron-right w-5 h-5 text-brand-on-tertiary"></div>
           </div>
-        </div>
-      </button>
-    </div>
+        </button>
+      </div>
 
-    <!-- Dot Indicators -->
-    <div v-if="mediaGallery.length > 1" class="inline-flex justify-center items-center gap-2">
-      <button v-for="(image, index) in mediaGallery" :key="image.media.url"
-        class="relative rounded-full transition-all duration-200 hover:scale-110" :class="{
-          'w-6 h-2 bg-surface-on-surface-variant': index === currentIndex,
-          'w-2 h-2 bg-surface-surface-container-highest': index !== currentIndex
-        }" @click="goToSlide(index)" :aria-label="`Go to image ${index + 1}`" />
+      <!-- Dot Indicators -->
+      <div v-if="mediaGallery.length > 1" class="flex justify-center items-center gap-2 mt-2">
+        <button v-for="(image, index) in mediaGallery" :key="image.media.url"
+          class="relative rounded-full transition-all duration-200 hover:scale-110" :class="{
+            'w-6 h-2 bg-surface-on-surface-variant': index === currentIndex,
+            'w-2 h-2 bg-surface-surface-container-highest': index !== currentIndex
+          }" @click="goToSlide(index)" :aria-label="`Go to image ${index + 1}`" />
+      </div>
     </div>
   </div>
 </template>
+
+<style scoped>
+/* Gallery fade transition */
+.gallery-fade-enter-active,
+.gallery-fade-leave-active {
+  transition: all 0.3s ease-in-out;
+}
+
+.gallery-fade-enter-from {
+  opacity: 0;
+  transform: scale(1.05) translateY(10px);
+}
+
+.gallery-fade-leave-to {
+  opacity: 0;
+  transform: scale(0.95) translateY(-10px);
+}
+
+.gallery-fade-enter-to,
+.gallery-fade-leave-from {
+  opacity: 1;
+  transform: scale(1) translateY(0);
+}
+</style>

--- a/packages/cms-base-layer/app/components/public/cms/element/CmsElementProductName.vue
+++ b/packages/cms-base-layer/app/components/public/cms/element/CmsElementProductName.vue
@@ -6,5 +6,6 @@ defineProps<{
 }>();
 </script>
 <template>
-  <CmsElementText :content="content as any" />
+  <!-- there is no css config coming from API for this element so we don't need to merge -->
+  <CmsElementText :content="content as any" class="self-stretch justify-start text-surface-on-surface text-4xl font-normal font-['Noto_Serif'] leading-[60px]" />
 </template>

--- a/packages/cms-base-layer/nuxt.config.ts
+++ b/packages/cms-base-layer/nuxt.config.ts
@@ -1,6 +1,7 @@
 import type { NuxtConfig } from "@nuxt/schema";
 import { defineNuxtConfig } from "nuxt/config";
 export default defineNuxtConfig({
+  modules: ["@unocss/nuxt"],
   components: [
     {
       path: "./components/public",

--- a/packages/cms-base-layer/package.json
+++ b/packages/cms-base-layer/package.json
@@ -23,21 +23,25 @@
     "lint:fix": "biome check . --write && pnpm run typecheck",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "check-colors": "tsx scripts/check-unused-colors.ts"
   },
   "dependencies": {
+    "@iconify-json/carbon": "1.2.9",
     "@nuxt/kit": "4.0.0",
+    "@shopware/api-client": "workspace:*",
     "@shopware/composables": "workspace:*",
     "@shopware/helpers": "workspace:*",
-    "@shopware/api-client": "workspace:*",
     "@tresjs/cientos": "4.3.1",
     "@tresjs/core": "4.3.6",
+    "@unocss/nuxt": "66.2.2",
     "@vuelidate/core": "2.0.3",
     "@vuelidate/validators": "2.0.4",
     "@vueuse/core": "13.5.0",
     "entities": "6.0.0",
     "html-to-ast": "0.0.6",
     "three": "0.173.0",
+    "unocss": "66.2.2",
     "vue": "3.5.17",
     "xss": "1.0.15"
   },

--- a/packages/cms-base-layer/scripts/check-unused-colors.ts
+++ b/packages/cms-base-layer/scripts/check-unused-colors.ts
@@ -1,0 +1,345 @@
+import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Get current directory
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const rootDir = join(__dirname, "..");
+
+// Load UnoCSS config from a specific path
+async function loadUnoConfigFromPath(configPath: string) {
+  try {
+    const configContent = readFileSync(configPath, "utf-8");
+
+    // Extract colors from the config using regex
+    const colorsMatch = configContent.match(
+      /colors:\s*{([^}]+(?:{[^}]*}[^}]*)*?)}/s,
+    );
+    if (!colorsMatch) {
+      return [];
+    }
+
+    const colorsSection = colorsMatch[1];
+    const colorMatches =
+      colorsSection?.matchAll(/"([^"]+)":\s*"([^"]+)"/g) || [];
+
+    const colors = Array.from(colorMatches).map((match) => ({
+      name: match[1],
+      value: match[2],
+    }));
+
+    return colors;
+  } catch (error) {
+    console.warn(`⚠️  Could not load config from ${configPath}: ${error}`);
+    return [];
+  }
+}
+
+// Load cms-base-layer config
+async function loadCmsBaseConfig() {
+  const configPath = join(rootDir, "uno.config.ts");
+  return {
+    path: configPath,
+    colors: await loadUnoConfigFromPath(configPath),
+  };
+}
+
+// Load vue-starter-template config
+async function loadTemplateConfig() {
+  const templateConfigPath = join(
+    rootDir,
+    "../../templates/vue-starter-template/uno.config.ts",
+  );
+  return {
+    path: templateConfigPath,
+    colors: await loadUnoConfigFromPath(templateConfigPath),
+  };
+}
+
+// Get all Vue/TypeScript files in components directory
+function getComponentFiles(dir: string): string[] {
+  const files: string[] = [];
+
+  function walkDirectory(currentDir: string) {
+    try {
+      const items = readdirSync(currentDir);
+
+      for (const item of items) {
+        const fullPath = join(currentDir, item);
+        const stat = statSync(fullPath);
+
+        if (stat.isDirectory()) {
+          walkDirectory(fullPath);
+        } else if (item.match(/\.(vue|ts|js)$/)) {
+          files.push(fullPath);
+        }
+      }
+    } catch (error) {
+      // Directory might not exist, skip it
+    }
+  }
+
+  walkDirectory(dir);
+  return files;
+}
+
+// Check if color is used in component files
+function isColorUsed(colorName: string, componentFiles: string[]): boolean {
+  const colorPrefixes = [
+    "bg-",
+    "text-",
+    "border-",
+    "ring-",
+    "outline-",
+    "decoration-",
+    "from-",
+    "to-",
+    "via-",
+    "fill-",
+    "stroke-",
+    "hover:bg-",
+    "hover:text-",
+    "hover:border-",
+    "focus:bg-",
+    "focus:text-",
+    "focus:border-",
+    "focus:ring-",
+    "active:bg-",
+    "active:text-",
+    "active:border-",
+    "disabled:bg-",
+    "disabled:text-",
+    "disabled:border-",
+  ];
+
+  for (const file of componentFiles) {
+    try {
+      const content = readFileSync(file, "utf-8");
+
+      for (const prefix of colorPrefixes) {
+        const classPattern = new RegExp(
+          `${prefix}${colorName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?![\\w-])`,
+          "g",
+        );
+        if (classPattern.test(content)) {
+          return true;
+        }
+      }
+    } catch (error) {
+      // Skip files that can't be read
+    }
+  }
+
+  return false;
+}
+
+// Update cms-base config based on template colors and usage
+function updateCmsBaseConfig(
+  configPath: string,
+  templateColors: Array<{ name: string; value: string }>,
+  usedColors: string[],
+  unusedColors: string[],
+) {
+  let configContent = readFileSync(configPath, "utf-8");
+
+  // Find the colors section
+  const colorsMatch = configContent.match(
+    /(colors:\s*{)([^}]+(?:{[^}]*}[^}]*)*?)(})/s,
+  );
+  if (!colorsMatch) {
+    console.error("❌ Could not find colors section in cms-base config");
+    return;
+  }
+
+  // @ts-ignore
+  const [fullMatch, openBrace, currentColorsSection, closeBrace] = colorsMatch;
+
+  // Build new colors section with only used template colors
+  const usedTemplateColors = templateColors.filter((color) =>
+    usedColors.includes(color.name),
+  );
+
+  let newColorsSection = "";
+  if (usedTemplateColors.length > 0) {
+    newColorsSection = `${usedTemplateColors
+      .map((color) => `      "${color.name}": "${color.value}"`)
+      .join(",\n")},`;
+  }
+
+  // Replace the colors section
+  const newColorsBlock = `${openBrace}\n${newColorsSection}\n    ${closeBrace}`;
+  configContent = configContent.replace(fullMatch, newColorsBlock);
+
+  // Write back to file
+  writeFileSync(configPath, configContent, "utf-8");
+
+  console.log("✅ Updated cms-base config:");
+  console.log(`   ➕ Kept ${usedColors.length} used colors`);
+  console.log(`   ➖ Removed ${unusedColors.length} unused colors`);
+}
+
+// Main function
+async function checkAndSyncColors() {
+  try {
+    console.log(
+      "🔄 Syncing cms-base-layer colors with vue-starter-template...\n",
+    );
+
+    // Load configurations
+    const cmsBaseConfig = await loadCmsBaseConfig();
+    const templateConfig = await loadTemplateConfig();
+
+    if (templateConfig.colors.length === 0) {
+      console.error("❌ No colors found in vue-starter-template config");
+      return;
+    }
+
+    // Get cms-base component files only
+    const cmsComponentsDir = join(rootDir, "components");
+    const cmsComponentFiles = getComponentFiles(cmsComponentsDir);
+
+    console.log(
+      `📁 Found ${cmsComponentFiles.length} cms-base-layer component files`,
+    );
+    console.log(
+      `🎯 Found ${templateConfig.colors.length} colors in vue-starter-template\n`,
+    );
+
+    // Check which template colors are used in cms-base components
+    const usedTemplateColors: string[] = [];
+    const unusedTemplateColors: string[] = [];
+
+    console.log("🔍 CHECKING TEMPLATE COLORS USAGE IN CMS-BASE:");
+
+    for (const color of templateConfig.colors) {
+      if (typeof color.name !== "string") {
+        continue;
+      }
+      const isUsed = isColorUsed(color.name, cmsComponentFiles);
+
+      if (isUsed) {
+        usedTemplateColors.push(color.name);
+        console.log(`✅ ${color.name} (used in cms-base)`);
+      } else {
+        unusedTemplateColors.push(color.name);
+        console.log(`🔴 ${color.name} (not used in cms-base)`);
+      }
+    }
+
+    // Check current cms-base colors that are not from template
+    const templateColorNames = new Set(
+      templateConfig.colors.map((c) => c.name),
+    );
+    const cmsOnlyColors = cmsBaseConfig.colors.filter(
+      (c) => !templateColorNames.has(c.name),
+    );
+
+    if (cmsOnlyColors.length > 0) {
+      console.log("\n📝 CMS-BASE ONLY COLORS (will be removed):");
+      for (const color of cmsOnlyColors) {
+        console.log(`   🗑️  ${color.name}: ${color.value}`);
+      }
+    }
+
+    // Summary
+    console.log("\n📊 SYNC SUMMARY:");
+    console.log(
+      `✅ Template colors to keep: ${usedTemplateColors.length}/${templateConfig.colors.length}`,
+    );
+    console.log(`🔴 Template colors to remove: ${unusedTemplateColors.length}`);
+    console.log(`🗑️  CMS-only colors to remove: ${cmsOnlyColors.length}`);
+    console.log(
+      `📈 Template usage rate: ${((usedTemplateColors.length / templateConfig.colors.length) * 100).toFixed(1)}%`,
+    );
+
+    if (usedTemplateColors.length > 0) {
+      console.log("\n✅ COLORS TO KEEP IN CMS-BASE:");
+      for (const colorName of usedTemplateColors) {
+        const color = templateConfig.colors.find((c) => c.name === colorName);
+        console.log(`   ✅ ${colorName}: ${color?.value}`);
+      }
+    }
+
+    if (unusedTemplateColors.length > 0 || cmsOnlyColors.length > 0) {
+      console.log("\n🔴 COLORS TO REMOVE FROM CMS-BASE:");
+      for (const colorName of unusedTemplateColors) {
+        const color = templateConfig.colors.find((c) => c.name === colorName);
+        console.log(
+          `   🔴 ${colorName}: ${color?.value} (from template, unused)`,
+        );
+      }
+      for (const color of cmsOnlyColors) {
+        console.log(`   🔴 ${color.name}: ${color.value} (cms-only)`);
+      }
+    }
+
+    // Update the cms-base config
+    console.log("\n🔄 Updating cms-base uno.config.ts...");
+    updateCmsBaseConfig(
+      cmsBaseConfig.path,
+      templateConfig.colors.filter(
+        (c): c is { name: string; value: string } =>
+          typeof c.name === "string" && typeof c.value === "string",
+      ),
+      usedTemplateColors,
+      [...unusedTemplateColors, ...cmsOnlyColors.map((c) => c.name)].filter(
+        (name): name is string => typeof name === "string",
+      ),
+    );
+
+    // Group kept colors by category for better understanding
+    if (usedTemplateColors.length > 0) {
+      console.log("\n📂 KEPT COLORS BY CATEGORY:");
+
+      const categories = {
+        Brand: usedTemplateColors.filter((c) => c.startsWith("brand-")),
+        Surface: usedTemplateColors.filter((c) => c.startsWith("surface-")),
+        States: usedTemplateColors.filter((c) => c.startsWith("states-")),
+        Outline: usedTemplateColors.filter((c) => c.startsWith("outline-")),
+        Primary: usedTemplateColors.filter(
+          (c) => c.startsWith("primary") && !c.startsWith("brand-primary"),
+        ),
+        Secondary: usedTemplateColors.filter(
+          (c) => c.startsWith("secondary") && !c.startsWith("brand-secondary"),
+        ),
+        Success: usedTemplateColors.filter((c) => c.startsWith("success")),
+        Warning: usedTemplateColors.filter((c) => c.startsWith("warning")),
+        Other: usedTemplateColors.filter(
+          (c) =>
+            ![
+              "brand-",
+              "surface-",
+              "states-",
+              "outline-",
+              "primary",
+              "secondary",
+              "success",
+              "warning",
+            ].some((prefix) => c.startsWith(prefix)),
+        ),
+      };
+
+      for (const [category, colors] of Object.entries(categories)) {
+        if (colors.length > 0) {
+          console.log(`\n${category}:`);
+          for (const color of colors) {
+            console.log(`   ✅ ${color}`);
+          }
+        }
+      }
+    }
+
+    console.log("\n🎉 Color sync completed successfully!");
+  } catch (error) {
+    console.error(
+      "❌ Error:",
+      error instanceof Error ? error.message : String(error),
+    );
+    process.exit(1);
+  }
+}
+
+// Run the script
+checkAndSyncColors();

--- a/packages/cms-base-layer/uno.config.ts
+++ b/packages/cms-base-layer/uno.config.ts
@@ -1,0 +1,45 @@
+import {
+  defineConfig,
+  presetAttributify,
+  presetIcons,
+  presetTypography,
+  presetWind3,
+} from "unocss";
+
+export default defineConfig({
+  theme: {
+    colors: {
+      "brand-primary": "#543B95",
+      "surface-surface": "#FFFFFF",
+      "outline-outline": "#79747E",
+      "outline-outline-variant": "#CAC4D0",
+      "surface-on-surface": "#1D1B20",
+      "surface-surface-variant": "#FBF6FF",
+      "states-success": "#15B31C",
+      "surface-on-surface-variant": "#696470",
+      "surface-surface-container-highest": "#E6E0E9",
+      "states-error": "#D12D24",
+      "brand-primary-hover": "#45317A",
+      "brand-secondary": "#E1D5FF",
+      "brand-secondary-hover": "#D0BCFC",
+      "brand-tertiary": "#F1F1F1",
+      "brand-tertiary-hover": "#E3E3E3",
+    },
+    fontFamily: {
+      inter: "Inter",
+      Noto_Serif: "Noto Serif",
+    },
+  },
+  safelist: ["states-success", "states-error", "states-info", "states-warning"],
+  presets: [
+    presetWind3(),
+    presetIcons({
+      collections: {
+        carbon: () =>
+          import("@iconify-json/carbon/icons.json").then((i) => i.default),
+      },
+    }),
+    presetAttributify(),
+    presetTypography(),
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,13 +215,13 @@ importers:
         version: link:../../packages/nuxt-module
       '@unocss/nuxt':
         specifier: 66.2.2
-        version: 66.2.2(magicast@0.3.5)(postcss@8.5.3)(vue@3.5.17(typescript@5.9.2))(webpack@5.91.0(@swc/core@1.7.10))
+        version: 66.2.2(magicast@0.3.5)(postcss@8.5.3)(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))(webpack@5.91.0(@swc/core@1.7.10))
       '@vueuse/nuxt':
         specifier: 13.3.0
-        version: 13.3.0(magicast@0.3.5)(nuxt@4.0.1(@biomejs/biome@1.8.3)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vercel/blob@1.0.2)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(encoding@0.1.13)(eslint@9.29.0(jiti@2.4.2))(ioredis@5.6.1)(less@4.2.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.43.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(typescript@5.9.2)(vue-tsc@2.2.10(typescript@5.9.2))(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))
+        version: 13.3.0(magicast@0.3.5)(nuxt@4.0.1(@biomejs/biome@1.8.3)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vercel/blob@1.0.2)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(encoding@0.1.13)(eslint@9.29.0(jiti@2.4.2))(ioredis@5.6.1)(less@4.2.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.43.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(typescript@5.9.2)(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue-tsc@2.2.10(typescript@5.9.2))(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))
       nuxt:
         specifier: 4.0.1
-        version: 4.0.1(@biomejs/biome@1.8.3)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vercel/blob@1.0.2)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(encoding@0.1.13)(eslint@9.29.0(jiti@2.4.2))(ioredis@5.6.1)(less@4.2.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.43.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(typescript@5.9.2)(vue-tsc@2.2.10(typescript@5.9.2))(yaml@2.7.1)
+        version: 4.0.1(@biomejs/biome@1.8.3)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vercel/blob@1.0.2)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(encoding@0.1.13)(eslint@9.29.0(jiti@2.4.2))(ioredis@5.6.1)(less@4.2.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.43.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(typescript@5.9.2)(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue-tsc@2.2.10(typescript@5.9.2))(yaml@2.7.1)
       vue-tsc:
         specifier: 2.2.10
         version: 2.2.10(typescript@5.9.2)
@@ -350,7 +350,7 @@ importers:
         version: 1.3.0(@nuxt/kit@4.0.1(magicast@0.3.5))(vue@3.5.17(typescript@5.9.2))
       unocss:
         specifier: 66.2.2
-        version: 66.2.2(@unocss/webpack@66.2.2(webpack@5.91.0(@swc/core@1.7.10)))(postcss@8.5.3)(vue@3.5.17(typescript@5.9.2))
+        version: 66.2.2(@unocss/webpack@66.2.2(webpack@5.91.0(@swc/core@1.7.10)))(postcss@8.5.3)(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))
 
   examples/b2b-quote-management:
     dependencies:
@@ -1074,6 +1074,9 @@ importers:
 
   packages/cms-base-layer:
     dependencies:
+      '@iconify-json/carbon':
+        specifier: 1.2.9
+        version: 1.2.9
       '@nuxt/kit':
         specifier: 4.0.0
         version: 4.0.0(magicast@0.3.5)
@@ -1092,6 +1095,9 @@ importers:
       '@tresjs/core':
         specifier: 4.3.6
         version: 4.3.6(three@0.173.0)(typescript@5.8.3)(vue@3.5.17(typescript@5.8.3))
+      '@unocss/nuxt':
+        specifier: 66.2.2
+        version: 66.2.2(magicast@0.3.5)(postcss@8.5.3)(vue@3.5.17(typescript@5.8.3))(webpack@5.91.0(@swc/core@1.7.10))
       '@vuelidate/core':
         specifier: 2.0.3
         version: 2.0.3(vue@3.5.17(typescript@5.8.3))
@@ -1110,6 +1116,9 @@ importers:
       three:
         specifier: 0.173.0
         version: 0.173.0
+      unocss:
+        specifier: 66.2.2
+        version: 66.2.2(@unocss/webpack@66.2.2(webpack@5.91.0(@swc/core@1.7.10)))(postcss@8.5.3)(vue@3.5.17(typescript@5.8.3))
       vue:
         specifier: 3.5.17
         version: 3.5.17(typescript@5.8.3)
@@ -1131,7 +1140,7 @@ importers:
         version: 3.2.3(vitest@3.2.3(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@22.13.14)(happy-dom@18.0.1)(jsdom@26.1.0)(less@4.2.0)(sass@1.89.2)(terser@5.43.0))
       nuxt:
         specifier: 4.0.1
-        version: 4.0.1(@biomejs/biome@1.8.3)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vercel/blob@1.0.2)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(encoding@0.1.13)(eslint@9.29.0(jiti@2.4.2))(ioredis@5.6.1)(less@4.2.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.43.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(typescript@5.8.3)(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.7.1)
+        version: 4.0.1(@biomejs/biome@1.8.3)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vercel/blob@1.0.2)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(encoding@0.1.13)(eslint@9.29.0(jiti@2.4.2))(ioredis@5.6.1)(less@4.2.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.43.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.7.1)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1845,6 +1854,11 @@ packages:
     resolution: {integrity: sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/parser@7.27.5':
+    resolution: {integrity: sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/parser@7.28.0':
     resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
     engines: {node: '>=6.0.0'}
@@ -1912,12 +1926,6 @@ packages:
 
   '@babel/plugin-syntax-import-attributes@7.26.0':
     resolution: {integrity: sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-import-attributes@7.27.1':
-    resolution: {integrity: sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2297,12 +2305,6 @@ packages:
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
-
-  '@babel/preset-typescript@7.26.0':
-    resolution: {integrity: sha512-NMk1IGZ5I/oHhoXEElcm+xUnL/szL6xflkFZmoEU9xj1qSJXpiS7rsspYo92B4DRCDvZn2erT5LdsCeXAKNCkg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
 
   '@babel/preset-typescript@7.27.0':
     resolution: {integrity: sha512-vxaPFfJtHhgeOVXRKuHpHPAOgymmy8V8I65T1q53R7GCZlefKeCaTyDs3zOPHTTbmquvNlQYC5klEvWsBAtrBQ==}
@@ -3108,6 +3110,9 @@ packages:
   '@iconify-json/carbon@1.2.8':
     resolution: {integrity: sha512-6xh4YiFBz6qoSnB3XMe23WvjTJroDFXB17J1MbiT7nATFe+70+em1acRXr8hgP/gYpwFMHFc4IvjA/IPTPnTzg==}
 
+  '@iconify-json/carbon@1.2.9':
+    resolution: {integrity: sha512-RyeSAuFTzhs1GX4yrzVEKEbNQGt95p9zMR4S2F63vbThtNoUr5OKwaWbhO/GbHQCSgdbKuZv2ApAOsY2fLxLbQ==}
+
   '@iconify-json/ph@1.2.0':
     resolution: {integrity: sha512-013eLpgTmX1lACOuDnkuhC7gRHyYj9w/j8SyDmlyUYvsKQrwdRsv1otcXtwH3DevuDAzSkreeeRsCeez+gTyVA==}
 
@@ -3363,8 +3368,16 @@ packages:
   '@jridgewell/gen-mapping@0.3.12':
     resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
 
+  '@jridgewell/gen-mapping@0.3.8':
+    resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/set-array@1.2.1':
+    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
 
   '@jridgewell/source-map@0.3.6':
@@ -3372,6 +3385,9 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
+  '@jridgewell/trace-mapping@0.3.25':
+    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
@@ -7609,10 +7625,6 @@ packages:
     resolution: {integrity: sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==}
     engines: {node: '>=10'}
 
-  aria-hidden@1.2.6:
-    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
-    engines: {node: '>=10'}
-
   aria-query@5.1.3:
     resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
 
@@ -10816,6 +10828,7 @@ packages:
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
@@ -12904,10 +12917,6 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
-
-  readdirp@4.0.1:
-    resolution: {integrity: sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==}
-    engines: {node: '>= 14.16.0'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -15193,8 +15202,8 @@ packages:
   vue-component-type-helpers@2.0.7:
     resolution: {integrity: sha512-7e12Evdll7JcTIocojgnCgwocX4WzIYStGClBQ+QuWPinZo/vQolv2EMq4a3lg16TKfwWafLimG77bxb56UauA==}
 
-  vue-component-type-helpers@3.0.4:
-    resolution: {integrity: sha512-WtR3kPk8vqKYfCK/HGyT47lK/T3FaVyWxaCNuosaHYE8h9/k0lYRZ/PI/+T/z2wP+uuNKmL6z30rOcBboOu/YA==}
+  vue-component-type-helpers@2.2.8:
+    resolution: {integrity: sha512-4bjIsC284coDO9om4HPA62M7wfsTvcmZyzdfR0aUlFXqq4tXxM1APyXpNVxPC8QazKw9OhmZNHBVDA6ODaZsrA==}
 
   vue-demi@0.13.11:
     resolution: {integrity: sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==}
@@ -15770,8 +15779,8 @@ snapshots:
 
   '@ampproject/remapping@2.3.0':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
 
   '@antfu/install-pkg@1.1.0':
     dependencies:
@@ -16038,16 +16047,16 @@ snapshots:
     dependencies:
       '@babel/parser': 7.28.0
       '@babel/types': 7.28.1
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.0.2
 
   '@babel/generator@7.27.5':
     dependencies:
       '@babel/parser': 7.28.0
       '@babel/types': 7.28.1
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
 
   '@babel/generator@7.28.0':
@@ -16232,7 +16241,7 @@ snapshots:
     dependencies:
       '@babel/template': 7.27.2
       '@babel/traverse': 7.27.4
-      '@babel/types': 7.28.1
+      '@babel/types': 7.27.6
     transitivePeerDependencies:
       - supports-color
 
@@ -16245,6 +16254,10 @@ snapshots:
     dependencies:
       '@babel/template': 7.27.2
       '@babel/types': 7.28.1
+
+  '@babel/parser@7.27.5':
+    dependencies:
+      '@babel/types': 7.27.6
 
   '@babel/parser@7.28.0':
     dependencies:
@@ -16318,7 +16331,7 @@ snapshots:
       '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-plugin-utils': 7.27.1
@@ -16754,7 +16767,7 @@ snapshots:
       '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.25.9(@babel/core@7.28.0)
       '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.0)
       '@babel/plugin-syntax-import-assertions': 7.26.0(@babel/core@7.28.0)
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.0)
+      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.28.0)
       '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.28.0)
       '@babel/plugin-transform-arrow-functions': 7.25.9(@babel/core@7.28.0)
       '@babel/plugin-transform-async-generator-functions': 7.25.9(@babel/core@7.28.0)
@@ -16826,19 +16839,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/types': 7.28.1
+      '@babel/types': 7.27.6
       esutils: 2.0.3
-
-  '@babel/preset-typescript@7.26.0(@babel/core@7.28.0)':
-    dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-modules-commonjs': 7.26.3(@babel/core@7.28.0)
-      '@babel/plugin-transform-typescript': 7.27.1(@babel/core@7.28.0)
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/preset-typescript@7.27.0(@babel/core@7.27.4)':
     dependencies:
@@ -16848,6 +16850,17 @@ snapshots:
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.27.4)
       '@babel/plugin-transform-modules-commonjs': 7.26.3(@babel/core@7.27.4)
       '@babel/plugin-transform-typescript': 7.27.1(@babel/core@7.27.4)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-typescript@7.27.0(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-validator-option': 7.25.9
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.0)
+      '@babel/plugin-transform-modules-commonjs': 7.26.3(@babel/core@7.28.0)
+      '@babel/plugin-transform-typescript': 7.27.1(@babel/core@7.28.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17679,6 +17692,10 @@ snapshots:
     dependencies:
       '@iconify/types': 2.0.0
 
+  '@iconify-json/carbon@1.2.9':
+    dependencies:
+      '@iconify/types': 2.0.0
+
   '@iconify-json/ph@1.2.0':
     dependencies:
       '@iconify/types': 2.0.0
@@ -17949,14 +17966,27 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.29
 
+  '@jridgewell/gen-mapping@0.3.8':
+    dependencies:
+      '@jridgewell/set-array': 1.2.1
+      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/trace-mapping': 0.3.25
+
   '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/set-array@1.2.1': {}
 
   '@jridgewell/source-map@0.3.6':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@jridgewell/trace-mapping@0.3.25':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   '@jridgewell/trace-mapping@0.3.29':
     dependencies:
@@ -18430,6 +18460,47 @@ snapshots:
       - utf-8-validate
       - vue
 
+  '@nuxt/devtools@2.6.2(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))':
+    dependencies:
+      '@nuxt/devtools-kit': 2.6.2(magicast@0.3.5)(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))
+      '@nuxt/devtools-wizard': 2.6.2
+      '@nuxt/kit': 3.17.7(magicast@0.3.5)
+      '@vue/devtools-core': 7.7.7(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))
+      '@vue/devtools-kit': 7.7.7
+      birpc: 2.4.0
+      consola: 3.4.2
+      destr: 2.0.5
+      error-stack-parser-es: 1.0.5
+      execa: 8.0.1
+      fast-npm-meta: 0.4.4
+      get-port-please: 3.2.0
+      hookable: 5.5.3
+      image-meta: 0.2.1
+      is-installed-globally: 1.0.0
+      launch-editor: 2.10.0
+      local-pkg: 1.1.1
+      magicast: 0.3.5
+      nypm: 0.6.0
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 1.0.0
+      pkg-types: 2.2.0
+      semver: 7.7.2
+      simple-git: 3.28.0
+      sirv: 3.0.1
+      structured-clone-es: 1.0.0
+      tinyglobby: 0.2.14
+      vite: 7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1)
+      vite-plugin-inspect: 11.3.0(@nuxt/kit@3.17.7(magicast@0.3.5))(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))
+      vite-plugin-vue-tracer: 1.0.0(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))
+      which: 5.0.0
+      ws: 8.18.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - vue
+
   '@nuxt/devtools@2.6.2(vue@3.5.17(typescript@5.8.3))':
     dependencies:
       '@nuxt/devtools-kit': 2.6.2(magicast@0.3.5)(vite@6.3.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))
@@ -18460,7 +18531,7 @@ snapshots:
       sirv: 3.0.1
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.14
-      vite-plugin-inspect: 11.3.0(@nuxt/kit@3.17.7(magicast@0.3.5))(vite@6.3.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))
+      vite-plugin-inspect: 11.3.0(@nuxt/kit@3.17.7(magicast@0.3.5))
       vite-plugin-vue-tracer: 1.0.0(vite@6.3.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.8.3))
       which: 5.0.0
       ws: 8.18.2
@@ -18500,8 +18571,8 @@ snapshots:
       sirv: 3.0.1
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.14
-      vite-plugin-inspect: 11.3.0(@nuxt/kit@3.17.7(magicast@0.3.5))(vite@6.3.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))
-      vite-plugin-vue-tracer: 1.0.0(vue@3.5.17(typescript@5.9.2))
+      vite-plugin-inspect: 11.3.0(@nuxt/kit@3.17.7(magicast@0.3.5))
+      vite-plugin-vue-tracer: 1.0.0(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))
       which: 5.0.0
       ws: 8.18.2
     transitivePeerDependencies:
@@ -19669,7 +19740,7 @@ snapshots:
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.3.13)(react@18.3.1)
       '@radix-ui/react-use-previous': 1.0.1(@types/react@18.3.13)(react@18.3.1)
       '@radix-ui/react-visually-hidden': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      aria-hidden: 1.2.6
+      aria-hidden: 1.2.4
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.5.5(@types/react@18.3.13)(react@18.3.1)
@@ -21120,7 +21191,7 @@ snapshots:
   '@storybook/addon-styling@1.3.7(@types/react-dom@17.0.25)(@types/react@18.3.13)(encoding@0.1.13)(less@4.2.0)(postcss@8.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.89.2)(typescript@5.8.3)(webpack@5.91.0(@swc/core@1.7.10)(esbuild@0.25.5))':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.1
+      '@babel/types': 7.27.6
       '@storybook/api': 7.6.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/components': 7.6.20(@types/react-dom@17.0.25)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
@@ -21271,7 +21342,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/preset-env': 7.26.7(@babel/core@7.28.0)
-      '@babel/types': 7.28.1
+      '@babel/types': 7.27.6
       '@ndelangen/get-tarball': 3.0.9
       '@storybook/codemod': 7.6.20
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
@@ -21327,7 +21398,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/preset-env': 7.26.7(@babel/core@7.28.0)
-      '@babel/types': 7.28.1
+      '@babel/types': 7.27.6
       '@storybook/csf': 0.1.12
       '@storybook/csf-tools': 7.6.20
       '@storybook/node-logger': 7.6.20
@@ -21459,10 +21530,10 @@ snapshots:
 
   '@storybook/csf-tools@7.6.20':
     dependencies:
-      '@babel/generator': 7.28.0
-      '@babel/parser': 7.28.0
+      '@babel/generator': 7.27.5
+      '@babel/parser': 7.27.5
       '@babel/traverse': 7.27.4
-      '@babel/types': 7.28.1
+      '@babel/types': 7.27.6
       '@storybook/csf': 0.1.12
       '@storybook/types': 7.6.20
       fs-extra: 11.3.0
@@ -21659,7 +21730,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.16(typescript@5.8.3)
-      vue-component-type-helpers: 3.0.4
+      vue-component-type-helpers: 2.2.8
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -22406,11 +22477,21 @@ snapshots:
     transitivePeerDependencies:
       - vue
 
-  '@unocss/astro@66.2.2(vue@3.5.17(typescript@5.9.2))':
+  '@unocss/astro@66.2.2(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))':
     dependencies:
       '@unocss/core': 66.2.2
       '@unocss/reset': 66.2.2
-      '@unocss/vite': 66.2.2(vue@3.5.17(typescript@5.9.2))
+      '@unocss/vite': 66.2.2(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))
+    optionalDependencies:
+      vite: 7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1)
+    transitivePeerDependencies:
+      - vue
+
+  '@unocss/astro@66.2.2(vue@3.5.17(typescript@5.8.3))':
+    dependencies:
+      '@unocss/core': 66.2.2
+      '@unocss/reset': 66.2.2
+      '@unocss/vite': 66.2.2(vue@3.5.17(typescript@5.8.3))
     transitivePeerDependencies:
       - vue
 
@@ -22610,6 +22691,17 @@ snapshots:
     transitivePeerDependencies:
       - vue
 
+  '@unocss/inspector@66.2.2(vue@3.5.17(typescript@5.8.3))':
+    dependencies:
+      '@unocss/core': 66.2.2
+      '@unocss/rule-utils': 66.2.2
+      colorette: 2.0.20
+      gzip-size: 6.0.0
+      sirv: 3.0.1
+      vue-flow-layout: 0.1.1(vue@3.5.17(typescript@5.8.3))
+    transitivePeerDependencies:
+      - vue
+
   '@unocss/inspector@66.2.2(vue@3.5.17(typescript@5.9.2))':
     dependencies:
       '@unocss/core': 66.2.2
@@ -22643,6 +22735,54 @@ snapshots:
     transitivePeerDependencies:
       - vue
 
+  '@unocss/nuxt@66.2.2(magicast@0.3.5)(postcss@8.5.3)(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))(webpack@5.91.0(@swc/core@1.7.10))':
+    dependencies:
+      '@nuxt/kit': 3.17.5(magicast@0.3.5)
+      '@unocss/config': 66.2.2
+      '@unocss/core': 66.2.2
+      '@unocss/preset-attributify': 66.2.2
+      '@unocss/preset-icons': 66.2.2
+      '@unocss/preset-tagify': 66.2.2
+      '@unocss/preset-typography': 66.2.2
+      '@unocss/preset-uno': 66.2.2
+      '@unocss/preset-web-fonts': 66.2.2
+      '@unocss/preset-wind': 66.2.2
+      '@unocss/reset': 66.2.2
+      '@unocss/vite': 66.2.2(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))
+      '@unocss/webpack': 66.2.2(webpack@5.91.0(@swc/core@1.7.10))
+      unocss: 66.2.2(@unocss/webpack@66.2.2(webpack@5.91.0(@swc/core@1.7.10)))(postcss@8.5.3)(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))
+    transitivePeerDependencies:
+      - magicast
+      - postcss
+      - supports-color
+      - vite
+      - vue
+      - webpack
+
+  '@unocss/nuxt@66.2.2(magicast@0.3.5)(postcss@8.5.3)(vue@3.5.17(typescript@5.8.3))(webpack@5.91.0(@swc/core@1.7.10))':
+    dependencies:
+      '@nuxt/kit': 3.17.5(magicast@0.3.5)
+      '@unocss/config': 66.2.2
+      '@unocss/core': 66.2.2
+      '@unocss/preset-attributify': 66.2.2
+      '@unocss/preset-icons': 66.2.2
+      '@unocss/preset-tagify': 66.2.2
+      '@unocss/preset-typography': 66.2.2
+      '@unocss/preset-uno': 66.2.2
+      '@unocss/preset-web-fonts': 66.2.2
+      '@unocss/preset-wind': 66.2.2
+      '@unocss/reset': 66.2.2
+      '@unocss/vite': 66.2.2(vue@3.5.17(typescript@5.8.3))
+      '@unocss/webpack': 66.2.2(webpack@5.91.0(@swc/core@1.7.10))
+      unocss: 66.2.2(@unocss/webpack@66.2.2(webpack@5.91.0(@swc/core@1.7.10)))(postcss@8.5.3)(vue@3.5.17(typescript@5.8.3))
+    transitivePeerDependencies:
+      - magicast
+      - postcss
+      - supports-color
+      - vite
+      - vue
+      - webpack
+
   '@unocss/nuxt@66.2.2(magicast@0.3.5)(postcss@8.5.3)(vue@3.5.17(typescript@5.9.2))(webpack@5.91.0(@swc/core@1.7.10))':
     dependencies:
       '@nuxt/kit': 3.17.5(magicast@0.3.5)
@@ -22656,7 +22796,7 @@ snapshots:
       '@unocss/preset-web-fonts': 66.2.2
       '@unocss/preset-wind': 66.2.2
       '@unocss/reset': 66.2.2
-      '@unocss/vite': 66.2.2(vue@3.5.17(typescript@5.9.2))
+      '@unocss/vite': 66.2.2(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))
       '@unocss/webpack': 66.2.2(webpack@5.91.0(@swc/core@1.7.10))
       unocss: 66.2.2(@unocss/webpack@66.2.2(webpack@5.91.0(@swc/core@1.7.10)))(postcss@8.5.3)(vue@3.5.17(typescript@5.9.2))
     transitivePeerDependencies:
@@ -23063,7 +23203,7 @@ snapshots:
 
   '@unocss/rule-utils@66.2.2':
     dependencies:
-      '@unocss/core': 66.3.3
+      '@unocss/core': 66.2.2
       magic-string: 0.30.17
 
   '@unocss/rule-utils@66.3.3':
@@ -23232,12 +23372,27 @@ snapshots:
     transitivePeerDependencies:
       - vue
 
-  '@unocss/vite@66.2.2(vue@3.5.17(typescript@5.9.2))':
+  '@unocss/vite@66.2.2(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@unocss/config': 66.2.2
       '@unocss/core': 66.2.2
       '@unocss/inspector': 66.2.2(vue@3.5.17(typescript@5.9.2))
+      chokidar: 3.6.0
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      tinyglobby: 0.2.14
+      unplugin-utils: 0.2.4
+      vite: 7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1)
+    transitivePeerDependencies:
+      - vue
+
+  '@unocss/vite@66.2.2(vue@3.5.17(typescript@5.8.3))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@unocss/config': 66.2.2
+      '@unocss/core': 66.2.2
+      '@unocss/inspector': 66.2.2(vue@3.5.17(typescript@5.8.3))
       chokidar: 3.6.0
       magic-string: 0.30.17
       pathe: 2.0.3
@@ -23979,6 +24134,18 @@ snapshots:
     transitivePeerDependencies:
       - vite
 
+  '@vue/devtools-core@7.7.7(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))':
+    dependencies:
+      '@vue/devtools-kit': 7.7.7
+      '@vue/devtools-shared': 7.7.7
+      mitt: 3.0.1
+      nanoid: 5.1.5
+      pathe: 2.0.3
+      vite-hot-client: 2.0.4(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))
+      vue: 3.5.17(typescript@5.9.2)
+    transitivePeerDependencies:
+      - vite
+
   '@vue/devtools-core@7.7.7(vue@3.5.17(typescript@5.9.2))':
     dependencies:
       '@vue/devtools-kit': 7.7.7
@@ -24208,13 +24375,13 @@ snapshots:
 
   '@vueuse/metadata@13.5.0': {}
 
-  '@vueuse/nuxt@13.3.0(magicast@0.3.5)(nuxt@4.0.1(@biomejs/biome@1.8.3)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vercel/blob@1.0.2)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(encoding@0.1.13)(eslint@9.29.0(jiti@2.4.2))(ioredis@5.6.1)(less@4.2.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.43.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(typescript@5.9.2)(vue-tsc@2.2.10(typescript@5.9.2))(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))':
+  '@vueuse/nuxt@13.3.0(magicast@0.3.5)(nuxt@4.0.1(@biomejs/biome@1.8.3)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vercel/blob@1.0.2)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(encoding@0.1.13)(eslint@9.29.0(jiti@2.4.2))(ioredis@5.6.1)(less@4.2.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.43.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(typescript@5.9.2)(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue-tsc@2.2.10(typescript@5.9.2))(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))':
     dependencies:
       '@nuxt/kit': 3.17.5(magicast@0.3.5)
       '@vueuse/core': 13.3.0(vue@3.5.17(typescript@5.9.2))
       '@vueuse/metadata': 13.3.0
       local-pkg: 1.1.1
-      nuxt: 4.0.1(@biomejs/biome@1.8.3)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vercel/blob@1.0.2)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(encoding@0.1.13)(eslint@9.29.0(jiti@2.4.2))(ioredis@5.6.1)(less@4.2.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.43.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(typescript@5.9.2)(vue-tsc@2.2.10(typescript@5.9.2))(yaml@2.7.1)
+      nuxt: 4.0.1(@biomejs/biome@1.8.3)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vercel/blob@1.0.2)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(encoding@0.1.13)(eslint@9.29.0(jiti@2.4.2))(ioredis@5.6.1)(less@4.2.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.43.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(typescript@5.9.2)(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue-tsc@2.2.10(typescript@5.9.2))(yaml@2.7.1)
       vue: 3.5.17(typescript@5.9.2)
     transitivePeerDependencies:
       - magicast
@@ -24611,10 +24778,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  aria-hidden@1.2.6:
-    dependencies:
-      tslib: 2.8.1
-
   aria-query@5.1.3:
     dependencies:
       deep-equal: 2.2.3
@@ -24664,7 +24827,7 @@ snapshots:
 
   ast-v8-to-istanbul@0.3.3:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/trace-mapping': 0.3.25
       estree-walker: 3.0.3
       js-tokens: 9.0.1
 
@@ -24961,7 +25124,7 @@ snapshots:
 
   babel-walk@3.0.0-canary-5:
     dependencies:
-      '@babel/types': 7.28.1
+      '@babel/types': 7.27.6
 
   bail@1.0.5: {}
 
@@ -25307,7 +25470,7 @@ snapshots:
 
   chokidar@4.0.1:
     dependencies:
-      readdirp: 4.0.1
+      readdirp: 4.1.2
 
   chokidar@4.0.3:
     dependencies:
@@ -25540,8 +25703,8 @@ snapshots:
 
   constantinople@4.0.1:
     dependencies:
-      '@babel/parser': 7.28.0
-      '@babel/types': 7.28.1
+      '@babel/parser': 7.27.5
+      '@babel/types': 7.27.6
 
   content-disposition@0.5.4:
     dependencies:
@@ -27939,7 +28102,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.27.5
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.2
@@ -27954,7 +28117,7 @@ snapshots:
 
   istanbul-lib-source-maps@5.0.6:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/trace-mapping': 0.3.25
       debug: 4.4.1(supports-color@10.0.0)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
@@ -28084,14 +28247,14 @@ snapshots:
   jscodeshift@0.15.2(@babel/preset-env@7.26.7(@babel/core@7.28.0)):
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.27.5
       '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.28.0)
       '@babel/plugin-transform-modules-commonjs': 7.26.3(@babel/core@7.28.0)
       '@babel/plugin-transform-nullish-coalescing-operator': 7.26.6(@babel/core@7.28.0)
       '@babel/plugin-transform-optional-chaining': 7.25.9(@babel/core@7.28.0)
       '@babel/plugin-transform-private-methods': 7.25.9(@babel/core@7.28.0)
       '@babel/preset-flow': 7.25.9(@babel/core@7.28.0)
-      '@babel/preset-typescript': 7.26.0(@babel/core@7.28.0)
+      '@babel/preset-typescript': 7.27.0(@babel/core@7.28.0)
       '@babel/register': 7.25.9(@babel/core@7.28.0)
       babel-core: 7.0.0-bridge.0(@babel/core@7.28.0)
       chalk: 4.1.2
@@ -29970,6 +30133,129 @@ snapshots:
       - xml2js
       - yaml
 
+  nuxt@4.0.1(@biomejs/biome@1.8.3)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vercel/blob@1.0.2)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(encoding@0.1.13)(eslint@9.29.0(jiti@2.4.2))(ioredis@5.6.1)(less@4.2.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.43.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(typescript@5.9.2)(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue-tsc@2.2.10(typescript@5.9.2))(yaml@2.7.1):
+    dependencies:
+      '@nuxt/cli': 3.26.4(magicast@0.3.5)
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/devtools': 2.6.2(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))
+      '@nuxt/kit': 4.0.1(magicast@0.3.5)
+      '@nuxt/schema': 4.0.1
+      '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
+      '@nuxt/vite-builder': 4.0.1(@biomejs/biome@1.8.3)(@types/node@22.13.14)(eslint@9.29.0(jiti@2.4.2))(less@4.2.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.43.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(typescript@5.9.2)(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.17(typescript@5.9.2))(yaml@2.7.1)
+      '@unhead/vue': 2.0.12(vue@3.5.17(typescript@5.9.2))
+      '@vue/shared': 3.5.17
+      c12: 3.1.0(magicast@0.3.5)
+      chokidar: 4.0.3
+      compatx: 0.2.0
+      consola: 3.4.2
+      cookie-es: 2.0.0
+      defu: 6.1.4
+      destr: 2.0.5
+      devalue: 5.1.1
+      errx: 0.1.0
+      esbuild: 0.25.5
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      exsolve: 1.0.7
+      h3: 1.15.3
+      hookable: 5.5.3
+      ignore: 7.0.5
+      impound: 1.0.0
+      jiti: 2.4.2
+      klona: 2.0.6
+      knitwork: 1.2.0
+      magic-string: 0.30.17
+      mlly: 1.7.4
+      mocked-exports: 0.1.1
+      nanotar: 0.2.0
+      nitropack: 2.12.3(@netlify/blobs@9.1.2)(@vercel/blob@1.0.2)(encoding@0.1.13)
+      nypm: 0.6.0
+      ofetch: 1.4.1
+      ohash: 2.0.11
+      on-change: 5.0.1
+      oxc-minify: 0.77.3
+      oxc-parser: 0.77.3
+      oxc-transform: 0.77.3
+      oxc-walker: 0.4.0(oxc-parser@0.77.3)
+      pathe: 2.0.3
+      perfect-debounce: 1.0.0
+      pkg-types: 2.2.0
+      radix3: 1.1.2
+      scule: 1.3.0
+      semver: 7.7.2
+      std-env: 3.9.0
+      strip-literal: 3.0.0
+      tinyglobby: 0.2.14
+      ufo: 1.6.1
+      ultrahtml: 1.6.0
+      uncrypto: 0.1.3
+      unctx: 2.4.1
+      unimport: 5.1.0
+      unplugin: 2.3.5
+      unplugin-vue-router: 0.14.0(@vue/compiler-sfc@3.5.17)(vue-router@4.5.1(vue@3.5.17(typescript@5.9.2)))(vue@3.5.17(typescript@5.9.2))
+      unstorage: 1.16.1(@netlify/blobs@9.1.2)(@vercel/blob@1.0.2)(db0@0.3.2)(ioredis@5.6.1)
+      untyped: 2.0.0
+      vue: 3.5.17(typescript@5.9.2)
+      vue-bundle-renderer: 2.1.1
+      vue-devtools-stub: 0.1.0
+      vue-router: 4.5.1(vue@3.5.17(typescript@5.9.2))
+    optionalDependencies:
+      '@parcel/watcher': 2.5.1
+      '@types/node': 22.13.14
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@biomejs/biome'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/kv'
+      - '@vue/compiler-sfc'
+      - aws4fetch
+      - better-sqlite3
+      - bufferutil
+      - db0
+      - drizzle-orm
+      - encoding
+      - eslint
+      - idb-keyval
+      - ioredis
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - mysql2
+      - optionator
+      - rolldown
+      - rollup
+      - sass
+      - sass-embedded
+      - sqlite3
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - vite
+      - vls
+      - vti
+      - vue-tsc
+      - xml2js
+      - yaml
+
   nuxt@4.0.1(@biomejs/biome@1.8.3)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vercel/blob@1.0.2)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(encoding@0.1.13)(eslint@9.29.0(jiti@2.4.2))(ioredis@5.6.1)(less@4.2.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.43.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(typescript@5.9.2)(vue-tsc@2.2.10(typescript@5.9.2))(yaml@2.7.1):
     dependencies:
       '@nuxt/cli': 3.26.4(magicast@0.3.5)
@@ -31489,8 +31775,6 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
-
-  readdirp@4.0.1: {}
 
   readdirp@4.1.2: {}
 
@@ -33471,9 +33755,9 @@ snapshots:
       - supports-color
       - vue
 
-  unocss@66.2.2(@unocss/webpack@66.2.2(webpack@5.91.0(@swc/core@1.7.10)))(postcss@8.5.3)(vue@3.5.17(typescript@5.9.2)):
+  unocss@66.2.2(@unocss/webpack@66.2.2(webpack@5.91.0(@swc/core@1.7.10)))(postcss@8.5.3)(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2)):
     dependencies:
-      '@unocss/astro': 66.2.2(vue@3.5.17(typescript@5.9.2))
+      '@unocss/astro': 66.2.2(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))
       '@unocss/cli': 66.2.2
       '@unocss/core': 66.2.2
       '@unocss/postcss': 66.2.2(postcss@8.5.3)
@@ -33491,7 +33775,64 @@ snapshots:
       '@unocss/transformer-compile-class': 66.2.2
       '@unocss/transformer-directives': 66.2.2
       '@unocss/transformer-variant-group': 66.2.2
-      '@unocss/vite': 66.2.2(vue@3.5.17(typescript@5.9.2))
+      '@unocss/vite': 66.2.2(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))
+    optionalDependencies:
+      '@unocss/webpack': 66.2.2(webpack@5.91.0(@swc/core@1.7.10))
+      vite: 7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1)
+    transitivePeerDependencies:
+      - postcss
+      - supports-color
+      - vue
+
+  unocss@66.2.2(@unocss/webpack@66.2.2(webpack@5.91.0(@swc/core@1.7.10)))(postcss@8.5.3)(vue@3.5.17(typescript@5.8.3)):
+    dependencies:
+      '@unocss/astro': 66.2.2(vue@3.5.17(typescript@5.8.3))
+      '@unocss/cli': 66.2.2
+      '@unocss/core': 66.2.2
+      '@unocss/postcss': 66.2.2(postcss@8.5.3)
+      '@unocss/preset-attributify': 66.2.2
+      '@unocss/preset-icons': 66.2.2
+      '@unocss/preset-mini': 66.2.2
+      '@unocss/preset-tagify': 66.2.2
+      '@unocss/preset-typography': 66.2.2
+      '@unocss/preset-uno': 66.2.2
+      '@unocss/preset-web-fonts': 66.2.2
+      '@unocss/preset-wind': 66.2.2
+      '@unocss/preset-wind3': 66.2.2
+      '@unocss/preset-wind4': 66.2.2
+      '@unocss/transformer-attributify-jsx': 66.2.2
+      '@unocss/transformer-compile-class': 66.2.2
+      '@unocss/transformer-directives': 66.2.2
+      '@unocss/transformer-variant-group': 66.2.2
+      '@unocss/vite': 66.2.2(vue@3.5.17(typescript@5.8.3))
+    optionalDependencies:
+      '@unocss/webpack': 66.2.2(webpack@5.91.0(@swc/core@1.7.10))
+    transitivePeerDependencies:
+      - postcss
+      - supports-color
+      - vue
+
+  unocss@66.2.2(@unocss/webpack@66.2.2(webpack@5.91.0(@swc/core@1.7.10)))(postcss@8.5.3)(vue@3.5.17(typescript@5.9.2)):
+    dependencies:
+      '@unocss/astro': 66.2.2(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))
+      '@unocss/cli': 66.2.2
+      '@unocss/core': 66.2.2
+      '@unocss/postcss': 66.2.2(postcss@8.5.3)
+      '@unocss/preset-attributify': 66.2.2
+      '@unocss/preset-icons': 66.2.2
+      '@unocss/preset-mini': 66.2.2
+      '@unocss/preset-tagify': 66.2.2
+      '@unocss/preset-typography': 66.2.2
+      '@unocss/preset-uno': 66.2.2
+      '@unocss/preset-web-fonts': 66.2.2
+      '@unocss/preset-wind': 66.2.2
+      '@unocss/preset-wind3': 66.2.2
+      '@unocss/preset-wind4': 66.2.2
+      '@unocss/transformer-attributify-jsx': 66.2.2
+      '@unocss/transformer-compile-class': 66.2.2
+      '@unocss/transformer-directives': 66.2.2
+      '@unocss/transformer-variant-group': 66.2.2
+      '@unocss/vite': 66.2.2(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2))
     optionalDependencies:
       '@unocss/webpack': 66.2.2(webpack@5.91.0(@swc/core@1.7.10))
     transitivePeerDependencies:
@@ -34093,6 +34434,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  vite-plugin-inspect@11.3.0(@nuxt/kit@3.17.7(magicast@0.3.5)):
+    dependencies:
+      ansis: 4.1.0
+      debug: 4.4.1(supports-color@10.0.0)
+      error-stack-parser-es: 1.0.5
+      ohash: 2.0.11
+      open: 10.1.2
+      perfect-debounce: 1.0.0
+      sirv: 3.0.1
+      unplugin-utils: 0.2.4
+      vite-dev-rpc: 1.1.0(vite@6.3.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))
+    optionalDependencies:
+      '@nuxt/kit': 3.17.7(magicast@0.3.5)
+    transitivePeerDependencies:
+      - supports-color
+
   vite-plugin-inspect@11.3.0(@nuxt/kit@3.17.7(magicast@0.3.5))(vite@6.3.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1)):
     dependencies:
       ansis: 4.1.0
@@ -34203,13 +34560,14 @@ snapshots:
       vite: 7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1)
       vue: 3.5.17(typescript@5.8.3)
 
-  vite-plugin-vue-tracer@1.0.0(vue@3.5.17(typescript@5.9.2)):
+  vite-plugin-vue-tracer@1.0.0(vite@7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1))(vue@3.5.17(typescript@5.9.2)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.7
       magic-string: 0.30.17
       pathe: 2.0.3
       source-map-js: 1.2.1
+      vite: 7.0.5(@types/node@22.13.14)(jiti@2.4.2)(less@4.2.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.19.2)(yaml@2.7.1)
       vue: 3.5.17(typescript@5.9.2)
 
   vite@5.4.19(@types/node@22.13.14)(less@4.2.0)(sass@1.89.2)(terser@5.43.0):
@@ -34582,7 +34940,7 @@ snapshots:
 
   vue-component-type-helpers@2.0.7: {}
 
-  vue-component-type-helpers@3.0.4: {}
+  vue-component-type-helpers@2.2.8: {}
 
   vue-demi@0.13.11(vue@3.5.17(typescript@5.8.3)):
     dependencies:
@@ -34592,8 +34950,8 @@ snapshots:
 
   vue-docgen-api@4.79.2(vue@3.5.16(typescript@5.8.3)):
     dependencies:
-      '@babel/parser': 7.28.0
-      '@babel/types': 7.28.1
+      '@babel/parser': 7.27.5
+      '@babel/types': 7.27.6
       '@vue/compiler-dom': 3.5.17
       '@vue/compiler-sfc': 3.5.17
       ast-types: 0.16.1
@@ -34917,8 +35275,8 @@ snapshots:
 
   with@7.0.2:
     dependencies:
-      '@babel/parser': 7.28.0
-      '@babel/types': 7.28.1
+      '@babel/parser': 7.27.5
+      '@babel/types': 7.27.6
       assert-never: 1.4.0
       babel-walk: 3.0.0-canary-5
 

--- a/templates/vue-demo-store/README.md
+++ b/templates/vue-demo-store/README.md
@@ -45,6 +45,12 @@ To generate your own types use [@shopware/api-gen](https://www.npmjs.com/package
 > [!NOTE]
 > Do not edit your `storeApiSchema.d.ts` file. It will be overwritten on the next schema generation. Instead use your `shopware.d.ts` file to extend types.
 
+## Styling and Shopping Experiences integration
+
+This tempalte uses [UnoCSS](https://unocss.dev/) for styling, which is a utility-first CSS framework. It is configured to use the [Tailwind CSS](https://tailwindcss.com/) classes. 
+
+The template also includes a [CMS Base nuxt layer](https://www.npmjs.com/package/@shopware/cms-base-layer) to provide the CMS components for Shopping Experiences integration. The layer is registered in the `nuxt.config.ts` file. In order to override the default Tailwind CSS configuration, you can create your own `uno.config.ts` file in the root of your project and extend the default configuration.
+
 ## Production
 
 Refer to to the Shopware documentation for best practices on deploying a production JavaScript application with Shopware: [Best Practices > Deployment](https://frontends.shopware.com/best-practices/deployment.html)

--- a/templates/vue-demo-store/app/components/FrontendDetailPage.vue
+++ b/templates/vue-demo-store/app/components/FrontendDetailPage.vue
@@ -74,13 +74,10 @@ useCmsHead(product, { mainShopTitle: "Shopware Frontends Demo Store" });
 
 <template>
   <LayoutBreadcrumbs />
-  <div v-if="product?.cmsPage" class="container mx-auto bg-white flex flex-col">
+  <div v-if="product?.cmsPage" class="container mx-auto bg-white flex flex-col p-6 md:p-0">
     <CmsPage :content="product.cmsPage" />
   </div>
-  <div
-    v-if="!product?.cmsPage"
-    class="container mx-auto bg-white flex flex-col"
-  >
+  <div v-if="!product?.cmsPage" class="container mx-auto bg-white flex flex-col">
     <!-- Since Shopware Version 6.6.0.0 there should be always a cmsPage for products -->
     <span>😱 cmsPage is missing.</span>
   </div>

--- a/templates/vue-demo-store/app/components/account/order/Status.vue
+++ b/templates/vue-demo-store/app/components/account/order/Status.vue
@@ -8,14 +8,14 @@ const props = defineProps<{
 const statusClass = computed(() => {
   switch (props.state.technicalName) {
     case "completed":
-      return "bg-green-100 text-green-800";
+      return "bg-states-success-container text-states-on-success-container";
     case "open":
     case "in_progress":
-      return "bg-yellow-100 text-yellow-800";
+      return "bg-states-warning-container text-states-on-warning-container";
     case "cancelled":
-      return "bg-red-100 text-red-800";
+      return "bg-states-error-container text-states-on-error-container";
     default:
-      return "bg-gray-100 text-gray-800";
+      return "bg-surface-surface-disabled text-surface-on-surface-disabled";
   }
 });
 </script>

--- a/templates/vue-demo-store/app/pages/checkout/cart.vue
+++ b/templates/vue-demo-store/app/pages/checkout/cart.vue
@@ -76,7 +76,7 @@ const hasItems = computed(() => cartItems.value.length > 0);
         </div>
 
         <NuxtLink
-          class="flex items-center justify-center rounded-md px-6 py-3 text-base font-medium text-white shadow-sm bg-primary hover:bg-dark"
+          class="flex items-center justify-center rounded-md px-6 py-3 text-base font-medium text-white shadow-sm bg-brand-primary hover:bg-dark"
           data-testid="cart-checkout-link"
           :to="formatLink(`/checkout`)"
         >

--- a/templates/vue-demo-store/nuxt.config.ts
+++ b/templates/vue-demo-store/nuxt.config.ts
@@ -117,6 +117,7 @@ export default defineNuxtConfig({
   },
   unocss: {
     // for presets, theme config, ... look at the uno.config.ts file
+    nuxtLayers: true,
   },
   css: [
     "@unocss/reset/tailwind-compat.css", // needed to reset styles see https://unocss.dev/guide/style-reset (@unocss/reset)

--- a/templates/vue-demo-store/uno.config.ts
+++ b/templates/vue-demo-store/uno.config.ts
@@ -1,14 +1,10 @@
 import { helpersCssClasses } from "@shopware/helpers";
+import { type ConfigBase, mergeConfigs } from "@unocss/core";
 import transformerDirectives from "@unocss/transformer-directives";
-import {
-  defineConfig,
-  presetAttributify,
-  presetIcons,
-  presetTypography,
-  presetUno,
-} from "unocss";
+// jump to the base config to see the presets and rules already applied
+import baseConfig from "./.nuxt/uno.config.mjs";
 
-export default defineConfig({
+const templateConfig: ConfigBase = {
   theme: {
     extend: {
       width: "width",
@@ -16,73 +12,96 @@ export default defineConfig({
     },
     // @see https://tailwindcss.com/docs/customizing-colors
     colors: {
-      primary: {
-        DEFAULT: "#0d588f",
-        100: "#dbeafe",
-        200: "#bfdbfe",
-        500: "#3b82f6",
-        600: "#2563eb",
-        700: "#1d4ed8",
-      },
-      secondary: {
-        DEFAULT: "#6b7280",
-        50: "#f9fafb",
-        100: "#f3f4f6",
-        200: "#e5e7eb",
-        300: "#d1d5db",
-        400: "#9ca3af",
-        500: "#6b7280",
-        600: "#475569",
-        700: "#374151",
-        800: "#1e293b",
-        900: "#111827",
-      },
-      light: {
-        DEFAULT: "#5ebbff",
-        200: "#e2e8f0",
-      },
-      dark: {
-        DEFAULT: "#026ebd",
-      },
-      white: {
-        DEFAULT: "#ffffff",
-      },
-      indigo: {
-        DEFAULT: "#6366f1",
-        50: "#f0f5ff",
-        500: "#6366f1",
-        600: "#4f46e5",
-        700: "#4338ca",
-      },
-      green: {
-        DEFAULT: "#22c55e",
-        100: "#dcfce7",
-        200: "#bbf7d0",
-        400: "#4ade80",
-        500: "#22c55e",
-        600: "#16a34a",
-        700: "#15803d",
-        800: "#166534",
-        900: "#14532d",
-      },
-      yellow: {
-        DEFAULT: "#eab308",
-        50: "#fefce8",
-        300: "#fde047",
-      },
+      // Brand Primary Colors (with fallbacks)
+      primary: "#0d588f",
+      "primary-50": "#f0f8ff",
+      "primary-100": "#dbeafe",
+      "primary-200": "#bfdbfe",
+      "primary-300": "#93c5fd",
+      "primary-400": "#60a5fa",
+      "primary-500": "#3b82f6",
+      "primary-600": "#2563eb",
+      "primary-700": "#1d4ed8",
+      "primary-800": "#1e40af",
+      "primary-900": "#1e3a8a",
+      "primary-hover": "#0b4f7a",
+      "brand-primary": "#0d588f",
+      "brand-primary-50": "#f0f8ff",
+      "brand-primary-100": "#dbeafe",
+      "brand-primary-200": "#bfdbfe",
+      "brand-primary-300": "#93c5fd",
+      "brand-primary-400": "#60a5fa",
+      "brand-primary-500": "#3b82f6",
+      "brand-primary-600": "#2563eb",
+      "brand-primary-700": "#1d4ed8",
+      "brand-primary-800": "#1e40af",
+      "brand-primary-900": "#1e3a8a",
+      "brand-primary-hover": "#0b4f7a",
+
+      // Brand Secondary Colors (with fallbacks)
+      secondary: "#6b7280",
+      "secondary-50": "#f9fafb",
+      "secondary-100": "#f3f4f6",
+      "secondary-200": "#e5e7eb",
+      "secondary-300": "#d1d5db",
+      "secondary-400": "#9ca3af",
+      "secondary-500": "#6b7280",
+      "secondary-600": "#475569",
+      "secondary-700": "#374151",
+      "secondary-800": "#1e293b",
+      "secondary-900": "#111827",
+      "secondary-hover": "#5a5f66",
+      "brand-secondary": "#6b7280",
+      "brand-secondary-50": "#f9fafb",
+      "brand-secondary-100": "#f3f4f6",
+      "brand-secondary-200": "#e5e7eb",
+      "brand-secondary-300": "#d1d5db",
+      "brand-secondary-400": "#9ca3af",
+      "brand-secondary-500": "#6b7280",
+      "brand-secondary-600": "#475569",
+      "brand-secondary-700": "#374151",
+      "brand-secondary-800": "#1e293b",
+      "brand-secondary-900": "#111827",
+      "brand-secondary-hover": "#5a5f66",
+      // Accent Colors
+      light: "#5ebbff",
+      "light-200": "#e2e8f0",
+      dark: "#026ebd",
+      white: "#ffffff",
+
+      // Semantic Colors
+      indigo: "#6366f1",
+      "indigo-50": "#f0f5ff",
+      "indigo-500": "#6366f1",
+      "indigo-600": "#4f46e5",
+      "indigo-700": "#4338ca",
+
+      success: "#22c55e",
+      "success-100": "#dcfce7",
+      "success-200": "#bbf7d0",
+      "success-400": "#4ade80",
+      "success-500": "#22c55e",
+      "success-600": "#16a34a",
+      "success-700": "#15803d",
+      "success-800": "#166534",
+      "success-900": "#14532d",
+      warning: "#eab308",
+      "warning-50": "#fefce8",
+      "warning-100": "#fef9c3",
+      "warning-300": "#fde047",
+      "warning-400": "#facc15",
+      "warning-500": "#eab308",
+      "warning-600": "#ca8a04",
+      "warning-700": "#a16207",
+      "warning-800": "#854d0e",
+      "warning-900": "#713f12",
+      // Surface Colors (example for the transformer)
+      "surface-surface": "#ffffff",
+      "surface-surface-variant": "#f5f5f5",
+      "surface-container": "#f0f0f0",
+      "surface-container-high": "#e8e8e8",
     },
   },
-  presets: [
-    presetUno(),
-    presetIcons({
-      collections: {
-        carbon: () =>
-          import("@iconify-json/carbon/icons.json").then((i) => i.default),
-      },
-    }),
-    presetAttributify(),
-    presetTypography(),
-  ],
   transformers: [transformerDirectives()],
   preflights: [
     // preflights can be used to set some base styles
@@ -115,4 +134,6 @@ export default defineConfig({
     },
   ],
   safelist: helpersCssClasses,
-});
+};
+
+export default mergeConfigs([baseConfig, templateConfig]);

--- a/templates/vue-starter-template/README.md
+++ b/templates/vue-starter-template/README.md
@@ -73,3 +73,9 @@ bun run preview
 ```
 
 Check out the [deployment documentation](https://nuxt.com/docs/getting-started/deployment) for more information.
+
+## Styling and Shopping Experiences integration
+
+This tempalte uses [UnoCSS](https://unocss.dev/) for styling, which is a utility-first CSS framework. It is configured to use the [Tailwind CSS](https://tailwindcss.com/) classes. 
+
+The template also includes a [CMS Base nuxt layer](https://www.npmjs.com/package/@shopware/cms-base-layer) to provide the CMS components for Shopping Experiences integration. The layer is registered in the `nuxt.config.ts` file. In order to override the default Tailwind CSS configuration, you can create your own `uno.config.ts` file in the root of your project and extend the default configuration.

--- a/templates/vue-starter-template/app/components/FrontendDetailPage.vue
+++ b/templates/vue-starter-template/app/components/FrontendDetailPage.vue
@@ -74,13 +74,10 @@ useCmsHead(product, { mainShopTitle: "Shopware Frontends Demo Store" });
 
 <template>
   <LayoutBreadcrumbs />
-  <div v-if="product?.cmsPage" class="container mx-auto bg-white flex flex-col">
+  <div v-if="product?.cmsPage" class="container mx-auto bg-white flex flex-col p-6 md:p-0">
     <CmsPage :content="product.cmsPage" />
   </div>
-  <div
-    v-if="!product?.cmsPage"
-    class="container mx-auto bg-white flex flex-col"
-  >
+  <div v-if="!product?.cmsPage" class="container mx-auto bg-white flex flex-col">
     <!-- Since Shopware Version 6.6.0.0 there should be always a cmsPage for products -->
     <span>😱 cmsPage is missing.</span>
   </div>

--- a/templates/vue-starter-template/nuxt.config.ts
+++ b/templates/vue-starter-template/nuxt.config.ts
@@ -24,6 +24,9 @@ export default defineNuxtConfig({
     strict: true,
   },
   css: ["@unocss/reset/tailwind-compat.css"],
+  unocss: {
+    nuxtLayers: true,
+  },
   components: {
     dirs: [
       {

--- a/templates/vue-starter-template/uno.config.ts
+++ b/templates/vue-starter-template/uno.config.ts
@@ -1,14 +1,19 @@
+import { type ConfigBase, mergeConfigs } from "@unocss/core";
 import {
-  defineConfig,
   presetAttributify,
   presetIcons,
   presetTypography,
   presetWind3,
 } from "unocss";
+// jump to the base config to see the presets and rules already applied
+import baseConfig from "./.nuxt/uno.config.mjs";
 
-export default defineConfig({
+const templateConfig: ConfigBase = {
+  // here you can add template-specific configurations
   theme: {
     colors: {
+      // "brand-primary": "#123456", // overwrite base color
+      // "custom-accent": "#FF00FF", // add a new color
       "brand-primary": "#543B95",
       "surface-surface": "#FFFFFF",
       "outline-outline": "#79747E",
@@ -109,4 +114,7 @@ export default defineConfig({
         `,
     },
   ],
-});
+  // and more...
+};
+
+export default mergeConfigs([baseConfig, templateConfig]);


### PR DESCRIPTION
### Description

closes: #1876 #1929 

during the work on the task, some problems were reported for UX team. 
the current design does not reflect the actual shape of nested elements designed in CMS, so that's a temporary state of PDP. 

The main focus was on:
- extendibility of uno config ✅ 
- example on how `SwButton` can be defined in both templates without breaking a view ✅ 


### Type of change

<!-- Comment out the type of change your PR is making -->

<!-- Bug fix (non-breaking change that fixes an issue) -->
-- New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

- [x] docs
- [x] changeset

<!-- Add the todo's that need to be done before merge -->
<!-- Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. -->

<!-- - [ ] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) -->
<!-- - [ ] Documentation added/updated -->
<!-- - [ ] Unit-Tests added/updated -->
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
