### PR TITLE
feat(composables): add includeSeoUrls option to useProductAssociations

### DIFF
--- a/.changeset/calm-rivers-spin.md
+++ b/.changeset/calm-rivers-spin.md
@@ -1,0 +1,5 @@
+---
+"@shopware/composables": patch
+---
+
+`useProductAssociations`: add optional `includeSeoUrls` option. When `true`, the cross-selling request sends `sw-include-seo-urls: true` so returned products include the `seoUrls` association. Defaults to `false` to avoid extra backend overhead.

--- a/packages/composables/src/useProductAssociations/useProductAssociations.spec.ts
+++ b/packages/composables/src/useProductAssociations/useProductAssociations.spec.ts
@@ -90,6 +90,53 @@ describe("useProductAssociations", () => {
     expect(vm.productAssociations).toStrictEqual(mockedCrossSelling);
   });
 
+  it("sends sw-include-seo-urls header when includeSeoUrls is true", async () => {
+    const { vm, injections } = useSetup(() =>
+      useProductAssociations(
+        computed(() => mockedProduct),
+        {
+          associationContext: "cross-selling",
+          includeSeoUrls: true,
+        },
+      ),
+    );
+    injections.apiClient.invoke.mockResolvedValue({ data: mockedCrossSelling });
+
+    await vm.loadAssociations({
+      method: "post",
+      searchParams: {},
+    });
+
+    expect(injections.apiClient.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("readProductCrossSellings"),
+      expect.objectContaining({
+        headers: {
+          "sw-include-seo-urls": true,
+        },
+      }),
+    );
+  });
+
+  it("omits sw-include-seo-urls header when includeSeoUrls is not set", async () => {
+    const { vm, injections } = useSetup(() =>
+      useProductAssociations(
+        computed(() => mockedProduct),
+        {
+          associationContext: "cross-selling",
+        },
+      ),
+    );
+    injections.apiClient.invoke.mockResolvedValue({ data: mockedCrossSelling });
+
+    await vm.loadAssociations({
+      method: "post",
+      searchParams: {},
+    });
+
+    const invokeOptions = injections.apiClient.invoke.mock.calls[0]?.[1];
+    expect(invokeOptions).not.toHaveProperty("headers");
+  });
+
   it("init without product should throw an error", () => {
     expect(() =>
       useSetup(() =>

--- a/packages/composables/src/useProductAssociations/useProductAssociations.ts
+++ b/packages/composables/src/useProductAssociations/useProductAssociations.ts
@@ -31,6 +31,7 @@ export function useProductAssociations(
   product: ComputedRef<Schemas["Product"]>,
   options: {
     associationContext: "cross-selling" | "reviews";
+    includeSeoUrls?: boolean;
   },
 ): UseProductAssociationsReturn {
   if (!product.value)
@@ -84,6 +85,11 @@ export function useProductAssociations(
       const response = await apiClient.invoke(
         "readProductCrossSellings post /product/{productId}/cross-selling",
         {
+          ...(options.includeSeoUrls && {
+            headers: {
+              "sw-include-seo-urls": true,
+            },
+          }),
           pathParams: { productId: product.value.id },
         },
       );


### PR DESCRIPTION
closes: #1432

## Summary
- Adds opt-in `includeSeoUrls` option to `useProductAssociations`
- When `true`, sends `sw-include-seo-urls: true` so the response hydrates the `seoUrls` association on cross-selling products
- Defaults to `false` to avoid extra backend overhead for consumers that don't need product links
