### PR TITLE
feat(vue-starter-template): enhance BaseButton and checkout flow 

### DIFF
--- a/templates/vue-starter-template/app/components/form/BaseButton.vue
+++ b/templates/vue-starter-template/app/components/form/BaseButton.vue
@@ -7,11 +7,15 @@ const {
   label,
   variant = "primary",
   size = "regular",
+  loading = false,
+  disabled = false,
 } = defineProps<{
   label?: string;
   variant?: "primary" | "secondary" | "tertiary" | "outline";
   size?: "regular" | "small";
   type?: "button" | "submit" | "reset";
+  loading?: boolean;
+  disabled?: boolean;
 }>();
 
 const variantClasses = {
@@ -29,9 +33,16 @@ const sizeClasses = {
 <template>
   <button
     :class="[variantClasses[variant], sizeClasses[size]]"
-    class="px-4 rounded inline-flex justify-center items-center gap-1 disabled:bg-surface-surface-disabled disabled:bg-text-bg-surface-surface-disabled"
+    class="px-4 rounded inline-flex justify-center items-center gap-2 disabled:cursor-not-allowed disabled:opacity-70 disabled:bg-surface-surface-disabled disabled:bg-text-bg-surface-surface-disabled"
     :type="type"
+    :disabled="disabled || loading"
+    :aria-busy="loading"
   >
+    <span
+      v-if="loading"
+      class="w-5 h-5 border-2 border-current border-t-transparent rounded-full animate-spin"
+      aria-hidden="true"
+    />
     <div class="justify-start text-base font-bold leading-normal">
       <slot> {{ label }}</slot>
     </div>

--- a/templates/vue-starter-template/app/pages/checkout/index.vue
+++ b/templates/vue-starter-template/app/pages/checkout/index.vue
@@ -47,10 +47,19 @@ function handleUpdateQuantity(id: string, quantity: number) {
   changeProductQuantity({ id, quantity });
 }
 
+const isPlacingOrder = ref(false);
+
 async function handlePlaceOrder() {
-  const order = await createOrder();
-  await push(formatLink(`/checkout/success/${order.id}`));
-  refreshCart();
+  if (isPlacingOrder.value) return;
+
+  isPlacingOrder.value = true;
+  try {
+    const order = await createOrder();
+    await push(formatLink(`/checkout/success/${order.id}`));
+    refreshCart();
+  } finally {
+    isPlacingOrder.value = false;
+  }
 }
 
 function handleChangeShippingMethod(id: string) {
@@ -128,7 +137,23 @@ onMounted(() => {
     </div>
 
     <div v-else class="flex gap-20 justify-between">
-      <div class="w-1/2">
+      <div class="w-1/2 relative">
+        <div
+          v-if="isPlacingOrder"
+          class="absolute inset-0 z-10 flex items-center justify-center bg-surface-surface/70 backdrop-blur-[1px] cursor-wait"
+          role="status"
+          :aria-label="$t('checkout.placingOrder')"
+        >
+          <div class="flex flex-col items-center gap-3">
+            <span
+              class="w-8 h-8 border-2 border-brand-primary border-t-transparent rounded-full animate-spin"
+              aria-hidden="true"
+            />
+            <span class="text-sm font-bold text-surface-on-surface">
+              {{ $t("checkout.placingOrder") }}
+            </span>
+          </div>
+        </div>
         <CheckoutStepHeader :step="1" label="Shipping address">
           <CheckoutCustomerBaseInfo
             class="mb-4"
@@ -163,12 +188,22 @@ onMounted(() => {
           />
         </CheckoutStepHeader>
         <FormBaseButton
-          :label="$t('checkout.placeOrderButton')"
-          @click="handlePlaceOrder"
+          :label="
+            isPlacingOrder
+              ? $t('checkout.placingOrder')
+              : $t('checkout.placeOrderButton')
+          "
+          :loading="isPlacingOrder"
           :disabled="!canPlaceOrder"
+          @click="handlePlaceOrder"
         />
       </div>
-      <div class="w-1/2">
+      <div class="w-1/2 relative">
+        <div
+          v-if="isPlacingOrder"
+          class="absolute inset-0 z-10 bg-surface-surface/70 backdrop-blur-[1px] cursor-wait"
+          aria-hidden="true"
+        />
         <CheckoutSummaryBox
           v-if="cart"
           :cart="cart"

--- a/templates/vue-starter-template/i18n/de-DE/checkout.json
+++ b/templates/vue-starter-template/i18n/de-DE/checkout.json
@@ -6,6 +6,7 @@
     "shippingCosts": "Versand",
     "total": "Gesamt",
     "placeOrderButton": "Bestellen",
+    "placingOrder": "Bestellung wird aufgegeben…",
     "customerAddress": {
       "firstNamePlaceholder": "Vorname eingeben",
       "firstNameLabel": "Vorname",

--- a/templates/vue-starter-template/i18n/en-GB/checkout.json
+++ b/templates/vue-starter-template/i18n/en-GB/checkout.json
@@ -6,6 +6,7 @@
     "shippingCosts": "Shipping",
     "total": "Total",
     "placeOrderButton": "Confirm and place order",
+    "placingOrder": "Placing order…",
     "customerAddress": {
       "firstNamePlaceholder": "Enter first name",
       "firstNameLabel": "First name",

--- a/templates/vue-starter-template/i18n/pl-PL/checkout.json
+++ b/templates/vue-starter-template/i18n/pl-PL/checkout.json
@@ -6,6 +6,7 @@
     "shippingCosts": "Wysyłka",
     "total": "Suma",
     "placeOrderButton": "Złóż zamówienie",
+    "placingOrder": "Składanie zamówienia…",
     "customerAddress": {
       "firstNamePlaceholder": "Wprowadź imię",
       "firstNameLabel": "Imię",


### PR DESCRIPTION
closes #2562 


This pull request adds a loading state to the order placement flow in the Vue starter template, improving user feedback and preventing duplicate order submissions. The main changes include updating the `BaseButton` component to support loading and disabled states, integrating a loading indicator and overlay into the checkout page, and adding new i18n strings for the loading state.

**Checkout process improvements:**

* Added an `isPlacingOrder` state in `checkout/index.vue` to prevent duplicate order submissions and display a loading overlay while an order is being placed. The order button is now disabled and shows a spinner and loading text during this process. [[1]](diffhunk://#diff-2980359c068008e2d662439c3957394f583df78c7a7854a417793f235ffd784eR50-R62) [[2]](diffhunk://#diff-2980359c068008e2d662439c3957394f583df78c7a7854a417793f235ffd784eL131-R156) [[3]](diffhunk://#diff-2980359c068008e2d662439c3957394f583df78c7a7854a417793f235ffd784eL166-R206)

**Component updates:**

* Enhanced `BaseButton.vue` to support `loading` and `disabled` props, display a spinner when loading, and update button accessibility attributes accordingly. [[1]](diffhunk://#diff-87eb9ef72e63a39b39d73ccfb9637b403e57cecf9aa286ec5dd7fa1ac2b0fe16R10-R18) [[2]](diffhunk://#diff-87eb9ef72e63a39b39d73ccfb9637b403e57cecf9aa286ec5dd7fa1ac2b0fe16L32-R45)

**Internationalization:**

* Added the `placingOrder` string to `checkout.json` in English, German, and Polish locales for improved localization of the loading state. [[1]](diffhunk://#diff-82012d4ff1e074fd28272afeb1a71c79f408e7cb6baae4bd67367df220caafabR9) [[2]](diffhunk://#diff-5a553d21e1a3acebf5ca93b4ea7eae86540d774c69d00c2f151287c226036d35R9) [[3]](diffhunk://#diff-8027c1db832867011c19ffafe1327ca827de24dc55a9b51cbcd71b94b0c13233R9)