### PR TITLE
chore(deps): add scule package and update package.json 

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -469,7 +469,7 @@ importers:
     devDependencies:
       '@nuxtjs/i18n':
         specifier: 10.4.0
-        version: 10.4.0(@netlify/blobs@9.1.2)(@vercel/blob@1.0.2)(@vue/compiler-dom@3.5.38)(db0@0.3.4)(eslint@10.3.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.3)(rollup@4.60.4)(supports-color@10.0.0)(typescript@5.9.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3))
+        version: 10.4.0(@netlify/blobs@9.1.2)(@vercel/blob@1.0.2)(@vue/compiler-dom@3.5.38)(db0@0.3.4)(eslint@10.3.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.3)(rollup@4.60.4)(typescript@5.9.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3))
       '@unocss/nuxt':
         specifier: 66.7.4
         version: 66.7.4(esbuild@0.28.1)(magicast@0.5.3)(rolldown@1.1.4)(rollup@4.60.4)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1))
@@ -1377,6 +1377,9 @@ importers:
       requrl:
         specifier: 3.0.2
         version: 3.0.2
+      scule:
+        specifier: 1.3.0
+        version: 1.3.0
       sitemap:
         specifier: 8.0.0
         version: 8.0.0
@@ -1477,6 +1480,9 @@ importers:
       nuxt:
         specifier: 4.4.8
         version: 4.4.8(@babel/plugin-proposal-decorators@7.25.9(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@26.1.0)(@vercel/blob@1.0.2)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(esbuild@0.28.1)(eslint@10.3.0(jiti@2.7.0))(ioredis@5.10.1)(less@4.2.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.4)(rollup@4.60.4))(rollup@4.60.4)(sass@1.89.2)(terser@5.48.0)(tsx@4.23.0)(typescript@5.9.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@5.9.3))(yaml@2.9.0)
+      scule:
+        specifier: 1.3.0
+        version: 1.3.0
       unocss:
         specifier: 66.7.4
         version: 66.7.4(@unocss/webpack@66.7.4(esbuild@0.28.1)(rolldown@1.1.4)(rollup@4.60.4)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.4(esbuild@0.28.1)(postcss@8.5.15)))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -14456,31 +14462,6 @@ snapshots:
       - supports-color
       - typescript
 
-  '@intlify/unplugin-vue-i18n@11.2.1(@vue/compiler-dom@3.5.38)(eslint@10.3.0(jiti@2.7.0))(rollup@4.60.4)(supports-color@10.0.0)(typescript@5.9.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vue-i18n@11.4.5(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0(jiti@2.7.0))
-      '@intlify/bundle-utils': 11.2.1(vue-i18n@11.4.5(vue@3.5.38(typescript@5.9.3)))
-      '@intlify/shared': 11.4.2
-      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.4.2)(@vue/compiler-dom@3.5.38)(vue-i18n@11.4.5(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
-      '@typescript-eslint/scope-manager': 8.17.0
-      '@typescript-eslint/typescript-estree': 8.32.0(supports-color@10.0.0)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@10.0.0)
-      fast-glob: 3.3.3
-      pathe: 2.0.3
-      picocolors: 1.1.1
-      unplugin: 2.3.11
-      vue: 3.5.38(typescript@5.9.3)
-    optionalDependencies:
-      vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
-      vue-i18n: 11.4.5(vue@3.5.38(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@vue/compiler-dom'
-      - eslint
-      - rollup
-      - supports-color
-      - typescript
-
   '@intlify/unplugin-vue-i18n@11.2.1(@vue/compiler-dom@3.5.38)(eslint@10.3.0(jiti@2.7.0))(rollup@4.60.4)(typescript@5.9.3)(vite@8.1.3(@types/node@22.13.14)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vue-i18n@11.4.5(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0(jiti@2.7.0))
@@ -16646,66 +16627,6 @@ snapshots:
       - '@deno/kv'
       - '@emnapi/core'
       - '@emnapi/runtime'
-      - '@netlify/blobs'
-      - '@pinia/colada'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vue/compiler-dom'
-      - aws4fetch
-      - db0
-      - eslint
-      - idb-keyval
-      - ioredis
-      - magicast
-      - petite-vue-i18n
-      - pinia
-      - rollup
-      - supports-color
-      - typescript
-      - uploadthing
-      - vite
-      - vue
-
-  '@nuxtjs/i18n@10.4.0(@netlify/blobs@9.1.2)(@vercel/blob@1.0.2)(@vue/compiler-dom@3.5.38)(db0@0.3.4)(eslint@10.3.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.3)(rollup@4.60.4)(supports-color@10.0.0)(typescript@5.9.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3))':
-    dependencies:
-      '@intlify/core': 11.4.5
-      '@intlify/h3': 0.7.4
-      '@intlify/shared': 11.4.2
-      '@intlify/unplugin-vue-i18n': 11.2.1(@vue/compiler-dom@3.5.38)(eslint@10.3.0(jiti@2.7.0))(rollup@4.60.4)(supports-color@10.0.0)(typescript@5.9.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vue-i18n@11.4.5(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))
-      '@intlify/utils': 0.14.1
-      '@miyaneee/rollup-plugin-json5': 1.2.0(rollup@4.60.4)
-      '@nuxt/kit': 4.4.8(magicast@0.5.3)
-      '@rollup/plugin-yaml': 4.1.2(rollup@4.60.4)
-      '@vue/compiler-sfc': 3.5.38
-      defu: 6.1.7
-      devalue: 5.8.1
-      h3: 1.15.11
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      nuxt-define: 1.0.0
-      oxc-parser: 0.128.0
-      oxc-transform: 0.128.0
-      oxc-walker: 0.7.0(oxc-parser@0.128.0)
-      pathe: 2.0.3
-      ufo: 1.6.4
-      unplugin: 3.0.0
-      unrouting: 0.1.7
-      unstorage: 1.17.5(@netlify/blobs@9.1.2)(@vercel/blob@1.0.2)(db0@0.3.4)(ioredis@5.10.1)
-      vue-i18n: 11.4.5(vue@3.5.38(typescript@5.9.3))
-      vue-router: 5.1.0(@vue/compiler-sfc@3.5.38)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
       - '@netlify/blobs'
       - '@pinia/colada'
       - '@planetscale/database'
@@ -18961,20 +18882,6 @@ snapshots:
   '@typescript-eslint/types@8.17.0': {}
 
   '@typescript-eslint/types@8.32.0': {}
-
-  '@typescript-eslint/typescript-estree@8.32.0(supports-color@10.0.0)(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.32.0
-      '@typescript-eslint/visitor-keys': 8.32.0
-      debug: 4.4.3(supports-color@10.0.0)
-      fast-glob: 3.3.3
-      is-glob: 4.0.3
-      minimatch: 10.2.5
-      semver: 7.8.5
-      ts-api-utils: 2.1.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/typescript-estree@8.32.0(typescript@5.9.3)':
     dependencies:

--- a/templates/vue-demo-store/package.json
+++ b/templates/vue-demo-store/package.json
@@ -29,6 +29,7 @@
     "@vueuse/nuxt": "14.3.0",
     "defu": "6.1.7",
     "requrl": "3.0.2",
+    "scule": "1.3.0",
     "sitemap": "8.0.0",
     "unocss": "66.7.4",
     "vue": "3.5.39"
@@ -39,10 +40,10 @@
     "@nuxtjs/i18n": "10.4.0",
     "@shopware/api-gen": "canary",
     "nuxt": "4.4.8",
-    "typescript": "5.9.3",
-    "vite": "8.1.3",
     "oxfmt": "0.55.0",
-    "oxlint": "1.70.0"
+    "oxlint": "1.70.0",
+    "typescript": "5.9.3",
+    "vite": "8.1.3"
   },
   "engines": {
     "node": "^20.x || ^22.x || ^24.x"

--- a/templates/vue-starter-template/package.json
+++ b/templates/vue-starter-template/package.json
@@ -37,22 +37,23 @@
     "@shopware/helpers": "canary",
     "@shopware/nuxt-module": "canary",
     "@shopware/unocss-design-tokens-layer": "canary",
-    "@unocss/nuxt": "66.7.4",
     "@unocss/core": "66.7.4",
+    "@unocss/nuxt": "66.7.4",
     "@vueuse/core": "14.3.0",
     "@vueuse/nuxt": "14.3.0",
     "nuxt": "4.4.8",
+    "scule": "1.3.0",
     "unocss": "66.7.4",
     "vue": "3.5.39"
   },
   "devDependencies": {
     "@shopware/api-gen": "canary",
     "@vue/compiler-sfc": "3.5.39",
+    "oxfmt": "0.55.0",
+    "oxlint": "1.70.0",
     "typescript": "5.9.3",
     "vite": "8.1.3",
-    "vue-tsc": "3.3.6",
-    "oxfmt": "0.55.0",
-    "oxlint": "1.70.0"
+    "vue-tsc": "3.3.6"
   },
   "overrides": {
     "glob": "^13",


### PR DESCRIPTION
closes #2546 

This pull request updates dependencies in the `pnpm-lock.yaml` file and the `package.json` files for the Vue demo and starter templates. The most significant change is the addition of the `scule` package as a dependency in both templates. Additionally, there are minor adjustments to the ordering of existing dependencies and some lockfile deduplication or normalization.

**Dependency additions:**

* Added `scule@1.3.0` as a dependency in both `templates/vue-demo-store/package.json` and `templates/vue-starter-template/package.json`, and updated the `pnpm-lock.yaml` accordingly. [[1]](diffhunk://#diff-1b91167ce54b372bfa6ccd8a83a79a9db06bac21e2abec3077acd39595a491cbR32) [[2]](diffhunk://#diff-3d5660346318c3340d4f56f5d773d7ce8b91d0ddd1db40a4cfc086a46dcd340eL40-R56) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1380-R1382) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1483-R1485)

**Dependency and lockfile normalization:**

* Reordered some dependencies in `package.json` files for better organization, but with no functional impact. [[1]](diffhunk://#diff-1b91167ce54b372bfa6ccd8a83a79a9db06bac21e2abec3077acd39595a491cbL42-R46) [[2]](diffhunk://#diff-3d5660346318c3340d4f56f5d773d7ce8b91d0ddd1db40a4cfc086a46dcd340eL40-R56)
* Updated dependency resolution details for `@nuxtjs/i18n` and related packages in `pnpm-lock.yaml`, removing some peer and transitive dependencies and normalizing version references. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL472-R472) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL14459-L14483) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL16672-L16731) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL18965-L18978)