### PR TITLE
fix(vue-demo-store): use bound src attributes for public images

### DIFF
--- a/.changeset/wide-spoons-grin.md
+++ b/.changeset/wide-spoons-grin.md
@@ -1,0 +1,5 @@
+---
+"vue-demo-store": patch
+---
+
+Use bound src attributes for public images in vue-demo-store so asset URLs are handled consistently by the Vue template compiler.

--- a/templates/vue-demo-store/app/components/account/AccountLoginForm.vue
+++ b/templates/vue-demo-store/app/components/account/AccountLoginForm.vue
@@ -59,7 +59,7 @@ async function invokeLogin(): Promise<void> {
       <div>
         <img
           class="mx-auto h-12 w-auto"
-          src="/logo.svg"
+          :src="'/logo.svg'"
           alt="logo of the shop"
         />
         <h2 class="mt-6 text-center text-3xl font-extrabold text-secondary-900">

--- a/templates/vue-demo-store/app/components/errors/MaintainMode.vue
+++ b/templates/vue-demo-store/app/components/errors/MaintainMode.vue
@@ -5,7 +5,7 @@
     <div class="flex items-center justify-center">
       <img
         class="w-full h-full"
-        src="/maintenance_mode.svg"
+        :src="'/maintenance_mode.svg'"
         alt="Maintenance"
       />
     </div>

--- a/templates/vue-demo-store/app/components/layout/LayoutCheckoutHeader.vue
+++ b/templates/vue-demo-store/app/components/layout/LayoutCheckoutHeader.vue
@@ -14,7 +14,7 @@ const { formatLink } = useInternationalization(localePath);
             <span class="sr-only">Shopware</span>
             <img
               class="h-8 w-auto sm:h-10"
-              src="/logo.svg"
+              :src="'/logo.svg'"
               alt="logo of the shop"
               width="40px"
               height="40px"

--- a/templates/vue-demo-store/app/components/layout/LayoutFooter.vue
+++ b/templates/vue-demo-store/app/components/layout/LayoutFooter.vue
@@ -24,7 +24,7 @@ const gridColumns = computed<number>(() =>
             <span class="sr-only">Shopware</span>
             <img
               class="h-15 w-auto sm:h-15"
-              src="/logo.svg"
+              :src="'/logo.svg'"
               alt="logo of the shop"
             />
           </NuxtLink>

--- a/templates/vue-demo-store/app/components/layout/LayoutHeader.vue
+++ b/templates/vue-demo-store/app/components/layout/LayoutHeader.vue
@@ -19,7 +19,7 @@ const miniCartModal = useMiniCartModal();
               <span class="sr-only">Shopware</span>
               <img
                 class="h-10 w-10 lg:h-12 lg:w-12"
-                src="/logo.svg"
+                :src="'/logo.svg'"
                 alt="logo of the shop"
                 width="40px"
                 height="40px"


### PR DESCRIPTION
This pull request makes a patch-level update to the `vue-demo-store` by ensuring that all public image sources use bound `:src` attributes in Vue templates. This change ensures asset URLs are handled consistently by the Vue template compiler, which can help avoid issues with asset resolution, especially in production environments.

**Consistent image asset handling:**

* Updated all image tags in the `vue-demo-store` components to use bound `:src` attributes instead of static `src` attributes, notably for `/logo.svg` and `/maintenance_mode.svg`, to ensure consistent asset URL handling by the Vue template compiler. [[1]](diffhunk://#diff-1d94aa6bc24bdab65397d036cc8583da7b837227625ee561b944019b081e41faL62-R62) [[2]](diffhunk://#diff-c6e65e9230a871e914c51737ff78967404519dedc780260d9f6e7f17bc2f421bL8-R8) [[3]](diffhunk://#diff-4f7ff2a4b25a165523667212b84481a07cff7654da1c51bc52351975928a8c7fL17-R17) [[4]](diffhunk://#diff-461c4f745e57a5a695b43915e9fed6692fa7a4eae7fca53a1c19cd3a322fa3fdL27-R27) [[5]](diffhunk://#diff-df89b5a07e6aaef38616f4845b5d9a3ef105dcec640440442e6ded3c3d83a2d7L22-R22)

**Documentation:**

* Added a changeset describing the update and the reason for switching to bound `:src` attributes for public images.