### PR TITLE
fix: state name in order status component

### DIFF
--- a/templates/vue-demo-store/app/components/account/order/Status.vue
+++ b/templates/vue-demo-store/app/components/account/order/Status.vue
@@ -1,12 +1,16 @@
 <script lang="ts" setup>
 import type { Schemas } from "#shopware";
 
-const props = defineProps<{
+const { state } = defineProps<{
   state: Schemas["StateMachineState"];
 }>();
 
+const stateName = computed(() => {
+  return state.translated?.name ?? state.name ?? state.technicalName;
+});
+
 const statusClass = computed(() => {
-  switch (props.state.technicalName) {
+  switch (state.technicalName) {
     case "completed":
       return "bg-states-success-container text-states-on-success-container";
     case "open":
@@ -23,6 +27,6 @@ const statusClass = computed(() => {
   <span
     class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full"
     :class="statusClass"
-    >{{ state.name }}</span
+    >{{ stateName }}</span
   >
 </template>

--- a/templates/vue-starter-template/app/components/account/order/Status.vue
+++ b/templates/vue-starter-template/app/components/account/order/Status.vue
@@ -1,12 +1,16 @@
 <script lang="ts" setup>
 import type { Schemas } from "#shopware";
 
-const props = defineProps<{
+const { state } = defineProps<{
   state: Schemas["StateMachineState"];
 }>();
 
+const stateName = computed(() => {
+  return state.translated?.name ?? state.name ?? state.technicalName;
+});
+
 const statusClass = computed(() => {
-  switch (props.state.technicalName) {
+  switch (state.technicalName) {
     case "completed":
       return "bg-green-100 text-green-800";
     case "open":
@@ -23,6 +27,6 @@ const statusClass = computed(() => {
   <span
     class="px-1.5 py-1 inline-flex text-xs leading-5 font-semibold rounded"
     :class="statusClass"
-    >{{ state.name }}</span
+    >{{ stateName }}</span
   >
 </template>


### PR DESCRIPTION

<img width="418" height="134" alt="Screenshot 2026-07-08 at 10 36 00" src="https://github.com/user-attachments/assets/26b2b56f-14e3-4fb1-b364-f38fbd109ab0" />
<img width="294" height="159" alt="Screenshot 2026-07-08 at 10 36 18" src="https://github.com/user-attachments/assets/34fdd1b1-ac15-4778-b0e4-d3a56b95e4a1" />


 closes #2545


This pull request refactors the order status display logic in both the `vue-demo-store` and `vue-starter-template` projects to improve how the status name is determined and displayed. The main change is to prioritize showing a translated status name if available, falling back to the raw name or technical name as needed.

**Order status display improvements:**

* Replaced direct usage of `state.name` in the `Status.vue` components with a computed property `stateName` that prefers `state.translated?.name`, then `state.name`, and finally `state.technicalName` for display. [[1]](diffhunk://#diff-2fe67d90c364374a66126d0c7950b4d0b24b58d9bdd45fee56f6e405242bb7a1L4-R13) [[2]](diffhunk://#diff-6803cf4cc1f4fc52164703051abd32991bcd62d6965d46d957d3d27319ed9a4eL4-R13)
* Updated the template to use the new `stateName` computed property for displaying the status name, ensuring better localization and fallback behavior. [[1]](diffhunk://#diff-2fe67d90c364374a66126d0c7950b4d0b24b58d9bdd45fee56f6e405242bb7a1L26-R30) [[2]](diffhunk://#diff-6803cf4cc1f4fc52164703051abd32991bcd62d6965d46d957d3d27319ed9a4eL26-R30)

**Code consistency and clarity:**

* Refactored prop destructuring for `state` and updated all references from `props.state` to `state` for clarity and consistency. [[1]](diffhunk://#diff-2fe67d90c364374a66126d0c7950b4d0b24b58d9bdd45fee56f6e405242bb7a1L4-R13) [[2]](diffhunk://#diff-6803cf4cc1f4fc52164703051abd32991bcd62d6965d46d957d3d27319ed9a4eL4-R13)