### PR TITLE
docs: add troubleshooting section for missing #import

### DIFF
--- a/apps/docs/src/resources/troubleshooting.md
+++ b/apps/docs/src/resources/troubleshooting.md
@@ -180,3 +180,45 @@ For more details on BFCache, refer to the [MDN Web Docs](https://developer.mozil
 ## CORS (Cross-Origin Resource Sharing) Issues
 
 See the [CORS](./troubleshooting/CORS) page for more information on how to handle CORS issues in your project.
+
+## [unimport] failed to find "createShopwareContext" imported from "#imports"
+
+### Problem
+
+This error occurs when `@shopware/nuxt-module` is added to your project, but `@shopware/composables/nuxt-layer` is not extended in your Nuxt configuration.
+
+### Why it happens
+
+The `@shopware/nuxt-module` plugin imports `createShopwareContext` from the `#imports` alias. The `@shopware/composables/nuxt-layer` is responsible for configuring Nuxt's auto-import system and TypeScript paths to make composables exports available via `#imports`.
+
+When you use Nuxt layers, the layer system merges TypeScript configuration files from both the composables layer and your project. This merge adds the composables exports to the `#imports` alias scope. Without extending the composables layer, these exports are not available, causing the import error.
+
+### Solution
+
+Extend `@shopware/composables/nuxt-layer` in your `nuxt.config.ts`:
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  extends: ["@shopware/composables/nuxt-layer"],
+  modules: ["@shopware/nuxt-module"],
+  // ... rest of your configuration
+});
+```
+
+:::tip
+If you're using `@shopware/cms-base-layer`, you can extend both layers together:
+
+```ts
+extends: [
+  "@shopware/composables/nuxt-layer",
+  "@shopware/cms-base-layer"
+],
+```
+:::
+
+### Additional Information
+
+- The `@shopware/composables/nuxt-layer` sets up auto-imports for all composables from the `src` directory
+- It also configures TypeScript path aliases (`#imports` and `#shopware`) that are required by the nuxt-module
+- Always extend the composables layer when using `@shopware/nuxt-module` in your project


### PR DESCRIPTION
This pull request adds a new troubleshooting section to the documentation to help users resolve the "failed to find 'createShopwareContext' imported from '#imports'" error when using the `@shopware/nuxt-module`. The new section explains why the error occurs and provides clear steps to fix it by extending the appropriate Nuxt layer.

Documentation improvements:

* Added a detailed troubleshooting guide for the "[unimport] failed to find 'createShopwareContext' imported from '#imports'" error, including the cause of the issue and step-by-step solution for configuring Nuxt with `@shopware/composables/nuxt-layer`.
* Included tips for users who also use `@shopware/cms-base-layer`, showing how to extend multiple layers in `nuxt.config.ts`.


closes #1834 