### PR TITLE
fix: suppress rolldown build warnings

### DIFF
--- a/.changeset/quiet-rolldown-build.md
+++ b/.changeset/quiet-rolldown-build.md
@@ -1,0 +1,5 @@
+---
+"@shopware/composables": patch
+---
+
+Suppress Rolldown diagnostic warnings for invalid third-party pure annotations and plugin timings in the Nuxt layer build config.

--- a/packages/composables/nuxt.config.ts
+++ b/packages/composables/nuxt.config.ts
@@ -8,6 +8,16 @@ export default defineNuxtConfig({
   build: {
     transpile: ["@shopware/composables"],
   },
+  vite: {
+    build: {
+      rolldownOptions: {
+        checks: {
+          invalidAnnotation: false,
+          pluginTimings: false,
+        },
+      },
+    },
+  },
   telemetry: {
     enabled: false,
   },


### PR DESCRIPTION
### Description

Suppresses Rolldown diagnostics for invalid third-party pure annotations and plugin timings in the composables Nuxt layer build config. Adds a patch changeset for `@shopware/composables`.

### Type of change

Bug fix (non-breaking change that fixes an issue)

### ToDo's

- [x] Changeset file provided
- [ ] Documentation added/updated
- [ ] Unit-Tests added/updated
- [ ] E2E-Tests added/updated
- [ ] Related Issue updated

### Screenshots (if applicable)

N/A

### Additional context

Verified with `pnpm --filter vue-demo-store build`, `pnpm --filter vue-blank build`, `pnpm run lint` via commit hook, and `git diff --check`.