### PR TITLE
fix(templates): stackblitz start command

### DIFF
--- a/templates/vue-blank/.stackblitzrc
+++ b/templates/vue-blank/.stackblitzrc
@@ -1,8 +1,9 @@
 {
   "env": {
     "NODE_OPTIONS": "--no-warnings",
+    "NODE_NO_WARNINGS": "1",
     "NUXT_TELEMETRY_DISABLED": "1",
     "SHOPWARE_STACKBLITZ": "true"
   },
-  "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr NODE_NO_WARNINGS=1"
+  "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr"
 }

--- a/templates/vue-starter-template-extended/.stackblitzrc
+++ b/templates/vue-starter-template-extended/.stackblitzrc
@@ -1,8 +1,9 @@
 {
   "env": {
     "NODE_OPTIONS": "--no-warnings",
+    "NODE_NO_WARNINGS": "1",
     "NUXT_TELEMETRY_DISABLED": "1",
     "SHOPWARE_STACKBLITZ": "true"
   },
-  "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr NODE_NO_WARNINGS=1"
+  "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr"
 }

--- a/templates/vue-starter-template/.stackblitzrc
+++ b/templates/vue-starter-template/.stackblitzrc
@@ -1,8 +1,9 @@
 {
   "env": {
     "NODE_OPTIONS": "--no-warnings",
+    "NODE_NO_WARNINGS": "1",
     "NUXT_TELEMETRY_DISABLED": "1",
     "SHOPWARE_STACKBLITZ": "true"
   },
-  "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr NODE_NO_WARNINGS=1"
+  "startCommand": "pnpm exec nuxt prepare && pnpm exec nuxt dev --no-qr"
 }


### PR DESCRIPTION
## Fix StackBlitz start command for Vue templates

- Trailing `NODE_NO_WARNINGS=1` in `startCommand` was parsed by the Nuxt CLI as the positional `[rootDir]` arg
- Nuxt booted in a phantom `NODE_NO_WARNINGS=1/` dir with no config/layers/`app.vue`, serving the default `NuxtWelcome` page instead of the storefront
- Removed the stray positional and moved `NODE_NO_WARNINGS` into the `env` block where it belongs
- Applied to all three affected templates: `vue-starter-template`, `vue-starter-template-extended`, `vue-blank`
