### PR TITLE
feat: improve cacheable reads and breadcrumb navigation

### DIFF
--- a/.changeset/cacheable-category-get.md
+++ b/.changeset/cacheable-category-get.md
@@ -1,0 +1,10 @@
+---
+"@shopware/composables": patch
+"@shopware/cms-base-layer": patch
+---
+
+Add cacheable GET support for category details and product reviews while preserving the existing POST behavior when `cacheableReads` is disabled.
+
+- `useCategorySearch.search` now calls `GET /category/{navigationId}` and sends the complete encoded Criteria in the `_criteria` query parameter when cacheable reads are enabled.
+- `useProductReviews.loadProductReviews` now calls `GET /product/{productId}/reviews` and sends its encoded Criteria in `_criteria` when cacheable reads are enabled.
+- The CMS product description reviews element follows the same flag and endpoint behavior when it needs to fetch reviews directly.

--- a/.changeset/smooth-starter-breadcrumbs.md
+++ b/.changeset/smooth-starter-breadcrumbs.md
@@ -1,0 +1,5 @@
+---
+"vue-starter-template": patch
+---
+
+Load category and product breadcrumbs after hydration so they no longer block the primary SSR response. Abort stale breadcrumb requests during navigation and animate the complete breadcrumb trail as a single transition while reserving its row height to avoid layout shifts.

--- a/.changeset/stable-cms-image-sizing.md
+++ b/.changeset/stable-cms-image-sizing.md
@@ -1,0 +1,5 @@
+---
+"@shopware/cms-base-layer": patch
+---
+
+Preserve CMS image aspect ratios when responsive dimensions are calculated after hydration, preventing visible image scaling as optimized sources load.

--- a/packages/cms-base-layer/app/components/public/cms/element/CmsElementImage.vue
+++ b/packages/cms-base-layer/app/components/public/cms/element/CmsElementImage.vue
@@ -92,7 +92,6 @@ const SwMedia3D = computed(() => {
       preset="productDetail"
       loading="lazy"
       :width="imageSize"
-      :height="imageSize"
       :class="{
         'w-full': !imageGallery,
         'h-full': !imageGallery && ['cover', 'stretch'].includes(displayMode),

--- a/packages/cms-base-layer/app/components/public/cms/element/CmsElementProductDescriptionReviews.vue
+++ b/packages/cms-base-layer/app/components/public/cms/element/CmsElementProductDescriptionReviews.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { encodeForQuery } from "@shopware/api-client/helpers";
 import type { CmsElementProductDescriptionReviews } from "@shopware/composables";
 import { useCmsTranslations } from "@shopware/composables";
 import { getTranslatedProperty } from "@shopware/helpers";
@@ -56,18 +57,26 @@ const isSectionOpen = (sectionNumber: number) => {
 };
 
 const reviews: Ref<Schemas["ProductReview"][]> = ref([]);
-const { apiClient } = useShopwareContext();
+const { apiClient, cacheableReads } = useShopwareContext();
 const { isLoggedIn } = useUser();
 const reviewAdded = ref(false);
 
 const fetchReviews = async () => {
   try {
-    const reviewsResponse = await apiClient.invoke(
-      "readProductReviews post /product/{productId}/reviews",
-      {
-        pathParams: { productId: product.value.id },
-      },
-    );
+    const reviewsResponse = cacheableReads
+      ? await apiClient.invoke(
+          "readProductReviewsGet get /product/{productId}/reviews",
+          {
+            pathParams: { productId: product.value.id },
+            query: { _criteria: encodeForQuery({}) },
+          },
+        )
+      : await apiClient.invoke(
+          "readProductReviews post /product/{productId}/reviews",
+          {
+            pathParams: { productId: product.value.id },
+          },
+        );
     reviews.value = reviewsResponse.data.elements || [];
   } catch (error) {
     console.error("Failed to fetch reviews:", error);

--- a/packages/composables/src/useCategorySearch/useCategorySearch.test.ts
+++ b/packages/composables/src/useCategorySearch/useCategorySearch.test.ts
@@ -14,7 +14,7 @@ describe("useCategorySearch", () => {
     vm.search("categoryId");
 
     expect(injections.apiClient.invoke).toHaveBeenCalledWith(
-      expect.stringContaining("readCategory"),
+      expect.stringContaining("readCategory post"),
       expect.objectContaining({
         pathParams: {
           navigationId: "categoryId",
@@ -36,7 +36,7 @@ describe("useCategorySearch", () => {
     });
 
     expect(injections.apiClient.invoke).toHaveBeenCalledWith(
-      expect.stringContaining("readCategory"),
+      expect.stringContaining("readCategory post"),
       expect.objectContaining({
         pathParams: {
           navigationId: "categoryId",
@@ -46,6 +46,79 @@ describe("useCategorySearch", () => {
         },
         body: {
           associations: cmsAssociations,
+        },
+      }),
+    );
+  });
+
+  it("search uses the cacheable GET variant when cacheableReads is enabled", () => {
+    const { vm, injections } = useSetup(useCategorySearch, {
+      shopware: { cacheableReads: true },
+    });
+    injections.apiClient.invoke.mockResolvedValue({
+      data: {},
+    });
+
+    vm.search("categoryId", {
+      query: {
+        filter: [{ type: "equals", field: "active", value: true }],
+        limit: 1,
+        sort: [{ field: "name", order: "ASC" }],
+      },
+      withCmsAssociations: true,
+    });
+
+    expect(injections.apiClient.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("readCategoryGet get"),
+      expect.objectContaining({
+        pathParams: {
+          navigationId: "categoryId",
+        },
+        headers: {
+          "sw-include-seo-urls": true,
+        },
+        query: {
+          _criteria: encodeForQuery({
+            associations: cmsAssociations,
+            filter: [{ type: "equals", field: "active", value: true }],
+            limit: 1,
+            sort: [{ field: "name", order: "ASC" }],
+          }),
+        },
+      }),
+    );
+  });
+
+  it("search encodes Criteria body keys into cacheable GET _criteria", () => {
+    const { vm, injections } = useSetup(useCategorySearch, {
+      shopware: { cacheableReads: true },
+    });
+    injections.apiClient.invoke.mockResolvedValue({
+      data: {},
+    });
+
+    vm.search("categoryId", {
+      query: {
+        aggregations: [{ type: "count", field: "id", name: "count-id" }],
+        fields: ["name"],
+        grouping: ["translated.name"],
+        ids: ["categoryId"],
+        "post-filter": [{ type: "equals", field: "active", value: true }],
+      },
+    });
+
+    expect(injections.apiClient.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("readCategoryGet get"),
+      expect.objectContaining({
+        query: {
+          _criteria: encodeForQuery({
+            associations: {},
+            aggregations: [{ type: "count", field: "id", name: "count-id" }],
+            fields: ["name"],
+            grouping: ["translated.name"],
+            ids: ["categoryId"],
+            "post-filter": [{ type: "equals", field: "active", value: true }],
+          }),
         },
       }),
     );

--- a/packages/composables/src/useCategorySearch/useCategorySearch.ts
+++ b/packages/composables/src/useCategorySearch/useCategorySearch.ts
@@ -1,9 +1,13 @@
 import { encodeForQuery } from "@shopware/api-client/helpers";
 
 import { useShopwareContext } from "#imports";
-import type { Schemas } from "#shopware";
+import type { Schemas, operations } from "#shopware";
 
 import { cmsAssociations } from "../cms/cmsAssociations";
+
+type ReadCategoryGetQuery = NonNullable<
+  operations["readCategoryGet get /category/{navigationId}"]["query"]
+> & { _criteria?: string };
 
 export type UseCategorySearchReturn = {
   /**
@@ -43,21 +47,31 @@ export function useCategorySearch(): UseCategorySearchReturn {
     },
   ) {
     const associations = options?.withCmsAssociations ? cmsAssociations : {};
-    const result = await apiClient.invoke(
-      "readCategory post /category/{navigationId}",
-      {
-        pathParams: {
-          navigationId: categoryId,
-        },
-        headers: {
-          "sw-include-seo-urls": true,
-        },
-        body: {
-          associations,
-          ...options?.query,
-        },
-      },
-    );
+    const criteria = {
+      associations,
+      ...options?.query,
+    };
+    const result = cacheableReads
+      ? await apiClient.invoke("readCategoryGet get /category/{navigationId}", {
+          pathParams: {
+            navigationId: categoryId,
+          },
+          headers: {
+            "sw-include-seo-urls": true,
+          },
+          query: {
+            _criteria: encodeForQuery(criteria),
+          } as ReadCategoryGetQuery,
+        })
+      : await apiClient.invoke("readCategory post /category/{navigationId}", {
+          pathParams: {
+            navigationId: categoryId,
+          },
+          headers: {
+            "sw-include-seo-urls": true,
+          },
+          body: criteria,
+        });
     return result.data;
   }
 

--- a/packages/composables/src/useProductReviews/useProductReviews.test.ts
+++ b/packages/composables/src/useProductReviews/useProductReviews.test.ts
@@ -1,3 +1,4 @@
+import { encodeForQuery } from "@shopware/api-client/helpers";
 import { describe, expect, it } from "vitest";
 import { ref } from "vue";
 
@@ -15,8 +16,46 @@ describe("useProductReviews", () => {
     });
     await vm.loadProductReviews();
     expect(injections.apiClient.invoke).toHaveBeenCalledWith(
-      expect.stringContaining("readProductReviews"),
-      expect.objectContaining({}),
+      expect.stringContaining("readProductReviews post"),
+      expect.objectContaining({
+        body: {},
+        pathParams: {
+          productId: ProductMock.id,
+        },
+      }),
+    );
+    expect(vm.productReviews).toEqual([{ id: "1", content: "Great!" }]);
+  });
+
+  it("load product reviews uses GET when cacheableReads is enabled", async () => {
+    const { vm, injections } = useSetup(
+      () => useProductReviews(ref(ProductMock)),
+      {
+        shopware: { cacheableReads: true },
+      },
+    );
+    injections.apiClient.invoke.mockResolvedValue({
+      data: { elements: [{ id: "1", content: "Great!" }] },
+    });
+
+    await vm.loadProductReviews({
+      limit: 5,
+      sort: [{ field: "createdAt", order: "DESC" }],
+    });
+
+    expect(injections.apiClient.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("readProductReviewsGet get"),
+      expect.objectContaining({
+        pathParams: {
+          productId: ProductMock.id,
+        },
+        query: {
+          _criteria: encodeForQuery({
+            limit: 5,
+            sort: [{ field: "createdAt", order: "DESC" }],
+          }),
+        },
+      }),
     );
     expect(vm.productReviews).toEqual([{ id: "1", content: "Great!" }]);
   });

--- a/packages/composables/src/useProductReviews/useProductReviews.ts
+++ b/packages/composables/src/useProductReviews/useProductReviews.ts
@@ -1,3 +1,4 @@
+import { encodeForQuery } from "@shopware/api-client/helpers";
 import { computed, ref } from "vue";
 import type { ComputedRef, Ref } from "vue";
 
@@ -39,7 +40,7 @@ export type UseProductReviewsReturn = {
 export function useProductReviews(
   product: Ref<Schemas["Product"]>,
 ): UseProductReviewsReturn {
-  const { apiClient } = useShopwareContext();
+  const { apiClient, cacheableReads } = useShopwareContext();
 
   const productReviews: Ref<Schemas["ProductReview"][]> = ref([]);
 
@@ -48,13 +49,21 @@ export function useProductReviews(
   ): Promise<
     operations["readProductReviews post /product/{productId}/reviews"]["response"]
   > => {
-    const fetchedReviews = await apiClient.invoke(
-      "readProductReviews post /product/{productId}/reviews",
-      {
-        pathParams: { productId: product.value.id },
-        body: parameters,
-      },
-    );
+    const fetchedReviews = cacheableReads
+      ? await apiClient.invoke(
+          "readProductReviewsGet get /product/{productId}/reviews",
+          {
+            pathParams: { productId: product.value.id },
+            query: { _criteria: encodeForQuery(parameters) },
+          },
+        )
+      : await apiClient.invoke(
+          "readProductReviews post /product/{productId}/reviews",
+          {
+            pathParams: { productId: product.value.id },
+            body: parameters,
+          },
+        );
     productReviews.value = fetchedReviews.data.elements ?? [];
     return fetchedReviews.data;
   };

--- a/templates/vue-starter-template/app/components/FrontendDetailPage.vue
+++ b/templates/vue-starter-template/app/components/FrontendDetailPage.vue
@@ -6,55 +6,45 @@ const props = defineProps<{
 }>();
 
 const { search } = useProductSearch();
-const { buildDynamicBreadcrumbs, pushBreadcrumb } = useBreadcrumbs();
+const { buildDynamicBreadcrumbs, clearBreadcrumbs, pushBreadcrumb } =
+  useBreadcrumbs();
 const { apiClient } = useShopwareContext();
-const errors = ref<string[]>([]);
+const router = useRouter();
+const breadcrumbRequestController = import.meta.client
+  ? new AbortController()
+  : undefined;
+
+if (import.meta.client) {
+  const removeBreadcrumbRequestGuard = router.beforeEach((to, from) => {
+    if (to.fullPath === from.fullPath) return;
+    breadcrumbRequestController?.abort();
+  });
+
+  onBeforeUnmount(() => {
+    breadcrumbRequestController?.abort();
+    removeBreadcrumbRequestGuard();
+  });
+}
 
 const { data, error } = await useAsyncData(
   `cmsProduct${props.navigationId}`,
-  async () => {
-    const responses = await Promise.allSettled([
-      search(props.navigationId, {
-        withCmsAssociations: true,
-        associations: {
-          openGraphMedia: {
-            associations: {
-              thumbnails: {},
-            },
+  async () =>
+    await search(props.navigationId, {
+      withCmsAssociations: true,
+      associations: {
+        openGraphMedia: {
+          associations: {
+            thumbnails: {},
           },
-          seoUrls: {},
         },
-      }),
-      apiClient.invoke("readBreadcrumb get /breadcrumb/{id}", {
-        pathParams: {
-          id: props.navigationId,
-        },
-      }),
-    ]);
-
-    for (const response of responses) {
-      if (response.status === "rejected") {
-        console.error("[FrontendDetailPage.vue]", response.reason.message);
-        errors.value.push(response.reason.message);
-      }
-    }
-
-    return {
-      productResponse:
-        responses[0].status === "fulfilled" ? responses[0].value : null,
-      breadcrumbs:
-        responses[1].status === "fulfilled" ? responses[1].value : null,
-    };
-  },
+        seoUrls: {},
+      },
+    }),
 );
-const productResponse = data.value?.productResponse;
-
-if (data.value?.breadcrumbs) {
-  buildDynamicBreadcrumbs(data.value.breadcrumbs.data);
-}
+const productResponse = data.value;
 
 if (!productResponse) {
-  const statusMessage = error.value?.message || errors.value.join(", ");
+  const statusMessage = error.value?.message || "Failed to load product";
   console.error("[FrontendDetailPage.vue]", statusMessage);
   throw createError({
     statusCode: 500,
@@ -64,9 +54,32 @@ if (!productResponse) {
 
 useProductJsonLD(productResponse.product);
 
-pushBreadcrumb({
+const productBreadcrumb = {
   name: getProductName({ product: productResponse.product }) ?? "",
   path: `/${productResponse.product.seoUrls?.[0]?.seoPathInfo}`,
+};
+
+clearBreadcrumbs();
+
+onMounted(async () => {
+  try {
+    const breadcrumbsResponse = await apiClient.invoke(
+      "readBreadcrumb get /breadcrumb/{id}",
+      {
+        pathParams: {
+          id: props.navigationId,
+        },
+        fetchOptions: {
+          signal: breadcrumbRequestController?.signal,
+        },
+      },
+    );
+    await buildDynamicBreadcrumbs(breadcrumbsResponse.data);
+    pushBreadcrumb(productBreadcrumb);
+  } catch (error) {
+    if (breadcrumbRequestController?.signal.aborted) return;
+    console.error("[FrontendDetailPage.vue]", error);
+  }
 });
 
 const { product } = useProduct(

--- a/templates/vue-starter-template/app/components/FrontendNavigationPage.vue
+++ b/templates/vue-starter-template/app/components/FrontendNavigationPage.vue
@@ -12,49 +12,61 @@ const props = defineProps<{
 
 const { search } = useCategorySearch();
 const route = useRoute();
-const { buildDynamicBreadcrumbs } = useBreadcrumbs();
+const { buildDynamicBreadcrumbs, clearBreadcrumbs } = useBreadcrumbs();
 const { apiClient } = useShopwareContext();
-const errors = ref<string[]>([]);
+const router = useRouter();
+const breadcrumbRequestController = import.meta.client
+  ? new AbortController()
+  : undefined;
+
+if (import.meta.client) {
+  const removeBreadcrumbRequestGuard = router.beforeEach((to, from) => {
+    if (to.fullPath === from.fullPath) return;
+    breadcrumbRequestController?.abort();
+  });
+
+  onBeforeUnmount(() => {
+    breadcrumbRequestController?.abort();
+    removeBreadcrumbRequestGuard();
+  });
+}
 
 const { data, error } = await useAsyncData(
   `cmsNavigation${props.navigationId}`,
-  async () => {
-    const responses = await Promise.allSettled([
-      search(props.navigationId, {
-        withCmsAssociations: true,
-        query: {
-          ...route.query,
-        },
-      }),
-      apiClient.invoke("readBreadcrumb get /breadcrumb/{id}", {
+  async () =>
+    await search(props.navigationId, {
+      withCmsAssociations: true,
+      query: {
+        ...route.query,
+      },
+    }),
+);
+const categoryResponse = ref(data.value);
+
+clearBreadcrumbs();
+
+onMounted(async () => {
+  try {
+    const breadcrumbsResponse = await apiClient.invoke(
+      "readBreadcrumb get /breadcrumb/{id}",
+      {
         pathParams: {
           id: props.navigationId,
         },
-      }),
-    ]);
-
-    for (const response of responses) {
-      if (response.status === "rejected") {
-        console.error("[FrontendNavigationPage.vue]", response.reason.message);
-        errors.value.push(response.reason.message);
-      }
-    }
-
-    return {
-      category: responses[0].status === "fulfilled" ? responses[0].value : null,
-      breadcrumbs:
-        responses[1].status === "fulfilled" ? responses[1].value : null,
-    };
-  },
-);
-const categoryResponse = ref(data.value?.category);
-
-if (data.value?.breadcrumbs) {
-  buildDynamicBreadcrumbs(data.value.breadcrumbs.data);
-}
+        fetchOptions: {
+          signal: breadcrumbRequestController?.signal,
+        },
+      },
+    );
+    await buildDynamicBreadcrumbs(breadcrumbsResponse.data);
+  } catch (error) {
+    if (breadcrumbRequestController?.signal.aborted) return;
+    console.error("[FrontendNavigationPage.vue]", error);
+  }
+});
 
 if (!categoryResponse.value) {
-  const statusMessage = error.value?.message || errors.value.join(", ");
+  const statusMessage = error.value?.message || "Failed to load category";
   console.error("[FrontendNavigationPage.vue]", statusMessage);
   throw createError({
     statusCode: 500,

--- a/templates/vue-starter-template/app/components/layout/breadcrumbs/index.vue
+++ b/templates/vue-starter-template/app/components/layout/breadcrumbs/index.vue
@@ -1,38 +1,132 @@
 <script setup lang="ts">
-const { breadcrumbs } = useBreadcrumbs();
+const { breadcrumbs, clearBreadcrumbs } = useBreadcrumbs();
 const localePath = useLocalePath();
 const { formatLink } = useInternationalization(localePath);
+const router = useRouter();
+const breadcrumbTransitionDuration = 180;
+const isTrailVisible = ref(true);
+let collapsePromise: Promise<void> | undefined;
+let finishCollapse: (() => void) | undefined;
+
+if (import.meta.client) {
+  const collapseTrail = () => {
+    if (collapsePromise) return collapsePromise;
+
+    collapsePromise = new Promise<void>((resolve) => {
+      const fallback = window.setTimeout(
+        () => finishCollapse?.(),
+        breadcrumbTransitionDuration + 80,
+      );
+
+      finishCollapse = () => {
+        window.clearTimeout(fallback);
+        finishCollapse = undefined;
+        resolve();
+      };
+
+      isTrailVisible.value = false;
+    });
+
+    return collapsePromise;
+  };
+
+  const removeRouteGuard = router.beforeEach(async (to, from) => {
+    if (to.fullPath === from.fullPath || !breadcrumbs.value.length) return;
+
+    if (!window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      await collapseTrail();
+    }
+
+    clearBreadcrumbs();
+  });
+
+  const removeAfterEach = router.afterEach((_to, _from, failure) => {
+    if (!failure) return;
+
+    collapsePromise = undefined;
+    finishCollapse = undefined;
+    isTrailVisible.value = true;
+  });
+
+  onBeforeUnmount(() => {
+    finishCollapse?.();
+    removeRouteGuard();
+    removeAfterEach();
+  });
+}
 </script>
+
 <template>
   <nav
-    class="container hidden lg:flex mt-8 mb-8 px-4 sm:px-0 mx-auto"
+    class="container hidden min-h-6 lg:flex mt-8 mb-8 px-4 sm:px-0 mx-auto"
     :aria-label="$t('layout.ariaLabels.breadcrumb')"
   >
-    <ol class="inline-flex items-center space-x-1 md:space-x-3">
-      <li class="inline-flex items-center">
-        <LayoutBreadcrumbsElement :to="formatLink(`/`)">
-          <div class="flex items-center">
-            <div class="w-5 h-5 i-carbon-home mr-2" />
-            <div>{{ $t("home") }}</div>
-          </div>
-        </LayoutBreadcrumbsElement>
-        <LayoutBreadcrumbsDivider />
-      </li>
-      <li
-        v-for="(breadcrumb, index) in breadcrumbs"
-        :key="breadcrumb.path"
-        class="inline-flex items-center"
+    <Transition name="breadcrumb" appear @after-leave="finishCollapse?.()">
+      <ol
+        v-if="isTrailVisible && breadcrumbs.length"
+        class="breadcrumb-trail inline-flex items-center gap-x-1 md:gap-x-3"
       >
-        <NuxtLink v-if="breadcrumb.path" :to="formatLink(breadcrumb.path)">
-          <LayoutBreadcrumbsElement>
+        <li class="inline-flex items-center">
+          <LayoutBreadcrumbsElement :to="formatLink(`/`)">
+            <div class="flex items-center">
+              <div class="w-5 h-5 i-carbon-home mr-2" />
+              <div>{{ $t("home") }}</div>
+            </div>
+          </LayoutBreadcrumbsElement>
+          <LayoutBreadcrumbsDivider />
+        </li>
+        <li
+          v-for="(breadcrumb, index) in breadcrumbs"
+          :key="breadcrumb.path || breadcrumb.name"
+          class="inline-flex items-center"
+        >
+          <NuxtLink v-if="breadcrumb.path" :to="formatLink(breadcrumb.path)">
+            <LayoutBreadcrumbsElement>
+              {{ breadcrumb.name }}
+            </LayoutBreadcrumbsElement>
+          </NuxtLink>
+          <LayoutBreadcrumbsElement v-else>
             {{ breadcrumb.name }}
           </LayoutBreadcrumbsElement>
-        </NuxtLink>
-        <LayoutBreadcrumbsElement v-else>
-          {{ breadcrumb.name }}
-        </LayoutBreadcrumbsElement>
-        <LayoutBreadcrumbsDivider v-if="index < breadcrumbs.length - 1" />
-      </li>
-    </ol>
+          <LayoutBreadcrumbsDivider v-if="index < breadcrumbs.length - 1" />
+        </li>
+      </ol>
+    </Transition>
   </nav>
 </template>
+
+<style scoped>
+.breadcrumb-trail {
+  transform-origin: left center;
+  will-change: clip-path, opacity, transform;
+}
+
+.breadcrumb-enter-active,
+.breadcrumb-leave-active {
+  transition:
+    clip-path 180ms cubic-bezier(0.2, 0, 0, 1),
+    opacity 120ms ease,
+    transform 180ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.breadcrumb-enter-from,
+.breadcrumb-leave-to {
+  clip-path: inset(0 100% 0 0);
+  opacity: 0;
+  transform: translateX(-0.375rem);
+}
+
+.breadcrumb-enter-to,
+.breadcrumb-leave-from {
+  clip-path: inset(0 0 0 0);
+  opacity: 1;
+  transform: translateX(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .breadcrumb-enter-active,
+  .breadcrumb-leave-active {
+    transition: none;
+  }
+}
+</style>

--- a/templates/vue-starter-template/nuxt.config.ts
+++ b/templates/vue-starter-template/nuxt.config.ts
@@ -104,6 +104,9 @@ export default defineNuxtConfig({
     ],
   },
   icon: {
+    clientBundle: {
+      includeCustomCollections: true,
+    },
     customCollections: [
       {
         prefix: "shopware",


### PR DESCRIPTION
### Description

Adds cacheable GET variants with encoded `_criteria` for category and product-review reads while retaining POST fallbacks. Moves starter category and product breadcrumbs out of the blocking SSR path, aborts stale requests, and adds a stable route transition without layout shifts.

### Type of change

New feature (non-breaking change which adds functionality)

### ToDo's

- [x] Changeset files provided
- [x] Unit tests added/updated
- [x] Type checks and linting completed

### Screenshots (if applicable)

Not applicable.

### Additional context

`vue-demo-store` remains unchanged.