### PR TITLE
chore: tune dependabot update cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 2
     versioning-strategy: "increase"
+    cooldown:
+      default-days: 4
+      exclude:
+        - "@shopware/*"
     ignore:
       # not upgrading until we move to new docs
       - dependency-name: "vitepress-shopware-docs"


### PR DESCRIPTION
### Description

Reduces npm Dependabot open PR concurrency from 3 to 2 and adds a 4-day cooldown for version updates, with `@shopware/*` excluded so internal packages can still update immediately. Existing dependency groups and the daily schedule are left unchanged.

### Type of change

Chore / maintenance

### ToDo's

No changeset needed; this only updates repository automation.

### Screenshots (if applicable)

Not applicable.

### Additional context

The cooldown mirrors the pnpm minimum release age with an extra day of buffer.