### PR TITLE
docs(api-client): hook registration syntax in README.md

### DIFF
--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -129,7 +129,7 @@ export const adminApiClient = createAdminAPIClient<operations>({
   sessionData: JSON.parse(Cookies.get("sw-admin-session-data") || "{}"),
 });
 
-adminApiClient.hooks("onAuthChange", (sessionData) => {
+adminApiClient.hook("onAuthChange", (sessionData) => {
   Cookies.set("sw-admin-session-data", JSON.stringify(sessionData), {
     expires: 1, // days
     path: "/",


### PR DESCRIPTION
minor typo in code example fixed
