### PR TITLE
Quality: Using deprecated find.sync method

### DIFF
--- a/apps/e2e-tests/utils/helpers.ts
+++ b/apps/e2e-tests/utils/helpers.ts
@@ -1,2 +1,2 @@
-import find from "find-up";
-export const findEnv = () => find.sync(process.env.ENV_FILE || ".env");
+import { findUp } from "find-up";
+export const findEnv = () => findUp(process.env.ENV_FILE || ".env");


### PR DESCRIPTION
## Summary

Quality: Using deprecated find.sync method

## Problem

**Severity**: `Medium` | **File**: `apps/e2e-tests/utils/helpers.ts:L2`

The find-up library's sync method is deprecated. Using find.sync() in helpers.ts

## Solution

Use async find() or import { findUp } from 'find-up' and use findUp()

## Changes

- `apps/e2e-tests/utils/helpers.ts` (modified)