### PR TITLE
feat: remove refreshing session context before login

### DIFF
--- a/.changeset/lazy-deer-unite.md
+++ b/.changeset/lazy-deer-unite.md
@@ -1,0 +1,5 @@
+---
+"vue-demo-store": patch
+---
+
+Remove refreshing session context before login

--- a/templates/vue-demo-store/app/components/account/AccountLoginForm.vue
+++ b/templates/vue-demo-store/app/components/account/AccountLoginForm.vue
@@ -4,18 +4,19 @@ import type { ApiError } from "@shopware/api-client";
 import { useTemplateRef } from "vue";
 
 const emits = defineEmits<{
-  (e: "success"): void;
-  (e: "close"): void;
+  success: [];
+  close: [];
 }>();
+
 const router = useRouter();
 const { isLoggedIn, login } = useUser();
 const { t } = useI18n();
-const { refreshSessionContext } = useSessionContext();
 const { mergeWishlistProducts } = useWishlist();
 const { pushSuccess } = useNotifications();
 const localePath = useLocalePath();
 const { formatLink } = useInternationalization(localePath);
 const loginErrors = ref<string[]>([]);
+const { resolveApiErrors } = useApiErrorsResolver("account_login");
 
 const formData = ref({
   username: "",
@@ -23,18 +24,17 @@ const formData = ref({
   remember: true,
 });
 
-const goToRegister = () => {
+const emailInputElement = useTemplateRef("emailInputElement");
+useFocus(emailInputElement, { initialValue: true });
+
+function goToRegister() {
   emits("close");
   router.push(formatLink("/register"));
-};
+}
 
-const { resolveApiErrors } = useApiErrorsResolver("account_login");
-
-const invokeLogin = async (): Promise<void> => {
+async function invokeLogin(): Promise<void> {
   loginErrors.value = [];
   try {
-    // TODO: remove this line once the https://github.com/shopware/frontends/issues/112 issue is fixed
-    await refreshSessionContext();
     await login(formData.value);
     emits("success");
     pushSuccess(t("account.messages.loggedInSuccess"));
@@ -45,10 +45,7 @@ const invokeLogin = async (): Promise<void> => {
       loginErrors.value = resolveApiErrors(error.details.errors as ApiError[]);
     }
   }
-};
-
-const emailInputElement = useTemplateRef("emailInputElement");
-useFocus(emailInputElement, { initialValue: true });
+}
 </script>
 <template>
   <div


### PR DESCRIPTION
### Description

* Login flow simplification:
  * Removed the call to `refreshSessionContext` before invoking `login` in `AccountLoginForm.vue`, as it is no longer needed.
  * Updated the emits definition and refactored related code for clarity and consistency in `AccountLoginForm.vue`. [[1]](diffhunk://#diff-1d94aa6bc24bdab65397d036cc8583da7b837227625ee561b944019b081e41faL7-L37) [[2]](diffhunk://#diff-1d94aa6bc24bdab65397d036cc8583da7b837227625ee561b944019b081e41faL48-R48)


### Type of change

<!-- Comment out the type of change your PR is making -->

<!-- Bug fix (non-breaking change that fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

<!-- Add the todo's that need to be done before merge -->
<!-- Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. -->

<!-- - [ ] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) -->
<!-- - [ ] Documentation added/updated -->
<!-- - [ ] Unit-Tests added/updated -->
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
