### PR TITLE
feat(security): set minimumReleaseAge for packages

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-pnpm run lint
-pnpm generateAutomd
+node --run lint
+node --run generateAutomd
 biome format --write --no-errors-on-unmatched $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
 git update-index --again

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "engines": {
     "node": "^20.x || ^22.x"
   },
-  "packageManager": "pnpm@10.2.0",
+  "packageManager": "pnpm@10.16.0",
   "pnpm": {
     "overrides": {
       "@antfu/utils": "^0.7.10",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,8 @@ packages:
 
 templates:
   - "templates/*"
+
+# Reduciing the risk of installing fresh compromised packages before detected
+minimumReleaseAge: 4320 ## 3 days
+minimumReleaseAgeExclude:
+- '@shopware/*'


### PR DESCRIPTION
### Description

Do not install packages right after release and allow npm registry to take it down before it hits the repo:
https://pnpm.io/settings#minimumreleaseage