### PR TITLE
fix(release): remove unnecessary flag from canary package publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
 
       - name: Publish canary packages
-        run: pnpm changeset publish --no-git-tag --no-git-checks --tag canary
+        run: pnpm changeset publish --no-git-tag --tag canary
 
   release:
     name: Create release PR or publish merged changesets


### PR DESCRIPTION
The pipeline started failing after upgrading @changesets/cli from 2.30.0 to 2.31.0.

The command used in the canary release workflow was:

```
pnpm changeset publish --no-git-tag --no-git-checks --tag canary
```

The problem is that --no-git-checks is not a valid flag for the changeset publish command. In older versions of @changesets/cli, unsupported flags were effectively ignored, so the workflow continued to work even though the command was not strictly valid.

Starting with @changesets/cli@2.31.0, Changesets now errors on unsupported flags for individual CLI commands. This is mentioned in the 2.31.0 release notes:

https://newreleases.io/project/github/changesets/changesets/release/%40changesets%2Fcli%402.31.0