### PR TITLE
fix: preserve category context in product breadcrumbs

### DIFF
--- a/.changeset/correct-product-breadcrumbs.md
+++ b/.changeset/correct-product-breadcrumbs.md
@@ -1,0 +1,6 @@
+---
+"@shopware/cms-base-layer": patch
+"vue-starter-template": patch
+---
+
+Show the category a shopper came from in product breadcrumbs, while direct product links continue to use the default category.

--- a/packages/cms-base-layer/app/components/SwProductCard.vue
+++ b/packages/cms-base-layer/app/components/SwProductCard.vue
@@ -17,6 +17,7 @@ import {
   useAddToCart,
   useCartErrorParamsResolver,
   useCartNotification,
+  useNavigationContext,
   useNotifications,
   useProductWishlist,
   useUrlResolver,
@@ -144,10 +145,25 @@ const productManufacturer = computed(() =>
   getProductManufacturerName(product.value),
 );
 
-const { getUrlPrefix } = useUrlResolver();
-const productLink = computed(() =>
-  buildUrlPrefix(getProductRoute(product.value), getUrlPrefix()),
+const { foreignKey: currentNavigationId, routeName } = useNavigationContext();
+const referrerCategoryId = computed(() =>
+  isProductListing && routeName.value === "frontend.navigation.page"
+    ? currentNavigationId.value
+    : undefined,
 );
+const { getUrlPrefix } = useUrlResolver();
+const productLink = computed(() => {
+  const productRoute = getProductRoute(product.value);
+  const productRouteWithReferrer = {
+    ...productRoute,
+    state: {
+      ...productRoute.state,
+      referrerCategoryId: referrerCategoryId.value,
+    },
+  };
+
+  return buildUrlPrefix(productRouteWithReferrer, getUrlPrefix());
+});
 </script>
 
 <template>

--- a/templates/vue-starter-template/app/components/FrontendDetailPage.vue
+++ b/templates/vue-starter-template/app/components/FrontendDetailPage.vue
@@ -13,6 +13,10 @@ const router = useRouter();
 const breadcrumbRequestController = import.meta.client
   ? new AbortController()
   : undefined;
+const referrerCategoryId =
+  import.meta.client && typeof history.state?.referrerCategoryId === "string"
+    ? history.state.referrerCategoryId
+    : undefined;
 
 if (import.meta.client) {
   const removeBreadcrumbRequestGuard = router.beforeEach((to, from) => {
@@ -69,6 +73,11 @@ onMounted(async () => {
         pathParams: {
           id: props.navigationId,
         },
+        query: referrerCategoryId
+          ? {
+              referrerCategoryId,
+            }
+          : undefined,
         fetchOptions: {
           signal: breadcrumbRequestController?.signal,
         },


### PR DESCRIPTION
### Description

Preserves the originating category when shoppers open a product from a category listing, so the product breadcrumb links back to the listing they came from. Direct product navigation continues to use the default category breadcrumb. Closes #2570.

### Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

### ToDo's

- [x] Changeset file provided
- [x] Related issue updated

### Screenshots (if applicable)

Not applicable.

### Additional context

Validated with CMS layer and starter-template typechecks, repository lint and formatting checks, and a browser reproduction against the starter demo catalog.
