### PR TITLE
fix: stabilize criteria query encoding

### DIFF
--- a/.changeset/stable-criteria-encoding.md
+++ b/.changeset/stable-criteria-encoding.md
@@ -1,0 +1,5 @@
+---
+"@shopware/api-client": patch
+---
+
+Make `_criteria` query encoding deterministic by pinning the gzip timestamp.

--- a/packages/api-client/src/helpers/encodeForQuery.test.ts
+++ b/packages/api-client/src/helpers/encodeForQuery.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { encodeForQuery } from "./encodeForQuery";
 
@@ -116,6 +116,23 @@ describe("encodeForQuery", () => {
     const result2 = encodeForQuery(obj);
 
     expect(result1).toBe(result2);
+  });
+
+  it("should produce consistent results when time changes", () => {
+    vi.useFakeTimers();
+    try {
+      const obj = { test: "value", number: 42 };
+
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      const result1 = encodeForQuery(obj);
+
+      vi.setSystemTime(new Date("2026-01-01T00:10:00Z"));
+      const result2 = encodeForQuery(obj);
+
+      expect(result1).toBe(result2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("should produce different results for different inputs", () => {

--- a/packages/api-client/src/helpers/encodeForQuery.ts
+++ b/packages/api-client/src/helpers/encodeForQuery.ts
@@ -8,7 +8,7 @@ import { gzipSync, strToU8 } from "fflate";
  */
 export function encodeForQuery(obj: unknown): string {
   const json = JSON.stringify(obj);
-  const compressed = gzipSync(strToU8(json));
+  const compressed = gzipSync(strToU8(json), { mtime: 0 });
 
   // Convert to base64url
   let base64 = btoa(String.fromCharCode.apply(null, Array.from(compressed)));


### PR DESCRIPTION
### Description

Fixes #2553 by pinning gzip `mtime` to `0` in `encodeForQuery`, making `_criteria` URLs stable for cacheable Store API reads.

### Type of change

Bug fix (non-breaking change that fixes an issue)

### ToDo's

- [x] Changeset file provided
- [x] Unit-Tests added/updated

### Screenshots (if applicable)

N/A

### Additional context

Validated with `pnpm --filter @shopware/api-client test`, `pnpm --filter @shopware/api-client lint`, and the commit hook lint run.