### PR TITLE
feat(composables): allow custom criteria in useCountries

### DIFF
--- a/.changeset/quiet-countries-fetch.md
+++ b/.changeset/quiet-countries-fetch.md
@@ -1,0 +1,5 @@
+---
+"@shopware/composables": patch
+---
+
+Allow passing custom criteria to `useCountries`.

--- a/packages/composables/src/useCountries/useCountries.test.ts
+++ b/packages/composables/src/useCountries/useCountries.test.ts
@@ -2,6 +2,8 @@ import { encodeForQuery } from "@shopware/api-client/helpers";
 import { describe, expect, it, vi } from "vitest";
 import { ref } from "vue";
 
+import type { Schemas } from "#shopware";
+
 import { useSetup } from "../_test";
 import CountryMock from "../mocks/Country";
 import { useCountries } from "./useCountries";
@@ -124,7 +126,7 @@ describe("useCountries", () => {
   });
 
   it("uses criteria passed to useCountries", async () => {
-    const criteria = { limit: 1 };
+    const criteria: Schemas["Criteria"] = { limit: 1 };
     const { vm, injections } = await useSetup(() => useCountries(criteria), {
       apiClient: {
         invoke: vi.fn().mockResolvedValue({ data: CountryMock }),
@@ -146,7 +148,7 @@ describe("useCountries", () => {
   });
 
   it("uses criteria passed to useCountries for cacheable fetchCountries", async () => {
-    const criteria = { limit: 1 };
+    const criteria: Schemas["Criteria"] = { limit: 1 };
     const { vm, injections } = await useSetup(() => useCountries(criteria), {
       shopware: { cacheableReads: true },
       apiClient: {
@@ -165,6 +167,28 @@ describe("useCountries", () => {
             associations: { states: {} },
             limit: 1,
           }),
+        },
+      }),
+    );
+  });
+
+  it("uses criteria passed to useCountries on mountedCallback", async () => {
+    const criteria: Schemas["Criteria"] = { limit: 1 };
+    const { vm, injections } = await useSetup(() => useCountries(criteria), {
+      apiClient: {
+        invoke: vi.fn().mockResolvedValue({ data: CountryMock }),
+      },
+      swCountries: ref(),
+    } as Parameters<typeof useSetup>[1]);
+
+    await vm.mountedCallback();
+
+    expect(injections.apiClient.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("readCountry post"),
+      expect.objectContaining({
+        body: {
+          associations: { states: {} },
+          limit: 1,
         },
       }),
     );

--- a/packages/composables/src/useCountries/useCountries.test.ts
+++ b/packages/composables/src/useCountries/useCountries.test.ts
@@ -123,6 +123,53 @@ describe("useCountries", () => {
     );
   });
 
+  it("uses criteria passed to useCountries", async () => {
+    const criteria = { limit: 1 };
+    const { vm, injections } = await useSetup(() => useCountries(criteria), {
+      apiClient: {
+        invoke: vi.fn().mockResolvedValue({ data: CountryMock }),
+      },
+      swCountries: ref([]),
+    } as Parameters<typeof useSetup>[1]);
+
+    await vm.fetchCountries();
+
+    expect(injections.apiClient.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("readCountry post"),
+      expect.objectContaining({
+        body: {
+          associations: { states: {} },
+          limit: 1,
+        },
+      }),
+    );
+  });
+
+  it("uses criteria passed to useCountries for cacheable fetchCountries", async () => {
+    const criteria = { limit: 1 };
+    const { vm, injections } = await useSetup(() => useCountries(criteria), {
+      shopware: { cacheableReads: true },
+      apiClient: {
+        invoke: vi.fn().mockResolvedValue({ data: CountryMock }),
+      },
+      swCountries: ref([]),
+    } as Parameters<typeof useSetup>[1]);
+
+    await vm.fetchCountries();
+
+    expect(injections.apiClient.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("readCountryGet get"),
+      expect.objectContaining({
+        query: {
+          _criteria: encodeForQuery({
+            associations: { states: {} },
+            limit: 1,
+          }),
+        },
+      }),
+    );
+  });
+
   it("should not fetch when swCountries already populated", async () => {
     const preloadedCountries = ref(CountryMock.elements);
     const { vm, injections } = await useSetup(useCountries, {

--- a/packages/composables/src/useCountries/useCountries.test.ts
+++ b/packages/composables/src/useCountries/useCountries.test.ts
@@ -10,7 +10,7 @@ import { useCountries } from "./useCountries";
 
 describe("useCountries", () => {
   it("useCountries flow", async () => {
-    const { vm, injections } = await useSetup(useCountries, {
+    const { vm, injections } = await useSetup(() => useCountries(), {
       apiClient: {
         invoke: vi.fn().mockResolvedValue({
           data: CountryMock,
@@ -32,7 +32,7 @@ describe("useCountries", () => {
   });
 
   it("useCountries flow - no states", async () => {
-    const { vm } = await useSetup(useCountries, {
+    const { vm } = await useSetup(() => useCountries(), {
       apiClient: {
         invoke: vi.fn().mockResolvedValue({
           data: {
@@ -53,7 +53,7 @@ describe("useCountries", () => {
   });
 
   it("useCountries flow - empty", async () => {
-    const { vm } = await useSetup(useCountries, {
+    const { vm } = await useSetup(() => useCountries(), {
       apiClient: {
         invoke: vi.fn().mockResolvedValue({
           data: {
@@ -68,7 +68,7 @@ describe("useCountries", () => {
   });
 
   it("useCountries flow - getCountriesOptions", async () => {
-    const { vm } = await useSetup(useCountries, {
+    const { vm } = await useSetup(() => useCountries(), {
       apiClient: {
         invoke: vi.fn().mockResolvedValue({
           data: CountryMock,
@@ -95,7 +95,7 @@ describe("useCountries", () => {
   });
 
   it("useCountries flow - getCountriesOptions - empty array", async () => {
-    const { vm } = await useSetup(useCountries, {
+    const { vm } = await useSetup(() => useCountries(), {
       apiClient: {
         invoke: vi.fn().mockResolvedValue({
           data: {
@@ -109,7 +109,7 @@ describe("useCountries", () => {
   });
 
   it("uses the cacheable GET variant when cacheableReads is enabled", async () => {
-    const { vm, injections } = await useSetup(useCountries, {
+    const { vm, injections } = await useSetup(() => useCountries(), {
       shopware: { cacheableReads: true },
       apiClient: {
         invoke: vi.fn().mockResolvedValue({ data: CountryMock }),
@@ -196,7 +196,7 @@ describe("useCountries", () => {
 
   it("should not fetch when swCountries already populated", async () => {
     const preloadedCountries = ref(CountryMock.elements);
-    const { vm, injections } = await useSetup(useCountries, {
+    const { vm, injections } = await useSetup(() => useCountries(), {
       apiClient: { invoke: vi.fn() },
       swCountries: preloadedCountries,
     } as Parameters<typeof useSetup>[1]);

--- a/packages/composables/src/useCountries/useCountries.ts
+++ b/packages/composables/src/useCountries/useCountries.ts
@@ -1,4 +1,5 @@
 import { encodeForQuery } from "@shopware/api-client/helpers";
+import { defu } from "defu";
 import { computed, inject, onMounted, provide, ref } from "vue";
 import type { ComputedRef } from "vue";
 
@@ -25,24 +26,27 @@ export type UseCountriesReturn = {
  * @public
  * @category Context & Language
  */
-export function useCountries(): UseCountriesReturn {
+export function useCountries(
+  criteria?: Schemas["Criteria"],
+): UseCountriesReturn {
   const { apiClient, cacheableReads } = useShopwareContext();
 
   const _sharedCountries = inject("swCountries", ref());
   provide("swCountries", _sharedCountries);
+  const searchCriteria = ref(criteria ?? {});
 
   async function fetchCountries() {
-    const criteria = {
+    const queryCriteria = defu(searchCriteria.value, {
       associations: {
         states: {},
       },
-    };
+    } as Schemas["Criteria"]);
     const result = cacheableReads
       ? await apiClient.invoke("readCountryGet get /country", {
-          query: { _criteria: encodeForQuery(criteria) },
+          query: { _criteria: encodeForQuery(queryCriteria) },
         })
       : await apiClient.invoke("readCountry post /country", {
-          body: criteria,
+          body: queryCriteria,
         });
     _sharedCountries.value = result.data.elements;
     return result.data;


### PR DESCRIPTION
This pull request adds support for passing custom criteria to the `useCountries` composable, allowing consumers to filter or limit the countries returned. It also includes new tests to ensure the criteria are correctly handled for both standard and cacheable fetches.

**Feature enhancement:**

* `useCountries` now accepts an optional `criteria` parameter, which is merged with default associations and used in API requests. [[1]](diffhunk://#diff-6e57946739c67023e44240b57203f75c40f388b1d4bf1318abab0de5773f43f9L28-R49) [[2]](diffhunk://#diff-4a59b3c89fee3704a0504c2aa6a032461e64ba2d04bdfb2e18a33495cf829b83R1-R5)
* The `defu` package is used to merge user-provided criteria with defaults, ensuring flexibility and backward compatibility.

**Testing improvements:**

* Added tests to verify that custom criteria are correctly passed to the API client for both standard and cacheable fetches in `useCountries`.

closes #2042 

