### PR TITLE
refactor(templates): enhance currency handling in MetaNavigation

### DIFF
--- a/templates/vue-starter-template/app/components/layout/MetaNavigation.vue
+++ b/templates/vue-starter-template/app/components/layout/MetaNavigation.vue
@@ -22,17 +22,19 @@ const emit = defineEmits<{
   onCurrencyChangeHandler: [string];
 }>();
 
+const selectedCurrencyId = computed({
+  get: () => props.changingCurrencyId ?? props.currentCurrencyId,
+  set: (currencyId: string) => {
+    if (currencyId && currencyId !== props.currentCurrencyId) {
+      emit("onCurrencyChangeHandler", currencyId);
+    }
+  },
+});
+
 function changeLanguage(event: Event) {
   const languageId = (event.target as HTMLSelectElement).value;
   if (languageId && languageId !== props.currentLanguageId) {
     emit("onLanguageChangeHandler", languageId);
-  }
-}
-
-function changeCurrency(event: Event) {
-  const currencyId = (event.target as HTMLSelectElement).value;
-  if (currencyId && currencyId !== props.currentCurrencyId) {
-    emit("onCurrencyChangeHandler", currencyId);
   }
 }
 </script>
@@ -83,11 +85,10 @@ function changeCurrency(event: Event) {
           <select
             class="h-full min-w-23 appearance-none bg-transparent pr-7 text-sm font-medium outline-none disabled:cursor-not-allowed"
             :aria-label="$t('layout.ariaLabels.currencySwitcher')"
-            :value="currentCurrencyId"
+            v-model="selectedCurrencyId"
             :disabled="
               currencies.length < 2 || Boolean(props.changingCurrencyId)
             "
-            @change="changeCurrency"
           >
             <option
               v-for="currency in currencies"

--- a/templates/vue-starter-template/nuxt.config.ts
+++ b/templates/vue-starter-template/nuxt.config.ts
@@ -19,6 +19,9 @@ export default defineNuxtConfig({
         endpoint: "https://demo-frontends.shopware.store/store-api/",
         accessToken: "SWSCNWDGMUWZM0TLVUU0YKLQVW",
         devStorefrontUrl: "https://frontends-demo.vercel.app",
+        // Uses the Shopware context cookie during SSR, so the first render matches
+        // the user's currency. Disable shared HTML cache/ISR for these pages.
+        // useUserContextInSSR: true,
       },
     },
   },
@@ -85,9 +88,13 @@ export default defineNuxtConfig({
   },
   routeRules: {
     "/**": {
-      // 24-hour ISR — reduce for frequently updated catalogs or CMS-heavy storefronts
+      // 24-hour ISR — reduce for frequently updated catalogs or CMS-heavy storefronts.
+      // If SSR uses the user's Shopware context for currency, disable this shared
+      // HTML cache and use the no-store headers below to avoid currency flicker.
       isr: 60 * 60 * 24,
       headers: {
+        // "Cache-Control": "private, no-store, max-age=0",
+        // "Surrogate-Control": "no-store",
         "Surrogate-Control": "max-age=86400, stale-while-revalidate=86400",
       },
     },


### PR DESCRIPTION
This pull request updates the currency selection logic in the `MetaNavigation.vue` component to use a computed property with `v-model`, streamlining how currency changes are handled and improving reactivity. It also adds documentation in `nuxt.config.ts` about how to handle SSR context and caching when currency is user-specific.

Currency selection improvements:

* Replaced the `changeCurrency` method and `@change` event with a `selectedCurrencyId` computed property using `v-model`, ensuring currency changes are handled reactively and consistently in the template. [[1]](diffhunk://#diff-d893a9ff6c0182ecfe0183eaaee5265401fcacf830dc884fc8156c54cea6d551R25-L37) [[2]](diffhunk://#diff-d893a9ff6c0182ecfe0183eaaee5265401fcacf830dc884fc8156c54cea6d551L86-L90)

SSR context and caching documentation:

* Added comments in `nuxt.config.ts` explaining how to enable SSR to use the user's Shopware context for currency, and how to adjust caching rules to prevent currency flicker by disabling shared HTML cache and using appropriate headers. [[1]](diffhunk://#diff-10e25a1f474625985a98f7b52c9b0ae1a2ef0f28e8158dcf0a40d4d218cfd7c7R22-R24) [[2]](diffhunk://#diff-10e25a1f474625985a98f7b52c9b0ae1a2ef0f28e8158dcf0a40d4d218cfd7c7L88-R97)
