### PR TITLE
feat(api-gen): support OpenAPI const schemas

### DIFF
--- a/.changeset/const-literal-api-gen.md
+++ b/.changeset/const-literal-api-gen.md
@@ -1,0 +1,5 @@
+---
+"@shopware/api-gen": patch
+---
+
+Support OpenAPI `const` schema values during type generation.

--- a/packages/api-gen/src/commands/generate.test.ts
+++ b/packages/api-gen/src/commands/generate.test.ts
@@ -1,4 +1,8 @@
-import type { SchemaObject } from "openapi-typescript";
+import openapiTS, {
+  astToString,
+  type OpenAPI3,
+  type SchemaObject,
+} from "openapi-typescript";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
@@ -30,6 +34,119 @@ describe("generate transformations", () => {
     });
 
     expect(typeNode && printTypeNode(typeNode)).toBe("GenericRecord");
+  });
+
+  it("uses literal types for const schema values", () => {
+    expect(
+      printTypeNode(
+        runTransformations({
+          type: "string",
+          const: "product",
+        } as SchemaObject)!,
+      ),
+    ).toBe('"product"');
+    expect(
+      printTypeNode(
+        runTransformations({
+          type: "number",
+          const: -1,
+        } as SchemaObject)!,
+      ),
+    ).toBe("-1");
+    expect(
+      printTypeNode(
+        runTransformations({
+          type: "boolean",
+          const: true,
+        } as SchemaObject)!,
+      ),
+    ).toBe("true");
+    expect(
+      printTypeNode(
+        runTransformations({
+          const: null,
+        } as SchemaObject)!,
+      ),
+    ).toBe("null");
+  });
+
+  it("uses string literal types for string schemas with non-string const values", () => {
+    expect(
+      printTypeNode(
+        runTransformations({
+          type: "string",
+          const: 1,
+        } as SchemaObject)!,
+      ),
+    ).toBe('"1"');
+  });
+
+  it("generates string const schema values as literal types", async () => {
+    const ast = await openapiTS(
+      {
+        openapi: "3.1.0",
+        info: {
+          title: "Test schema",
+          version: "1.0.0",
+        },
+        paths: {},
+        components: {
+          schemas: {
+            Product: {
+              type: "object",
+              required: ["apiAlias"],
+              properties: {
+                apiAlias: {
+                  type: "string",
+                  const: "product",
+                },
+              },
+            },
+          },
+        },
+      } as OpenAPI3,
+      {
+        version: 3,
+        exportType: true,
+        transform: runTransformations,
+      },
+    );
+
+    expect(astToString(ast)).toContain('apiAlias: "product";');
+  });
+
+  it("generates non-string const values on string schemas as string literal types", async () => {
+    const ast = await openapiTS(
+      {
+        openapi: "3.1.0",
+        info: {
+          title: "Test schema",
+          version: "1.0.0",
+        },
+        paths: {},
+        components: {
+          schemas: {
+            Product: {
+              type: "object",
+              required: ["apiAlias"],
+              properties: {
+                apiAlias: {
+                  type: "string",
+                  const: 1,
+                },
+              },
+            },
+          },
+        },
+      } as OpenAPI3,
+      {
+        version: 3,
+        exportType: true,
+        transform: runTransformations,
+      },
+    );
+
+    expect(astToString(ast)).toContain('apiAlias: "1";');
   });
 
   it("normalizes generated customFields properties", () => {

--- a/packages/api-gen/src/commands/generate.ts
+++ b/packages/api-gen/src/commands/generate.ts
@@ -355,6 +355,11 @@ export function runTransformations(
   schemaObject: SchemaObject,
   metadata?: { path?: string | string[] },
 ) {
+  const constLiteralType = createConstLiteralType(schemaObject);
+  if (constLiteralType) {
+    return constLiteralType;
+  }
+
   /**
    * Blob type is used for binary data
    */
@@ -393,6 +398,59 @@ export function runTransformations(
   }
 
   return undefined;
+}
+
+function createConstLiteralType(schemaObject: SchemaObject) {
+  if (!("const" in schemaObject)) {
+    return undefined;
+  }
+
+  const constValue = schemaObject.const;
+
+  if (hasSchemaType(schemaObject, "string")) {
+    return ts.factory.createLiteralTypeNode(
+      ts.factory.createStringLiteral(String(constValue)),
+    );
+  }
+
+  if (constValue === null) {
+    return ts.factory.createLiteralTypeNode(ts.factory.createNull());
+  }
+
+  if (typeof constValue === "string") {
+    return ts.factory.createLiteralTypeNode(
+      ts.factory.createStringLiteral(constValue),
+    );
+  }
+
+  if (typeof constValue === "number" && Number.isFinite(constValue)) {
+    const numericLiteral = ts.factory.createNumericLiteral(
+      Math.abs(constValue),
+    );
+
+    return ts.factory.createLiteralTypeNode(
+      constValue < 0
+        ? ts.factory.createPrefixUnaryExpression(
+            ts.SyntaxKind.MinusToken,
+            numericLiteral,
+          )
+        : numericLiteral,
+    );
+  }
+
+  if (typeof constValue === "boolean") {
+    return ts.factory.createLiteralTypeNode(
+      constValue ? ts.factory.createTrue() : ts.factory.createFalse(),
+    );
+  }
+
+  return undefined;
+}
+
+function hasSchemaType(schemaObject: SchemaObject, type: string) {
+  return Array.isArray(schemaObject.type)
+    ? (schemaObject.type as readonly string[]).includes(type)
+    : schemaObject.type === type;
 }
 
 function isCustomFieldsSchema(metadata?: { path?: string | string[] }) {

--- a/packages/api-gen/src/validation-rules/componentsApiAlias.rule.test.ts
+++ b/packages/api-gen/src/validation-rules/componentsApiAlias.rule.test.ts
@@ -45,6 +45,24 @@ describe("componentsApiAlias.rule", async () => {
     expect(result).toBe(null);
   });
 
+  it("accepts const alias definitions", async () => {
+    const componentName = "CmsBlock";
+    const body = {
+      type: "object",
+      required: ["apiAlias"],
+      properties: {
+        apiAlias: {
+          type: "string",
+          const: "cms_block",
+        },
+      },
+    } as ObjectSubtype;
+
+    const result = componentsApiAliasRule(componentName, body);
+
+    expect(result).toBe(null);
+  });
+
   it("should fail if alias is not in snake_case", async () => {
     const componentName = "CmsBlock";
     const body = {
@@ -71,6 +89,36 @@ describe("componentsApiAlias.rule", async () => {
       -     "cms_block",
       +     "cmsBlock",
           ],
+          "type": "string",
+        }
+      It's also possible, that the schema component name is not correct and apiApias is proper. In that case schema component name should be CmsBlock. Confirm proper solution with the source code."
+    `);
+  });
+
+  it("should fail if const alias is not in snake_case", async () => {
+    const componentName = "CmsBlock";
+    const body = {
+      type: "object",
+      required: ["apiAlias"],
+      properties: {
+        apiAlias: {
+          type: "string",
+          const: "cmsBlock",
+        },
+      },
+    } as ObjectSubtype;
+
+    const result = componentsApiAliasRule(componentName, body);
+
+    expect(result).not.toBe(null);
+    expect(_uncolorize(result)).toMatchInlineSnapshot(`
+      "Component CmsBlock has invalid apiAlias definition. Diff:
+       - Expected
+      + Received
+
+        {
+      -   "const": "cms_block",
+      +   "const": "cmsBlock",
           "type": "string",
         }
       It's also possible, that the schema component name is not correct and apiApias is proper. In that case schema component name should be CmsBlock. Confirm proper solution with the source code."

--- a/packages/api-gen/src/validation-rules/componentsApiAlias.rule.ts
+++ b/packages/api-gen/src/validation-rules/componentsApiAlias.rule.ts
@@ -8,9 +8,13 @@ export default (componentName: string, body: ObjectSubtype) => {
   // aliast needs to be in snake case. Examples:
   // - "Category" is "category"
   // - "CmsBlock" is "cms_block"
-  const properAliasDefinition = {
+  const properEnumAliasDefinition = {
     type: "string",
     enum: [snakeCase(componentName)],
+  };
+  const properConstAliasDefinition = {
+    type: "string",
+    const: snakeCase(componentName),
   };
 
   const bodyValue = body?.properties?.apiAlias as ObjectSubtype;
@@ -20,16 +24,25 @@ export default (componentName: string, body: ObjectSubtype) => {
     return null;
   }
 
-  const result = equals(properAliasDefinition, bodyValue);
+  const result =
+    equals(properEnumAliasDefinition, bodyValue) ||
+    equals(properConstAliasDefinition, bodyValue);
   if (!result) {
     let additionalMessage = "";
-    const bodyEnumValue = bodyValue?.enum?.[0] as string | undefined;
-    if (bodyEnumValue && properAliasDefinition.enum[0] !== bodyEnumValue) {
-      additionalMessage = `It's also possible, that the schema component name is not correct and apiApias is proper. In that case schema component name should be ${c.bold(pascalCase(bodyEnumValue))}. Confirm proper solution with the source code.`;
+    const bodyLiteralValue = getStringLiteralValue(bodyValue);
+    if (
+      bodyLiteralValue &&
+      properEnumAliasDefinition.enum[0] !== bodyLiteralValue
+    ) {
+      additionalMessage = `It's also possible, that the schema component name is not correct and apiApias is proper. In that case schema component name should be ${c.bold(pascalCase(bodyLiteralValue))}. Confirm proper solution with the source code.`;
     }
+    const expectedAliasDefinition =
+      "const" in bodyValue
+        ? properConstAliasDefinition
+        : properEnumAliasDefinition;
 
     return `Component ${c.bold(componentName)} has invalid ${c.bold("apiAlias")} definition. Diff:\n ${diff(
-      properAliasDefinition,
+      expectedAliasDefinition,
       bodyValue,
       {
         aColor: c.green,
@@ -45,3 +58,17 @@ export default (componentName: string, body: ObjectSubtype) => {
 
   return null;
 };
+
+function getStringLiteralValue(bodyValue: ObjectSubtype) {
+  const enumValue = bodyValue?.enum?.[0];
+  if (typeof enumValue === "string") {
+    return enumValue;
+  }
+
+  const constValue = (bodyValue as { const?: unknown })?.const;
+  if (typeof constValue === "string") {
+    return constValue;
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
### Description

Adds OpenAPI `const` schema support to api-gen so const values generate literal TypeScript types, with string schemas emitted as string literals.
Accepts `const` definitions in the `COMPONENTS_API_ALIAS` validation rule alongside one-value enums.
Related to https://github.com/shopware/shopware/pull/18340.

### Type of change

New feature (non-breaking change which adds functionality)

### ToDo's

- [x] Changeset file provided
- [x] Unit-Tests added/updated

### Screenshots (if applicable)

Not applicable.

### Additional context

Verified with `pnpm --filter @shopware/api-gen test`, `pnpm --filter @shopware/api-gen typecheck`, and `pnpm --filter @shopware/api-gen lint`.