### PR TITLE
feat(templates): add StackBlitz configuration for various Vue templates

### DIFF
--- a/templates/astro/.stackblitzrc
+++ b/templates/astro/.stackblitzrc
@@ -1,6 +1,6 @@
 {
   "env": {
-    "NODE_OPTIONS": "--no-warnings=ExperimentalWarning"
+    "NODE_OPTIONS": "--no-warnings"
   },
   "startCommand": "pnpm dev"
 }

--- a/templates/astro/.stackblitzrc
+++ b/templates/astro/.stackblitzrc
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "NODE_OPTIONS": "--no-warnings=ExperimentalWarning"
+  },
+  "startCommand": "pnpm dev"
+}

--- a/templates/vue-blank/.stackblitzrc
+++ b/templates/vue-blank/.stackblitzrc
@@ -4,5 +4,5 @@
     "NUXT_TELEMETRY_DISABLED": "1",
     "SHOPWARE_STACKBLITZ": "true"
   },
-  "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr"
+  "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr NODE_NO_WARNINGS=1"
 }

--- a/templates/vue-blank/.stackblitzrc
+++ b/templates/vue-blank/.stackblitzrc
@@ -1,6 +1,6 @@
 {
   "env": {
-    "NODE_OPTIONS": "--no-warnings=ExperimentalWarning",
+    "NODE_OPTIONS": "--no-warnings",
     "NUXT_TELEMETRY_DISABLED": "1",
     "SHOPWARE_STACKBLITZ": "true"
   },

--- a/templates/vue-blank/.stackblitzrc
+++ b/templates/vue-blank/.stackblitzrc
@@ -2,8 +2,7 @@
   "env": {
     "NODE_OPTIONS": "--no-warnings=ExperimentalWarning",
     "NUXT_TELEMETRY_DISABLED": "1",
-    "SHOPWARE_STACKBLITZ": "true",
-    "NUXT_PUBLIC_SHOPWARE_DEV_STOREFRONT_URL": "https://demo-frontends.shopware.store"
+    "SHOPWARE_STACKBLITZ": "true"
   },
   "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr"
 }

--- a/templates/vue-blank/nuxt.config.ts
+++ b/templates/vue-blank/nuxt.config.ts
@@ -1,6 +1,9 @@
 // https://v3.nuxtjs.org/api/configuration/nuxt.config
+const isStackBlitz = process.env.SHOPWARE_STACKBLITZ === "true";
+
 export default defineNuxtConfig({
   extends: ["@shopware/composables/nuxt-layer", "@shopware/cms-base-layer"],
+  ...(isStackBlitz ? { devtools: { enabled: false } } : {}),
   shopware: {
     endpoint: "https://demo-frontends.shopware.store/store-api/",
     accessToken: "SWSCBHFSNTVMAWNZDNFKSHLAYW",

--- a/templates/vue-demo-store/.stackblitzrc
+++ b/templates/vue-demo-store/.stackblitzrc
@@ -5,5 +5,5 @@
     "SHOPWARE_STACKBLITZ": "true",
     "NUXT_PUBLIC_SHOPWARE_DEV_STOREFRONT_URL": "https://demo-frontends.shopware.store"
   },
-  "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr"
+  "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr NODE_NO_WARNINGS=1"
 }

--- a/templates/vue-demo-store/.stackblitzrc
+++ b/templates/vue-demo-store/.stackblitzrc
@@ -3,7 +3,8 @@
     "NODE_OPTIONS": "--no-warnings=ExperimentalWarning",
     "NUXT_TELEMETRY_DISABLED": "1",
     "SHOPWARE_STACKBLITZ": "true",
-    "NUXT_PUBLIC_SHOPWARE_DEV_STOREFRONT_URL": "https://demo-frontends.shopware.store"
+    "NUXT_PUBLIC_SHOPWARE_DEV_STOREFRONT_URL": "https://demo-frontends.shopware.store",
+    "NPM_CONFIG_LOGLEVEL": "silent"
   },
   "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr NODE_NO_WARNINGS=1"
 }

--- a/templates/vue-demo-store/.stackblitzrc
+++ b/templates/vue-demo-store/.stackblitzrc
@@ -1,10 +1,10 @@
 {
   "env": {
-    "NODE_OPTIONS": "--no-warnings=ExperimentalWarning",
+    "NODE_OPTIONS": "--no-warnings",
     "NUXT_TELEMETRY_DISABLED": "1",
     "SHOPWARE_STACKBLITZ": "true",
     "NUXT_PUBLIC_SHOPWARE_DEV_STOREFRONT_URL": "https://demo-frontends.shopware.store",
     "NPM_CONFIG_LOGLEVEL": "silent"
   },
-  "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr NODE_NO_WARNINGS=1"
+  "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr"
 }

--- a/templates/vue-demo-store/nuxt.config.ts
+++ b/templates/vue-demo-store/nuxt.config.ts
@@ -1,6 +1,9 @@
 // https://v3.nuxtjs.org/docs/directory-structure/nuxt.config
+const isStackBlitz = process.env.SHOPWARE_STACKBLITZ === "true";
+
 export default defineNuxtConfig({
   extends: ["@shopware/composables/nuxt-layer", "@shopware/cms-base-layer"],
+  ...(isStackBlitz ? { devtools: { enabled: false } } : {}),
   runtimeConfig: {
     shopware: {
       /**

--- a/templates/vue-starter-template-extended/.stackblitzrc
+++ b/templates/vue-starter-template-extended/.stackblitzrc
@@ -4,5 +4,5 @@
     "NUXT_TELEMETRY_DISABLED": "1",
     "SHOPWARE_STACKBLITZ": "true"
   },
-  "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr"
+  "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr NODE_NO_WARNINGS=1"
 }

--- a/templates/vue-starter-template-extended/.stackblitzrc
+++ b/templates/vue-starter-template-extended/.stackblitzrc
@@ -1,6 +1,6 @@
 {
   "env": {
-    "NODE_OPTIONS": "--no-warnings=ExperimentalWarning",
+    "NODE_OPTIONS": "--no-warnings",
     "NUXT_TELEMETRY_DISABLED": "1",
     "SHOPWARE_STACKBLITZ": "true"
   },

--- a/templates/vue-starter-template-extended/.stackblitzrc
+++ b/templates/vue-starter-template-extended/.stackblitzrc
@@ -2,8 +2,7 @@
   "env": {
     "NODE_OPTIONS": "--no-warnings=ExperimentalWarning",
     "NUXT_TELEMETRY_DISABLED": "1",
-    "SHOPWARE_STACKBLITZ": "true",
-    "NUXT_PUBLIC_SHOPWARE_DEV_STOREFRONT_URL": "https://demo-frontends.shopware.store"
+    "SHOPWARE_STACKBLITZ": "true"
   },
   "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr"
 }

--- a/templates/vue-starter-template-extended/nuxt.config.ts
+++ b/templates/vue-starter-template-extended/nuxt.config.ts
@@ -1,7 +1,10 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+const isStackBlitz = process.env.SHOPWARE_STACKBLITZ === "true";
+
 export default defineNuxtConfig({
   extends: ["../vue-starter-template"],
   compatibilityDate: "2025-12-05",
+  ...(isStackBlitz ? { devtools: { enabled: false } } : {}),
   modules: ["@unocss/nuxt"],
   runtimeConfig: {
     public: {
@@ -26,4 +29,5 @@ export default defineNuxtConfig({
       ],
     },
   },
+  telemetry: false,
 });

--- a/templates/vue-starter-template/.stackblitzrc
+++ b/templates/vue-starter-template/.stackblitzrc
@@ -4,5 +4,5 @@
     "NUXT_TELEMETRY_DISABLED": "1",
     "SHOPWARE_STACKBLITZ": "true"
   },
-  "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr"
+  "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr NODE_NO_WARNINGS=1"
 }

--- a/templates/vue-starter-template/.stackblitzrc
+++ b/templates/vue-starter-template/.stackblitzrc
@@ -1,6 +1,6 @@
 {
   "env": {
-    "NODE_OPTIONS": "--no-warnings=ExperimentalWarning",
+    "NODE_OPTIONS": "--no-warnings",
     "NUXT_TELEMETRY_DISABLED": "1",
     "SHOPWARE_STACKBLITZ": "true"
   },

--- a/templates/vue-starter-template/.stackblitzrc
+++ b/templates/vue-starter-template/.stackblitzrc
@@ -2,8 +2,7 @@
   "env": {
     "NODE_OPTIONS": "--no-warnings=ExperimentalWarning",
     "NUXT_TELEMETRY_DISABLED": "1",
-    "SHOPWARE_STACKBLITZ": "true",
-    "NUXT_PUBLIC_SHOPWARE_DEV_STOREFRONT_URL": "https://demo-frontends.shopware.store"
+    "SHOPWARE_STACKBLITZ": "true"
   },
   "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr"
 }

--- a/templates/vue-starter-template/nuxt.config.ts
+++ b/templates/vue-starter-template/nuxt.config.ts
@@ -2,6 +2,7 @@
 import { createResolver } from "@nuxt/kit";
 
 const { resolve } = createResolver(import.meta.url);
+const isStackBlitz = process.env.SHOPWARE_STACKBLITZ === "true";
 
 export default defineNuxtConfig({
   extends: [
@@ -10,7 +11,7 @@ export default defineNuxtConfig({
     "@shopware/unocss-design-tokens-layer",
   ],
   compatibilityDate: "2025-04-15",
-  devtools: { enabled: true },
+  devtools: { enabled: !isStackBlitz },
   modules: [
     "@vueuse/nuxt",
     "@unocss/nuxt",
@@ -116,4 +117,5 @@ export default defineNuxtConfig({
       resolve("./i18n/src/helpers"),
     ],
   },
+  telemetry: false,
 });

--- a/templates/vue-vite-blank/.stackblitzrc
+++ b/templates/vue-vite-blank/.stackblitzrc
@@ -1,6 +1,6 @@
 {
   "env": {
-    "NODE_OPTIONS": "--no-warnings=ExperimentalWarning"
+    "NODE_OPTIONS": "--no-warnings"
   },
   "startCommand": "pnpm dev"
 }

--- a/templates/vue-vite-blank/.stackblitzrc
+++ b/templates/vue-vite-blank/.stackblitzrc
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "NODE_OPTIONS": "--no-warnings=ExperimentalWarning"
+  },
+  "startCommand": "pnpm dev"
+}


### PR DESCRIPTION
 closes #2404

This pull request adds and updates StackBlitz configuration files and adjusts Nuxt configuration for improved compatibility and developer experience when running templates on StackBlitz. The changes primarily focus on disabling Nuxt telemetry and devtools in the StackBlitz environment, suppressing Node warnings, and ensuring a consistent startup command across templates.

