### PR TITLE
fix(templates): proper locale loading

### DIFF
--- a/examples/snippets-middleware/i18n/langs/de-DE.ts
+++ b/examples/snippets-middleware/i18n/langs/de-DE.ts
@@ -1,3 +1,3 @@
-export default defineI18nLocale(async (locale) => {
+export default async (locale: string) => {
   return $fetch(`/api/translations?locale=${locale}`);
-});
+};

--- a/examples/snippets-middleware/i18n/langs/en-GB.ts
+++ b/examples/snippets-middleware/i18n/langs/en-GB.ts
@@ -1,3 +1,3 @@
-export default defineI18nLocale(async (locale) => {
+export default async (locale: string) => {
   return $fetch(`/api/translations?locale=${locale}`);
-});
+};

--- a/templates/vue-demo-store/i18n/src/langs/de-DE.ts
+++ b/templates/vue-demo-store/i18n/src/langs/de-DE.ts
@@ -1,2 +1,2 @@
 import deDE from "../../de-DE/de-DE";
-export default defineI18nLocale(() => deDE);
+export default () => deDE;

--- a/templates/vue-demo-store/i18n/src/langs/en-GB.ts
+++ b/templates/vue-demo-store/i18n/src/langs/en-GB.ts
@@ -1,2 +1,2 @@
 import enGB from "../../en-GB/en-GB";
-export default defineI18nLocale(() => enGB);
+export default () => enGB;

--- a/templates/vue-demo-store/i18n/src/langs/pl-PL.ts
+++ b/templates/vue-demo-store/i18n/src/langs/pl-PL.ts
@@ -1,2 +1,2 @@
 import plPL from "../../pl-PL/pl-PL";
-export default defineI18nLocale(() => plPL);
+export default () => plPL;

--- a/templates/vue-starter-template/i18n/src/langs/de-DE.ts
+++ b/templates/vue-starter-template/i18n/src/langs/de-DE.ts
@@ -1,2 +1,2 @@
 import deDE from "../../de-DE/de-DE";
-export default defineI18nLocale(() => deDE);
+export default () => deDE;

--- a/templates/vue-starter-template/i18n/src/langs/en-GB.ts
+++ b/templates/vue-starter-template/i18n/src/langs/en-GB.ts
@@ -1,2 +1,2 @@
 import enGB from "../../en-GB/en-GB";
-export default defineI18nLocale(() => enGB);
+export default () => enGB;

--- a/templates/vue-starter-template/i18n/src/langs/pl-PL.ts
+++ b/templates/vue-starter-template/i18n/src/langs/pl-PL.ts
@@ -1,2 +1,2 @@
 import plPL from "../../pl-PL/pl-PL";
-export default defineI18nLocale(() => plPL);
+export default () => plPL;


### PR DESCRIPTION
### Description

fix for 
<img width="943" height="269" alt="image" src="https://github.com/user-attachments/assets/4d7e9375-19a1-4536-a130-22e58ccbcba2" />



### Additional context

After the i18n v10 upgrade, the dev-mode SSR pipeline stopped unwrapping our defineI18nLocale(...) locale exports, so the validator rejected them and no translations loaded (production was unaffected).
