### PR TITLE
feat(newsletter):  newsletter status handling

### DIFF
--- a/.changeset/kind-starter-template-newsletter.md
+++ b/.changeset/kind-starter-template-newsletter.md
@@ -1,0 +1,5 @@
+---
+"vue-starter-template": patch
+---
+
+Remove the extra newsletter status call after subscribing on the account overview now that `useNewsletter` syncs from the API response.

--- a/.changeset/sharp-eagles-sync.md
+++ b/.changeset/sharp-eagles-sync.md
@@ -1,0 +1,5 @@
+---
+"@shopware/composables": patch
+---
+
+Update `useNewsletter` so `newsletterStatus` is set from the subscribe API response, keeping `isNewsletterSubscriber` in sync without an extra status request.

--- a/.changeset/swift-demo-store-newsletter.md
+++ b/.changeset/swift-demo-store-newsletter.md
@@ -1,0 +1,5 @@
+---
+"vue-demo-store": patch
+---
+
+Remove redundant newsletter status refresh on the account overview now that `useNewsletter` updates state after subscribe.

--- a/packages/composables/src/useNewsletter/useNewsletter.test.ts
+++ b/packages/composables/src/useNewsletter/useNewsletter.test.ts
@@ -5,7 +5,9 @@ import { useNewsletter } from "./useNewsletter";
 describe("useNewsletter", () => {
   it("newsletter subscribe", async () => {
     const { vm, injections } = useSetup(useNewsletter);
-    injections.apiClient.invoke.mockResolvedValue({ data: {} });
+    injections.apiClient.invoke.mockResolvedValue({
+      data: { status: "direct" },
+    });
 
     await vm.newsletterSubscribe({
       email: "test@shopware.com",
@@ -16,6 +18,7 @@ describe("useNewsletter", () => {
       expect.stringContaining("subscribeToNewsletter"),
       expect.anything(),
     );
+    expect(vm.newsletterStatus).toBe("direct");
   });
 
   it("newsletter unsubscribe", async () => {

--- a/packages/composables/src/useNewsletter/useNewsletter.ts
+++ b/packages/composables/src/useNewsletter/useNewsletter.ts
@@ -78,6 +78,7 @@ export function useNewsletter(): UseNewsletterReturn {
         },
       },
     );
+    newsletterStatus.value = result.data.status;
     return result.data;
   }
 

--- a/templates/vue-demo-store/app/pages/account/index.vue
+++ b/templates/vue-demo-store/app/pages/account/index.vue
@@ -61,6 +61,7 @@ async function updateNewsletterStatus() {
       }
     }
   } finally {
+    newsletter.value = isNewsletterSubscriber.value;
     newsletterDisabled.value = false;
   }
 }

--- a/templates/vue-demo-store/app/pages/account/index.vue
+++ b/templates/vue-demo-store/app/pages/account/index.vue
@@ -61,9 +61,6 @@ async function updateNewsletterStatus() {
       }
     }
   } finally {
-    await getNewsletterStatus();
-
-    newsletter.value = isNewsletterSubscriber.value;
     newsletterDisabled.value = false;
   }
 }

--- a/templates/vue-starter-template/app/pages/account/index.vue
+++ b/templates/vue-starter-template/app/pages/account/index.vue
@@ -24,8 +24,6 @@ async function handleNewsletterChange() {
         email: user.value?.email || "",
         option: SUBSCRIBE_KEY,
       });
-      // Wait to avoid UI flickering
-      await getNewsletterStatus();
       pushSuccess(t("account.overview.newsletter.messages.subscribed"));
     } else {
       await newsletterUnsubscribe(user.value?.email || "");


### PR DESCRIPTION
closes #2327 

This pull request streamlines the newsletter subscription logic by ensuring that the `useNewsletter` composable updates the subscription status directly from the API response. As a result, redundant status refresh calls in the account overview pages are removed, making the code more efficient and reducing unnecessary API requests.

**Newsletter subscription logic improvements:**

* Updated `useNewsletter` so that `newsletterStatus` is set directly from the subscribe API response, keeping `isNewsletterSubscriber` in sync without requiring an extra status request (`useNewsletter.ts`). [[1]](diffhunk://#diff-5a882d2dd521d0c332cc12fc198797ba682e71cf4e011c7f208a7afdb4ab7783R81) [[2]](diffhunk://#diff-0fa9a28417a442a5d87cac5cc2ae32c687da96d819d9773d739eded2b8703aceR1-R5)

**Redundant code removal in account overview pages:**

* Removed the extra call to refresh newsletter status after subscribing in the `vue-starter-template` account overview page, since state is now updated by the composable (`index.vue`). [[1]](diffhunk://#diff-404ab597f2610df0ca9a883f42bf42bbb6f59780cd6646ee37cadb705fdde8f1L27-L28) [[2]](diffhunk://#diff-399b10653559c5276ebf77653e6fac77488dc3bf0c2df019eb5e3349b951bf0dR1-R5)
* Removed the redundant newsletter status refresh in the `vue-demo-store` account overview page for the same reason (`index.vue`). [[1]](diffhunk://#diff-640f7989a59cd79f66d804083e1646583c646ac0f202df2d33eef4f501e9d5e9L64-L66) [[2]](diffhunk://#diff-d6dc6880d1a02a829fef6d32e6a4f12eff82a652bd4e675ddb51989f74d3b586R1-R5)