### PR TITLE
fix(templates): avoid type cast and add no-cms fallback in `FrontendLandingPage`

### DIFF
--- a/templates/vue-demo-store/app/components/FrontendLandingPage.vue
+++ b/templates/vue-demo-store/app/components/FrontendLandingPage.vue
@@ -14,25 +14,23 @@ const { data: landingResponse, error } = await useAsyncData(
 );
 
 if (!landingResponse.value) {
-  console.error("[FrontendLandingPage.vue]", error.value?.message);
+  const statusMessage = error.value?.message || "No landing page found";
+  console.error("[FrontendLandingPage.vue]", statusMessage);
   throw createError({
     statusCode: 500,
-    message: error.value?.message,
+    message: statusMessage,
   });
 }
 
-useBreadcrumbs(getCmsBreadcrumbs(landingResponse.value));
+const landingPage = landingResponse.value;
 
-const landingPage = computed(() => {
-  if (!landingResponse.value) {
-    throw createError({
-      statusCode: 500,
-      message: error.value?.message,
-    });
-  }
-  return landingResponse.value;
-});
-useCmsHead(landingPage, { mainShopTitle: "Shopware Frontends Demo Store" });
+useBreadcrumbs(getCmsBreadcrumbs(landingPage));
+useCmsHead(
+  computed(() => landingPage),
+  {
+    mainShopTitle: "Shopware Frontends Demo Store",
+  },
+);
 </script>
 
 <template>

--- a/templates/vue-demo-store/app/components/FrontendLandingPage.vue
+++ b/templates/vue-demo-store/app/components/FrontendLandingPage.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { getCmsBreadcrumbs } from "@shopware/helpers";
 import { useLandingSearch } from "#imports";
-import type { Schemas } from "#shopware";
 
 const props = defineProps<{
   navigationId: string;
@@ -11,20 +10,10 @@ const { search } = useLandingSearch();
 
 const { data: landingResponse, error } = await useAsyncData(
   `cmsLanding${props.navigationId}`,
-  async () => {
-    const landingPage = await search(props.navigationId, {
-      withCmsAssociations: true,
-    });
-    return landingPage;
-  },
+  () => search(props.navigationId, { withCmsAssociations: true }),
 );
 
-if (landingResponse.value) {
-  const breadcrumbs = getCmsBreadcrumbs(landingResponse.value);
-  useBreadcrumbs(breadcrumbs);
-}
-
-if (!landingResponse?.value) {
+if (!landingResponse.value) {
   console.error("[FrontendLandingPage.vue]", error.value?.message);
   throw createError({
     statusCode: 500,
@@ -32,11 +21,24 @@ if (!landingResponse?.value) {
   });
 }
 
-const landingPage = landingResponse as Ref<Schemas["LandingPage"]>;
+useBreadcrumbs(getCmsBreadcrumbs(landingResponse.value));
+
+const landingPage = computed(() => {
+  if (!landingResponse.value) {
+    throw createError({
+      statusCode: 500,
+      message: error.value?.message,
+    });
+  }
+  return landingResponse.value;
+});
 useCmsHead(landingPage, { mainShopTitle: "Shopware Frontends Demo Store" });
 </script>
 
 <template>
   <LayoutBreadcrumbs />
   <CmsPage v-if="landingResponse?.cmsPage" :content="landingResponse.cmsPage" />
+  <div v-else class="container mx-auto bg-white flex flex-col">
+    <span>😱 cmsPage is missing.</span>
+  </div>
 </template>

--- a/templates/vue-starter-template/app/components/FrontendLandingPage.vue
+++ b/templates/vue-starter-template/app/components/FrontendLandingPage.vue
@@ -14,25 +14,23 @@ const { data: landingResponse, error } = await useAsyncData(
 );
 
 if (!landingResponse.value) {
-  console.error("[FrontendLandingPage.vue]", error.value?.message);
+  const statusMessage = error.value?.message || "No landing page found";
+  console.error("[FrontendLandingPage.vue]", statusMessage);
   throw createError({
     statusCode: 500,
-    message: error.value?.message,
+    message: statusMessage,
   });
 }
 
-useBreadcrumbs(getCmsBreadcrumbs(landingResponse.value));
+const landingPage = landingResponse.value;
 
-const landingPage = computed(() => {
-  if (!landingResponse.value) {
-    throw createError({
-      statusCode: 500,
-      message: error.value?.message,
-    });
-  }
-  return landingResponse.value;
-});
-useCmsHead(landingPage, { mainShopTitle: "Shopware Frontends Demo Store" });
+useBreadcrumbs(getCmsBreadcrumbs(landingPage));
+useCmsHead(
+  computed(() => landingPage),
+  {
+    mainShopTitle: "Shopware Frontends Demo Store",
+  },
+);
 </script>
 
 <template>

--- a/templates/vue-starter-template/app/components/FrontendLandingPage.vue
+++ b/templates/vue-starter-template/app/components/FrontendLandingPage.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { getCmsBreadcrumbs } from "@shopware/helpers";
 import { useLandingSearch } from "#imports";
-import type { Schemas } from "#shopware";
 
 const props = defineProps<{
   navigationId: string;
@@ -11,20 +10,10 @@ const { search } = useLandingSearch();
 
 const { data: landingResponse, error } = await useAsyncData(
   `cmsLanding${props.navigationId}`,
-  async () => {
-    const landingPage = await search(props.navigationId, {
-      withCmsAssociations: true,
-    });
-    return landingPage;
-  },
+  () => search(props.navigationId, { withCmsAssociations: true }),
 );
 
-if (landingResponse.value) {
-  const breadcrumbs = getCmsBreadcrumbs(landingResponse.value);
-  useBreadcrumbs(breadcrumbs);
-}
-
-if (!landingResponse?.value) {
+if (!landingResponse.value) {
   console.error("[FrontendLandingPage.vue]", error.value?.message);
   throw createError({
     statusCode: 500,
@@ -32,11 +21,24 @@ if (!landingResponse?.value) {
   });
 }
 
-const landingPage = landingResponse as Ref<Schemas["LandingPage"]>;
+useBreadcrumbs(getCmsBreadcrumbs(landingResponse.value));
+
+const landingPage = computed(() => {
+  if (!landingResponse.value) {
+    throw createError({
+      statusCode: 500,
+      message: error.value?.message,
+    });
+  }
+  return landingResponse.value;
+});
 useCmsHead(landingPage, { mainShopTitle: "Shopware Frontends Demo Store" });
 </script>
 
 <template>
   <LayoutBreadcrumbs />
   <CmsPage v-if="landingResponse?.cmsPage" :content="landingResponse.cmsPage" />
+  <div v-else class="container mx-auto bg-white flex flex-col">
+    <span>😱 cmsPage is missing.</span>
+  </div>
 </template>


### PR DESCRIPTION
closes: #1846

## Summary
- Replace `as Ref<Schemas["LandingPage"]>` cast with a `computed()` that narrows the type via an explicit throw - addresses [#1843 review comment](https://github.com/shopware/frontends/pull/1843#discussion_r2055621156)
- Add a `v-else` fallback in the template when `cmsPage` is missing - addresses [#1843 review comment](https://github.com/shopware/frontends/pull/1843#discussion_r2055622624)
- Drop the redundant `if (landingResponse.value)` guard around breadcrumbs (the early throw already handles the null case)
- Mirror the change in both `vue-demo-store` and `vue-starter-template`