### PR TITLE
feat: add CmsBlockImageGalleryBig component - fixes #1306

### DIFF
--- a/packages/cms-base-layer/app/components/public/cms/block/CmsBlockImageGalleryBig.vue
+++ b/packages/cms-base-layer/app/components/public/cms/block/CmsBlockImageGalleryBig.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import type { CmsBlockImageGalleryBig } from "@shopware/composables";
+import { useCmsBlock } from "#imports";
+
+const props = defineProps<{
+  content: CmsBlockImageGalleryBig;
+}>();
+
+const { getSlotContent } = useCmsBlock(props.content);
+
+const cmsContent = getSlotContent("imageGallery");
+</script>
+
+<template>
+  <div class="cms-block-image-gallery-big">
+    <CmsGenericElement :content="cmsContent" />
+  </div>
+</template>
+
+<style scoped>
+.cms-block-image-gallery-big {
+  @apply w-full;
+}
+
+.cms-block-image-gallery-big :deep(.cms-element-image-gallery) {
+  @apply max-w-screen-xl mx-auto;
+}
+
+/* Enhanced styling for the big gallery version */
+.cms-block-image-gallery-big :deep(.gallery-slider) {
+  @apply max-h-[800px];
+}
+
+.cms-block-image-gallery-big :deep(img) {
+  @apply object-contain mx-auto;
+}
+
+/* Larger navigation controls */
+.cms-block-image-gallery-big :deep(.gallery-slider-controls) {
+  @apply scale-125;
+}
+</style>

--- a/packages/composables/src/types/cmsBlockTypes.ts
+++ b/packages/composables/src/types/cmsBlockTypes.ts
@@ -79,3 +79,5 @@ export type CmsBlockCrossSelling = BlockType<"content">;
 
 export type CmsBlockForm = BlockType<"content">;
 export type CmsBlockHtml = BlockType<"content">;
+
+export type CmsBlockImageGalleryBig = BlockType<"imageGallery">;


### PR DESCRIPTION
### Description

This PR adds support for the CmsBlockImageGalleryBig CMS component that was previously missing from the Shopware Frontends framework. 
When this component was encountered in a Shopware CMS page, it would show the error:

Component not resolved: CmsBlockImageGalleryBig

The implementation follows the same pattern as the existing CmsBlockImageGallery component but adds enhanced styling for a larger gallery presentation.

closes #1306

### Type of change

New feature (non-breaking change which adds functionality)

### Additional context

The component uses the same "imageGallery" slot type as the regular gallery component but includes specific styling to make images display larger and more prominently. It maintains compatibility with existing CMS content structure while providing an enhanced visual presentation.


