### PR TITLE
fix(cms-base-layer): adjust components paths

### DIFF
--- a/.changeset/true-onions-win.md
+++ b/.changeset/true-onions-win.md
@@ -1,0 +1,5 @@
+---
+"@shopware/cms-base-layer": patch
+---
+
+Use proper paths for components configuration

--- a/packages/cms-base-layer/nuxt.config.ts
+++ b/packages/cms-base-layer/nuxt.config.ts
@@ -3,12 +3,11 @@ import { defineNuxtConfig } from "nuxt/config";
 export default defineNuxtConfig({
   components: [
     {
-      path: "./components/public",
+      path: "./app/components/public",
       pathPrefix: false,
-      // global: true,
     },
     {
-      path: "./components/",
+      path: "./app/components/",
       pattern: "Sw*",
       extensions: [".vue"],
       global: false,


### PR DESCRIPTION
### Description

Issue found during testing a stack blitz template, the error says that 

```bash
[nuxt 9:34:29 AM]  WARN  Components directory not found: /home/projects/zzmiowrnrq.github/node_modules/@shopware/cms-base-layer/components/public
```

### Type of change

<!-- Comment out the type of change your PR is making -->

 Bug fix (non-breaking change that fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

<!-- Add the todo's that need to be done before merge -->
<!-- Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. -->

<!-- - [ ] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) -->
<!-- - [ ] Documentation added/updated -->
<!-- - [ ] Unit-Tests added/updated -->
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
