### PR TITLE
chore(api-client): exclude tests from build:types

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -45,7 +45,7 @@
   },
   "scripts": {
     "build": "export NODE_ENV=production && unbuild && pnpm build:types",
-    "build:types": "tsgo ./src/*.ts --ignoreConfig --declaration --allowJs --emitDeclarationOnly --outDir ./temp --skipLibCheck",
+    "build:types": "tsgo --project tsconfig.build.json --declaration --emitDeclarationOnly --outDir ./temp --skipLibCheck",
     "dev": "export NODE_ENV=development && unbuild --stub",
     "lint": "biome check .",
     "lint:fix": "biome check . --write && pnpm typecheck",

--- a/packages/api-client/tsconfig.build.json
+++ b/packages/api-client/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.test-d.ts",
+    "**/*.bench.ts",
+    "src/tests"
+  ]
+}


### PR DESCRIPTION
closes: #2418 