### PR TITLE
chore: update turbo and use oxfmt in api-gen

### DIFF
--- a/.changeset/modern-api-gen-formatter.md
+++ b/.changeset/modern-api-gen-formatter.md
@@ -1,0 +1,5 @@
+---
+"@shopware/api-gen": patch
+---
+
+Use `oxfmt` instead of Prettier for generated API files.

--- a/package.json
+++ b/package.json
@@ -46,10 +46,9 @@
     "dotenv-cli": "11.0.0",
     "esno": "4.8.0",
     "husky": "9.1.7",
-    "prettier": "3.8.3",
-    "turbo": "2.9.18",
     "oxfmt": "0.55.0",
-    "oxlint": "1.70.0"
+    "oxlint": "1.70.0",
+    "turbo": "2.10.0"
   },
   "engines": {
     "node": "^20.x || ^22.x || ^24.x"

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -67,12 +67,10 @@
     "generate-admin-types": "esno ../api-gen/src/cli.ts generate --apiType=admin"
   },
   "devDependencies": {
-    "@types/prettier": "3.0.0",
     "@typescript/native-preview": "7.0.0-dev.20260205.1",
     "@vitest/coverage-v8": "4.1.9",
     "fflate": "0.8.3",
     "happy-dom": "20.10.6",
-    "prettier": "3.8.3",
     "tsconfig": "workspace:*",
     "unbuild": "3.6.1",
     "vitest": "4.1.9"

--- a/packages/api-gen/build.config.ts
+++ b/packages/api-gen/build.config.ts
@@ -6,5 +6,5 @@ export default defineBuildConfig({
     cjsBridge: true,
   },
   declaration: true,
-  externals: ["prettier"],
+  externals: ["oxfmt"],
 });

--- a/packages/api-gen/package.json
+++ b/packages/api-gen/package.json
@@ -46,7 +46,6 @@
     "test:watch": "vitest --typecheck"
   },
   "devDependencies": {
-    "@types/prettier": "3.0.0",
     "@types/yargs": "17.0.35",
     "@typescript/native-preview": "7.0.0-dev.20260205.1",
     "@vitest/coverage-v8": "4.1.9",
@@ -60,7 +59,7 @@
     "@shopware/api-client": "workspace:*",
     "ofetch": "1.5.1",
     "openapi-typescript": "7.8.0",
-    "prettier": "3.8.3",
+    "oxfmt": "0.55.0",
     "ts-morph": "27.0.2",
     "typescript": "5.9.3",
     "yargs": "18.0.0"

--- a/packages/api-gen/src/commands/generate.ts
+++ b/packages/api-gen/src/commands/generate.ts
@@ -11,9 +11,9 @@ import openapiTS, {
 import "dotenv/config";
 import type { OpenAPI3, SchemaObject } from "openapi-typescript";
 import c from "picocolors";
-import { format } from "prettier";
 import ts from "typescript";
 
+import { formatSource } from "../formatSource";
 import type { TransformedElements } from "../generateFile";
 import {
   displayPatchingSummary,
@@ -256,11 +256,7 @@ export async function generate(args: {
         });
         console.log(`[DEBUG]: Debug Schema saved to ${fullOutputFilePath}`);
 
-        schema = await format(schema, {
-          // semi: false,
-          parser: "typescript",
-          // plugins: [tsParser],
-        });
+        schema = await formatSource(fullOutputFilePath, schema);
         schema = schema.trim();
       }
 

--- a/packages/api-gen/src/commands/loadSchema.ts
+++ b/packages/api-gen/src/commands/loadSchema.ts
@@ -3,11 +3,10 @@ import { join } from "node:path";
 
 // read .env file and load it into process.env
 import "dotenv/config";
-import json5 from "json5";
 import c from "picocolors";
-import { format } from "prettier";
 
 import { getAdminApiClient, getStoreApiClient } from "../apiClient";
+import { formatSource } from "../formatSource";
 import { validateAdminEnvVars } from "../validateEnv";
 
 const SCHEMA_ENDPOINT = "_info/openapi3.json";
@@ -107,10 +106,10 @@ export async function loadSchema(args: {
       apiJSON = result.data;
     }
 
-    const formatted = await format(json5.stringify(apiJSON), {
-      semi: false,
-      parser: "json",
-    });
+    const formatted = await formatSource(
+      outputFilename,
+      JSON.stringify(apiJSON, null, 2),
+    );
     const content = formatted.trim();
 
     // const version = apiJSON?.info?.version;

--- a/packages/api-gen/src/commands/split.ts
+++ b/packages/api-gen/src/commands/split.ts
@@ -2,8 +2,8 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { bundle, lint, loadConfig } from "@redocly/openapi-core";
-import { format } from "prettier";
 
+import { formatSource } from "../formatSource";
 import {
   createNewSchema,
   filterPathsByTag,
@@ -110,11 +110,9 @@ export async function split(options: SplitOptions): Promise<void> {
       const outputPath = resolve(outputDir || "output", fileName);
 
       mkdirSync(outputDir || "output", { recursive: true });
-      const formattedSchema = await format(
+      const formattedSchema = await formatSource(
+        outputPath,
         JSON.stringify(finalSchema, null, 2),
-        {
-          parser: "json",
-        },
       );
       writeFileSync(outputPath, formattedSchema);
       console.log(`Generated ${outputPath}`);
@@ -146,11 +144,9 @@ export async function split(options: SplitOptions): Promise<void> {
       const outputPath = resolve(outputDir || "output", fileName);
 
       mkdirSync(outputDir || "output", { recursive: true });
-      const formattedSchema = await format(
+      const formattedSchema = await formatSource(
+        outputPath,
         JSON.stringify(finalSchema, null, 2),
-        {
-          parser: "json",
-        },
       );
       writeFileSync(outputPath, formattedSchema);
       console.log(`Generated ${outputPath}`);

--- a/packages/api-gen/src/formatSource.test.ts
+++ b/packages/api-gen/src/formatSource.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { formatSource } from "./formatSource";
+
+describe("formatSource", () => {
+  it("formats TypeScript sources with api-gen defaults", async () => {
+    await expect(
+      formatSource(
+        "storeApiTypes.d.ts",
+        'export type operations={"read product":{response:{id:string}}}',
+      ),
+    ).resolves.toMatchInlineSnapshot(`
+      "export type operations = { "read product": { response: { id: string } } };
+      "
+    `);
+  });
+
+  it("formats JSON sources based on the file name", async () => {
+    await expect(
+      formatSource(
+        "storeApiSchema.json",
+        `{
+          "openapi": "3.1.0",
+          "paths": {
+            "/checkout/cart": {
+              "get": {}
+            }
+          }
+        }`,
+      ),
+    ).resolves.toMatchInlineSnapshot(`
+      "{
+        "openapi": "3.1.0",
+        "paths": {
+          "/checkout/cart": {
+            "get": {}
+          }
+        }
+      }
+      "
+    `);
+  });
+
+  it("allows call sites to override formatting options", async () => {
+    await expect(
+      formatSource("schema.ts", 'const value={label:"Shopware"}', {
+        semi: false,
+      }),
+    ).resolves.toMatchInlineSnapshot(`
+      "const value = { label: "Shopware" }
+      "
+    `);
+  });
+
+  it("throws a useful error when oxfmt cannot parse the source", async () => {
+    await expect(formatSource("broken.ts", "export type =")).rejects.toThrow(
+      "Could not format broken.ts:\nUnexpected token",
+    );
+  });
+});

--- a/packages/api-gen/src/formatSource.ts
+++ b/packages/api-gen/src/formatSource.ts
@@ -1,0 +1,39 @@
+import { format } from "oxfmt";
+import type { FormatConfig } from "oxfmt";
+
+const formatConfig = {
+  arrowParens: "always",
+  bracketSameLine: false,
+  bracketSpacing: true,
+  endOfLine: "lf",
+  printWidth: 80,
+  quoteProps: "as-needed",
+  semi: true,
+  singleQuote: false,
+  tabWidth: 2,
+  trailingComma: "all",
+  useTabs: false,
+} satisfies FormatConfig;
+
+export async function formatSource(
+  fileName: string,
+  sourceText: string,
+  options?: FormatConfig,
+) {
+  const result = await format(fileName, sourceText, {
+    ...formatConfig,
+    ...options,
+  });
+
+  if (result.errors.length) {
+    const messages = result.errors
+      .map((error) => error.message)
+      .filter(Boolean)
+      .join("\n");
+    throw new Error(
+      `Could not format ${fileName}${messages ? `:\n${messages}` : ""}`,
+    );
+  }
+
+  return result.code;
+}

--- a/packages/api-gen/src/generateFile.ts
+++ b/packages/api-gen/src/generateFile.ts
@@ -1,5 +1,6 @@
-import { format } from "prettier";
 import { Project } from "ts-morph";
+
+import { formatSource } from "./formatSource";
 
 export type MethodDefinition = {
   operationId: string;
@@ -292,9 +293,7 @@ export async function prepareFileContent({
 
   x += sourceFile.getFullText();
 
-  const formatted = await format(x, {
-    parser: "typescript",
-  });
+  const formatted = await formatSource(filepath, x);
   sourceFile.replaceWithText(formatted);
 
   return project;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,12 +70,9 @@ importers:
       oxlint:
         specifier: 1.70.0
         version: 1.70.0
-      prettier:
-        specifier: 3.8.3
-        version: 3.8.3
       turbo:
-        specifier: 2.9.18
-        version: 2.9.18
+        specifier: 2.10.0
+        version: 2.10.0
 
   apps/docs: {}
 
@@ -965,9 +962,6 @@ importers:
         specifier: 1.5.1
         version: 1.5.1
     devDependencies:
-      '@types/prettier':
-        specifier: 3.0.0
-        version: 3.0.0
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260205.1
         version: 7.0.0-dev.20260205.1
@@ -980,9 +974,6 @@ importers:
       happy-dom:
         specifier: 20.10.6
         version: 20.10.6
-      prettier:
-        specifier: 3.8.3
-        version: 3.8.3
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1004,9 +995,9 @@ importers:
       openapi-typescript:
         specifier: 7.8.0
         version: 7.8.0(typescript@5.9.3)
-      prettier:
-        specifier: 3.8.3
-        version: 3.8.3
+      oxfmt:
+        specifier: 0.55.0
+        version: 0.55.0
       ts-morph:
         specifier: 27.0.2
         version: 27.0.2
@@ -1017,9 +1008,6 @@ importers:
         specifier: 18.0.0
         version: 18.0.0
     devDependencies:
-      '@types/prettier':
-        specifier: 3.0.0
-        version: 3.0.0
       '@types/yargs':
         specifier: 17.0.35
         version: 17.0.35
@@ -6126,33 +6114,33 @@ packages:
   '@ts-morph/common@0.28.1':
     resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
 
-  '@turbo/darwin-64@2.9.18':
-    resolution: {integrity: sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw==}
+  '@turbo/darwin-64@2.10.0':
+    resolution: {integrity: sha512-EwvHThXzpY0KGd1/NAmuewI5D+aVa3Rl/OlxE36yfjUKb/+ySrfJrSlEFt8aD1OXwnnaHnQnPKHFndor0Zxlsg==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.9.18':
-    resolution: {integrity: sha512-9A6TMRq/Ib+QnbhLlgkhOm+624wO4pzSQ/yQviQfWHOlFvaYxdnIAYmu2H6TS6y7kSVL0DvzNe04NbESTOzFVQ==}
+  '@turbo/darwin-arm64@2.10.0':
+    resolution: {integrity: sha512-9d2fTyyG0lf5Wq1bwJA9qUaeecViMkLcdctWaMMmCkxZ/JqypmqOwK3W6vmejeKVgkr06gSoiX8bD+xN5Jpxcg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.9.18':
-    resolution: {integrity: sha512-zCdIDtz69AnbYh913elJRRoF3QY5aa2HNnf+4rAkc7bQ+tWujiDkCNV7stazOUPggaDvhKIf2Z87qHftTeXSkw==}
+  '@turbo/linux-64@2.10.0':
+    resolution: {integrity: sha512-sZBtjMuufitanjzi6UssoUpJMnnPlLMcdcJj3m3ptNsSq31Xh7MnjhwA5nWvLDTfEFg8GPcbYFXMo8vSdKRfqQ==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.9.18':
-    resolution: {integrity: sha512-Va1kXI04naMgYwqv/5Dfa36dTDx8015U7oaQAjrXa45ua9OoFjSV4OmvkML4EmXvUclQHCiBRbY8bvd0jV7eAg==}
+  '@turbo/linux-arm64@2.10.0':
+    resolution: {integrity: sha512-vkq/Z8R+1DQ+kifWFa810IjRy2NNBVvha3cg9sWA3nFh6nnGrHSMnnJKrzH7c/No9kq4Jb55Ru44YKsCSBgrKg==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.9.18':
-    resolution: {integrity: sha512-m0kDhZANxSNz9ck1ybogFscHabriAsp4eDFNrN/1H5WrgTF7b3VlcPZnhuO3v2+E2KnCbeAc+UUT10BZZHdDKw==}
+  '@turbo/windows-64@2.10.0':
+    resolution: {integrity: sha512-CRUEguLWxFQHptYZS7HjPhNhAFawfea07iR+xAQ5e4klgLrPCMdexBkXwSCwOxqTFknJ7RZFN3gOaADsw+Gttg==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.9.18':
-    resolution: {integrity: sha512-nUdR8WqoomUys9iIQmG45TMiizJ+5BV8egSeLLZba/AWblyp3fVBcIH1kSE58OtK4g2YzbMJEth6Ttv9w5rqMA==}
+  '@turbo/windows-arm64@2.10.0':
+    resolution: {integrity: sha512-dVHGaf9F8twzgibcBqKoADT/LLqf9++jDb+hq/LPWWaOmRpp4M+/pVOm7vy4z9D++xg8eaxWLT0+wQxFwhYu9A==}
     cpu: [arm64]
     os: [win32]
 
@@ -6270,10 +6258,6 @@ packages:
 
   '@types/paypal-checkout-components@4.0.8':
     resolution: {integrity: sha512-Z3IWbFPGdgL3O+Bg+TyVmMT8S3uGBsBjw3a8uRNR4OlYWa9m895djENErJMYU8itoki9rtcQMzoHOSFn8NFb1A==}
-
-  '@types/prettier@3.0.0':
-    resolution: {integrity: sha512-mFMBfMOz8QxhYVbuINtswBp9VL2b4Y0QqYHwqLz3YbgtfAcat2Dl6Y1o4e22S/OVE6Ebl9m7wWiMT2lSbAs1wA==}
-    deprecated: This is a stub types definition. prettier provides its own type definitions, so you do not need this installed.
 
   '@types/prismjs@1.26.6':
     resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
@@ -11625,8 +11609,8 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo@2.9.18:
-    resolution: {integrity: sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg==}
+  turbo@2.10.0:
+    resolution: {integrity: sha512-o016H9PPtuH2deb3mh3Vci3Avfi9UYgM/RONQisY7HnloupP0IFSbFS3gFYJgFJP8nwBrByHWFQIDa8T2zIXPw==}
     hasBin: true
 
   type-check@0.4.0:
@@ -19057,22 +19041,22 @@ snapshots:
       path-browserify: 1.0.1
       tinyglobby: 0.2.17
 
-  '@turbo/darwin-64@2.9.18':
+  '@turbo/darwin-64@2.10.0':
     optional: true
 
-  '@turbo/darwin-arm64@2.9.18':
+  '@turbo/darwin-arm64@2.10.0':
     optional: true
 
-  '@turbo/linux-64@2.9.18':
+  '@turbo/linux-64@2.10.0':
     optional: true
 
-  '@turbo/linux-arm64@2.9.18':
+  '@turbo/linux-arm64@2.10.0':
     optional: true
 
-  '@turbo/windows-64@2.9.18':
+  '@turbo/windows-64@2.10.0':
     optional: true
 
-  '@turbo/windows-arm64@2.9.18':
+  '@turbo/windows-arm64@2.10.0':
     optional: true
 
   '@tweenjs/tween.js@23.1.3': {}
@@ -19187,10 +19171,6 @@ snapshots:
   '@types/offscreencanvas@2019.7.3': {}
 
   '@types/paypal-checkout-components@4.0.8': {}
-
-  '@types/prettier@3.0.0':
-    dependencies:
-      prettier: 3.8.3
 
   '@types/prismjs@1.26.6': {}
 
@@ -27233,14 +27213,14 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  turbo@2.9.18:
+  turbo@2.10.0:
     optionalDependencies:
-      '@turbo/darwin-64': 2.9.18
-      '@turbo/darwin-arm64': 2.9.18
-      '@turbo/linux-64': 2.9.18
-      '@turbo/linux-arm64': 2.9.18
-      '@turbo/windows-64': 2.9.18
-      '@turbo/windows-arm64': 2.9.18
+      '@turbo/darwin-64': 2.10.0
+      '@turbo/darwin-arm64': 2.10.0
+      '@turbo/linux-64': 2.10.0
+      '@turbo/linux-arm64': 2.10.0
+      '@turbo/windows-64': 2.10.0
+      '@turbo/windows-arm64': 2.10.0
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
### Description

Update Turbo from 2.9.18 to 2.10.0 and replace @shopware/api-gen's Prettier-based generated file formatting with oxfmt. The PR removes now-unused direct Prettier declarations from root/api-client/api-gen manifests, keeps oxfmt externalized for api-gen, and adds unit coverage for the new formatter wrapper.

### Type of change

<!-- Bug fix (non-breaking change that fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality not to work as expected) -->

### ToDo's

- [x] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation)
- [ ] Documentation added/updated
- [x] Unit-Tests added/updated
- [ ] E2E-Tests added/updated
- [ ] Related Issue updated

### Screenshots (if applicable)

N/A

### Additional context

Verified with api-gen tests, typecheck, build, package lint checks, api-client typecheck/lint, and git diff checks.