### PR TITLE
fix(docs): proper path resolving - fallback

### DIFF
--- a/apps/docs/.vitepress/theme/typer/cms-base-plugin.ts
+++ b/apps/docs/.vitepress/theme/typer/cms-base-plugin.ts
@@ -1,15 +1,9 @@
 import { resolve } from "node:path";
-import { findSync } from "find-in-files";
 // @ts-nocheck
 import type { Plugin } from "vite";
 
 import { readFileSync, readdirSync } from "node:fs";
-import {
-  getToggleContainer,
-  getWrappedCodeBlock,
-  prepareGithubPermalink,
-  replacer,
-} from "./utils";
+import { prepareGithubPermalink, replacer } from "./utils";
 
 export async function CmsBaseReference({
   projectRootDir,


### PR DESCRIPTION
### Description

solving vitepress build issue occuring in vercel:

```bash
docs:build: build error:
docs:build: [cms-base-reference-md-transform] Cannot read properties of undefined (reading 'split')
docs:build: file: /vercel/path0/apps/docs/src/packages/cms-base-layer.md
docs:build: [cms-base-reference-md-transform] Cannot read properties of undefined (reading 'split')
docs:build: file: /vercel/path0/apps/docs/src/packages/cms-base-layer.md
docs:build:     at Object.transform (file:///vercel/path0/apps/docs/.vitepress/config.ts.timestamp-1764321394754-a67ab4cba36548.mjs:92:35)
docs:build:     at file:///vercel/path0/node_modules/.pnpm/rollup@4.53.2/node_modules/rollup/dist/es/shared/node-entry.js:22437:40
docs:build:  ELIFECYCLE  Command failed with exit code 1.
docs:build: ERROR: command finished with error: command (/vercel/path0/apps/docs) /pnpm9/node_modules/.bin/pnpm run build exited (1)
docs#build: command (/vercel/path0/apps/docs) /pnpm9/node_modules/.bin/pnpm run build exited (1)
  Tasks:    3 successful, 4 total
 Cached:    3 cached, 4 total
   Time:    6.908s 
Summary:    /vercel/path0/.turbo/runs/366K5n2FImlsGVgHbPYe1jaiKY2.json
 Failed:    docs#build
 ERROR  run failed: command  exited (1)
 ELIFECYCLE  Command failed with exit code 1.
Error: Command "cd ../../ && pnpm run build --filter=docs" exited with 1
```

### Type of change

<!-- Comment out the type of change your PR is making -->

Bug fix (non-breaking change that fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

<!-- Add the todo's that need to be done before merge -->
<!-- Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. -->
