### PR TITLE
fix(vue-starter-template): inline Iconify utils in Nitro

### DIFF
--- a/templates/vue-starter-template/nuxt.config.ts
+++ b/templates/vue-starter-template/nuxt.config.ts
@@ -52,6 +52,11 @@ export default defineNuxtConfig({
   features: {
     inlineStyles: true,
   },
+  nitro: {
+    externals: {
+      inline: ["@iconify/utils"],
+    },
+  },
   vite: {
     ...viteServerWebSocketWorkaround,
     optimizeDeps: {


### PR DESCRIPTION
### Description

Inline `@iconify/utils` in Nitro for `vue-starter-template` so Vercel functions do not rely on a partially traced Iconify package root. This fixes the server render crash where Node cannot resolve `@iconify/utils/lib/index.js`.

### Type of change

Bug fix (non-breaking change that fixes an issue)

### ToDo's

- [x] Verified Vercel Nitro build locally
- [ ] Changeset file provided (not needed: private starter template config only)

### Screenshots (if applicable)

N/A

### Additional context

Verified with `NITRO_PRESET=vercel pnpm --filter vue-starter-template build` and by running the generated Vercel function entry locally.