### PR TITLE
fix(templates): i18n config resolving

### DIFF
--- a/templates/vue-starter-template/nuxt.config.ts
+++ b/templates/vue-starter-template/nuxt.config.ts
@@ -56,7 +56,7 @@ export default defineNuxtConfig({
     defaultLocale: "en-GB",
     detectBrowserLanguage: false,
     langDir: "./src/langs/",
-    vueI18n: resolve("./config"),
+    vueI18n: "config.ts",
     locales: [
       {
         code: "en-GB",


### PR DESCRIPTION
### Description

Fix the @nuxtjs/i18n v10 config resolution in the vue-starter-template by setting vueI18n to a path relative to the i18n/ dir ("config.ts") instead of an absolute resolve("./config"), which pointed at the wrong directory and broke when the template is consumed as a Nuxt layer.

```[nuxt-i18n 11:25:44 AM]  WARN  Vue I18n configuration file /templates/vue-starter-template/config not found in /templates/vue-starter-template/i18n. Skipping...```

