### PR TITLE
fix(nuxt-module): register #shopware types in all tsconfig contexts

### DIFF
--- a/.changeset/gentle-otters-cheer.md
+++ b/.changeset/gentle-otters-cheer.md
@@ -1,0 +1,5 @@
+---
+"@shopware/nuxt-module": patch
+---
+
+Register the `#shopware` types in every TypeScript context (app, server/nitro, node, shared) instead of only the app one. This fixes `Cannot find module '#shopware'` in server-side code (e.g. `server/` routes and API builders) when a project uses the Nuxt 4 project-references `tsconfig.json` layout. Projects that ship their own `shopware.d.ts` are referenced in place so their relative imports keep resolving.

--- a/packages/nuxt-module/src/index.test.ts
+++ b/packages/nuxt-module/src/index.test.ts
@@ -75,25 +75,44 @@ describe("@shopware/nuxt-module", () => {
     isConfigDeprecatedMock.mockReturnValue(false);
   });
 
-  it("should inject default shopware.d.ts when project has no custom types", async () => {
+  const ALL_TYPE_CONTEXTS = {
+    nuxt: true,
+    nitro: true,
+    node: true,
+    shared: true,
+  };
+
+  it("should inject default shopware.d.ts in all type contexts when project has no custom types", async () => {
     existsSyncMock.mockReturnValue(false);
     const setup = await getModuleSetup();
 
     await setup({}, createNuxtMock("/tmp/test-project"));
 
-    expect(addTypeTemplateMock).toHaveBeenCalledWith({
-      filename: "shopware.d.ts",
-      src: "/mocked-module-dir/../shopware.d.ts",
-    });
+    expect(addTypeTemplateMock).toHaveBeenCalledWith(
+      {
+        filename: "shopware.d.ts",
+        src: "/mocked-module-dir/../shopware.d.ts",
+      },
+      ALL_TYPE_CONTEXTS,
+    );
   });
 
-  it("should skip injecting shopware.d.ts when project has custom types", async () => {
+  it("should reference the project's own shopware.d.ts in all type contexts when it exists", async () => {
     existsSyncMock.mockReturnValue(true);
     const setup = await getModuleSetup();
 
     await setup({}, createNuxtMock("/tmp/test-project"));
 
-    expect(addTypeTemplateMock).not.toHaveBeenCalled();
+    expect(addTypeTemplateMock).toHaveBeenCalledTimes(1);
+    const [template, context] = addTypeTemplateMock.mock.calls[0] as [
+      { filename: string; getContents: () => string },
+      Record<string, boolean>,
+    ];
+    expect(template.filename).toBe("shopware.d.ts");
+    expect(template.getContents()).toContain(
+      '/// <reference path="/tmp/test-project/shopware.d.ts" />',
+    );
+    expect(context).toEqual(ALL_TYPE_CONTEXTS);
   });
 
   it("should check for shopware.d.ts in the project root directory", async () => {

--- a/packages/nuxt-module/src/index.ts
+++ b/packages/nuxt-module/src/index.ts
@@ -81,11 +81,31 @@ export default defineNuxtModule<ShopwareNuxtOptions>({
     });
 
     const projectShopwareTypes = resolve(nuxt.options.rootDir, "shopware.d.ts");
-    if (!existsSync(projectShopwareTypes)) {
-      addTypeTemplate({
-        filename: "shopware.d.ts",
-        src: resolver.resolve("../shopware.d.ts"),
-      });
+    // Register `#shopware` in every type-check context, not just the app one.
+    const shopwareTypeContexts = {
+      nuxt: true,
+      nitro: true,
+      node: true,
+      shared: true,
+    };
+    if (existsSync(projectShopwareTypes)) {
+      // Reference the project's file in place so its relative imports keep resolving.
+      const referencePath = projectShopwareTypes.replace(/\\/g, "/");
+      addTypeTemplate(
+        {
+          filename: "shopware.d.ts",
+          getContents: () => `/// <reference path="${referencePath}" />\n`,
+        },
+        shopwareTypeContexts,
+      );
+    } else {
+      addTypeTemplate(
+        {
+          filename: "shopware.d.ts",
+          src: resolver.resolve("../shopware.d.ts"),
+        },
+        shopwareTypeContexts,
+      );
     }
 
     addCustomTab({


### PR DESCRIPTION
Enables part of shopware/frontends#2057 (migrate `tsconfig.json` to the Nuxt 4 reference)

## What

`@shopware/nuxt-module` registered the `#shopware` ambient type via `addTypeTemplate` without a context, so it only landed in the **app** context. Under Nuxt 4's reference-style `tsconfig.json` (project references), the server/shared/node contexts are type-checked as separate projects, so server code importing `#shopware` (e.g. `server/apiBuilder.ts`, `server/routes/**`) failed with `Cannot find module '#shopware'`.

## Fix

- Register the `#shopware` type in all four contexts (app, server/nitro, node, shared).
- For projects that ship their own `shopware.d.ts`, reference it in place so its relative imports keep resolving (instead of copying it into the build dir).
- Unit tests updated.

> Prerequisite for migrating projects to the reference-style tsconfig. It does **not** address the separate upstream auto-import blocker.

## Related

- Same class as upstream nuxt/nuxt#34385 (ambient type declarations not resolved per-context)
- Out of scope / still blocking: nuxt/nuxt#34212 (auto-imports unresolved under build-mode typecheck)
