### PR TITLE
fix: surface session context refresh failures

### DIFF
--- a/.changeset/verified-session-refresh.md
+++ b/.changeset/verified-session-refresh.md
@@ -1,0 +1,5 @@
+---
+"@shopware/composables": patch
+---
+
+Propagate session context refresh failures so login, registration, logout, and context setters cannot complete after an unverifiable context switch.

--- a/apps/docs/src/guides/e-commerce/checkout.md
+++ b/apps/docs/src/guides/e-commerce/checkout.md
@@ -311,3 +311,34 @@ const {
 
 await loadOrderDetails();
 ```
+
+## Guest checkout boundaries
+
+Guest checkout uses the active Shopware customer from the current session
+context. After a guest order is placed, do not let a later buyer continue with
+the same guest context. A changed email, first name, or last name should start a
+new guest registration instead of updating the existing guest address.
+
+For simple synchronous flows, rotate the context with `logout()` after the order
+is placed and before starting a new checkout. `logout()` refreshes the session
+context and throws if the new context cannot be verified, so block checkout
+progression when it fails.
+
+```ts
+const { logout } = useUser();
+
+try {
+  await logout();
+} catch (error) {
+  // Keep the user on a recoverable state instead of reusing the old guest.
+  console.error("[Checkout][logout]", error);
+}
+```
+
+For asynchronous payment or order-processing flows, the application backend
+should own the boundary. Keep the old context token only while payment handlers
+or recovery jobs still need it, expose the current boundary state to checkout
+bootstrap, and block a second checkout until the first order is terminal or the
+guest context has been safely rotated. Do not rely on success-page lifecycle
+hooks such as route leave or unmount handlers as the authority for guest
+rotation; the user can reload, close the tab, or open checkout in another tab.

--- a/apps/docs/src/integrations/cms/storyblok.md
+++ b/apps/docs/src/integrations/cms/storyblok.md
@@ -119,8 +119,8 @@ On this page we explain the basics of how to integrate it into our [vue-blank te
    <script setup lang="ts">
    const { refreshSessionContext } = useSessionContext();
 
-   onMounted(() => {
-     refreshSessionContext();
+   onMounted(async () => {
+     await refreshSessionContext();
    });
    </script>
 

--- a/examples/mollie-credit-card/app/app.vue
+++ b/examples/mollie-credit-card/app/app.vue
@@ -3,7 +3,9 @@ const { refreshSessionContext } = useSessionContext();
 const CreditCardError = ref();
 const CreditCardToken = ref();
 onMounted(() => {
-  refreshSessionContext();
+  refreshSessionContext().catch((error) => {
+    console.error("[App][refreshSessionContext]", error);
+  });
 });
 </script>
 

--- a/examples/snippets-middleware/app/app.vue
+++ b/examples/snippets-middleware/app/app.vue
@@ -3,7 +3,9 @@ import Frontends from "./components/Frontends.vue";
 const { refreshSessionContext } = useSessionContext();
 
 onMounted(() => {
-  refreshSessionContext();
+  refreshSessionContext().catch((error) => {
+    console.error("[App][refreshSessionContext]", error);
+  });
 });
 </script>
 

--- a/packages/composables/README.md
+++ b/packages/composables/README.md
@@ -88,7 +88,7 @@ Now you can use any composable function in your setup function:
 
     const { login } = useUser();
     const { refreshSessionContext, sessionContext } = useSessionContext();
-    refreshSessionContext();
+    await refreshSessionContext();
 </script>
 <template>
     <pre>{{ sessionContext }}</pre>

--- a/packages/composables/src/useSessionContext/useSessionContext.test.ts
+++ b/packages/composables/src/useSessionContext/useSessionContext.test.ts
@@ -1,15 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { Schemas } from "#shopware";
 
 import { useSetup } from "../_test";
 import { useSessionContext } from "./useSessionContext";
 
-const consoleErrorSpy = vi.spyOn(console, "error");
-consoleErrorSpy.mockImplementation(() => {});
-
 describe("useSessionContext", () => {
   const consoleErrorSpy = vi.spyOn(console, "error");
+  consoleErrorSpy.mockImplementation(() => {});
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("setLanguage", () => {
     const { vm, injections } = useSetup(() => useSessionContext());
     injections.apiClient.invoke.mockResolvedValue({ data: {} });
@@ -57,15 +60,16 @@ describe("useSessionContext", () => {
   });
 
   it("refreshSessionContext - error", async () => {
+    const error = new Error("error test");
     const { vm } = useSetup(() => useSessionContext(), {
       apiClient: {
         invoke: vi.fn().mockImplementation(() => {
-          throw new Error("error test");
+          throw error;
         }),
       },
     });
     consoleErrorSpy.mockImplementation(() => {});
-    await vm.refreshSessionContext();
+    await expect(vm.refreshSessionContext()).rejects.toThrow(error);
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -115,6 +119,62 @@ describe("useSessionContext", () => {
     ).rejects.toThrowError(
       "You need to provide shipping method id in order to set shipping method.",
     );
+  });
+
+  it("setActiveShippingAddress waits for refreshed context", async () => {
+    const { vm, injections } = useSetup(() => useSessionContext());
+    const calls: string[] = [];
+    injections.apiClient.invoke.mockImplementation(async (route) => {
+      calls.push(route);
+      return { data: {} };
+    });
+
+    await vm.setActiveShippingAddress({ id: "shipping-address-id" });
+
+    expect(calls).toEqual([
+      expect.stringContaining("updateContext"),
+      expect.stringContaining("readContext"),
+    ]);
+  });
+
+  it("setActiveShippingAddress rejects when refreshed context fails", async () => {
+    const error = new Error("refresh failed");
+    const { vm, injections } = useSetup(() => useSessionContext());
+    injections.apiClient.invoke
+      .mockResolvedValueOnce({ data: {} })
+      .mockRejectedValueOnce(error);
+
+    await expect(
+      vm.setActiveShippingAddress({ id: "shipping-address-id" }),
+    ).rejects.toThrow(error);
+  });
+
+  it("setActiveBillingAddress waits for refreshed context", async () => {
+    const { vm, injections } = useSetup(() => useSessionContext());
+    const calls: string[] = [];
+    injections.apiClient.invoke.mockImplementation(async (route) => {
+      calls.push(route);
+      return { data: {} };
+    });
+
+    await vm.setActiveBillingAddress({ id: "billing-address-id" });
+
+    expect(calls).toEqual([
+      expect.stringContaining("updateContext"),
+      expect.stringContaining("readContext"),
+    ]);
+  });
+
+  it("setActiveBillingAddress rejects when refreshed context fails", async () => {
+    const error = new Error("refresh failed");
+    const { vm, injections } = useSetup(() => useSessionContext());
+    injections.apiClient.invoke
+      .mockResolvedValueOnce({ data: {} })
+      .mockRejectedValueOnce(error);
+
+    await expect(
+      vm.setActiveBillingAddress({ id: "billing-address-id" }),
+    ).rejects.toThrow(error);
   });
 
   it("setPaymentMethod", async () => {

--- a/packages/composables/src/useSessionContext/useSessionContext.ts
+++ b/packages/composables/src/useSessionContext/useSessionContext.ts
@@ -21,6 +21,10 @@ export type UseSessionContextReturn = {
   sessionContext: ComputedRef<Schemas["SalesChannelContext"] | undefined>;
   /**
    * Fetches the session context and assigns the result to the `sessionContext` property
+   *
+   * Throws when the context cannot be loaded. Callers that depend on a verified
+   * context switch, such as logout or checkout flows, should block progression
+   * when this fails.
    */
   refreshSessionContext(): Promise<void>;
   /**
@@ -137,6 +141,7 @@ export function useSessionContext(
       _sessionContext.value = data;
     } catch (e) {
       console.error("[UseSessionContext][refreshSessionContext]", e);
+      throw e;
     }
   };
 
@@ -227,7 +232,7 @@ export function useSessionContext(
         shippingAddressId: address.id,
       },
     });
-    refreshSessionContext();
+    await refreshSessionContext();
   };
 
   // TODO: replace the source from defaultBillingAddress by new value once NEXT-28627 is solved
@@ -247,7 +252,7 @@ export function useSessionContext(
         billingAddressId: address.id,
       },
     });
-    refreshSessionContext();
+    await refreshSessionContext();
   };
 
   const setContext = (context: Schemas["SalesChannelContext"]) => {

--- a/packages/composables/src/useUser/useUser.test.ts
+++ b/packages/composables/src/useUser/useUser.test.ts
@@ -56,6 +56,8 @@ const REGISTRATION_DATA: Omit<
 
 describe("useUser", () => {
   afterEach(() => {
+    vi.clearAllMocks();
+    refreshSessionContextSpy.mockReset();
     userFromContextRef.value = undefined;
   });
 
@@ -151,7 +153,25 @@ describe("useUser", () => {
     expect(injections.apiClient.invoke).toHaveBeenCalledWith(
       expect.stringContaining("logoutCustomer"),
     );
+    expect(refreshSessionContextSpy).toHaveBeenCalled();
+    expect(refreshCartSpy).toHaveBeenCalled();
     expect(result).toEqual(logoutResponse.data);
+  });
+
+  it("logout rejects when the session context cannot be verified", async () => {
+    const { vm, injections } = useSetup(() => useUser());
+    const error = new Error("context refresh failed");
+    injections.apiClient.invoke.mockResolvedValue({
+      data: { redirectUrl: "/" },
+    });
+    refreshSessionContextSpy.mockRejectedValue(error);
+
+    await expect(vm.logout()).rejects.toThrow(error);
+
+    expect(injections.apiClient.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("logoutCustomer"),
+    );
+    expect(refreshCartSpy).not.toHaveBeenCalled();
   });
 
   it("refreshUser", async () => {

--- a/packages/nuxt-module/README.md
+++ b/packages/nuxt-module/README.md
@@ -67,7 +67,7 @@ Now you can use any composable function you need without extra import:
 <script setup>
   const { login } = useUser();
   const { refreshSessionContext } = useSessionContext();
-  refreshSessionContext();
+  await refreshSessionContext();
 </script>
 ```
 

--- a/templates/vue-blank/app/app.vue
+++ b/templates/vue-blank/app/app.vue
@@ -3,7 +3,9 @@ import Frontends from "./components/Frontends.vue";
 const { refreshSessionContext } = useSessionContext();
 
 onMounted(() => {
-  refreshSessionContext();
+  refreshSessionContext().catch((error) => {
+    console.error("[App][refreshSessionContext]", error);
+  });
 });
 </script>
 

--- a/templates/vue-demo-store/app/components/account/AccountAddressCard.vue
+++ b/templates/vue-demo-store/app/components/account/AccountAddressCard.vue
@@ -42,7 +42,7 @@ const canBeDeleted = computed(
 const setDefaultShippingAddress = async () => {
   try {
     await setDefaultCustomerShippingAddress(address.id);
-    refreshSessionContext();
+    await refreshSessionContext();
     pushSuccess(t("account.messages.defaultShippingAddressSuccess"));
   } catch (error) {
     pushError(t("account.messages.defaultShippingAddressError"));
@@ -52,7 +52,7 @@ const setDefaultShippingAddress = async () => {
 const setDefaultBillingAddress = async () => {
   try {
     await setDefaultCustomerBillingAddress(address.id);
-    refreshSessionContext();
+    await refreshSessionContext();
     pushSuccess(t("account.messages.defaultBillingAddressSuccess"));
   } catch (error) {
     pushError(t("account.messages.defaultBillingAddressError"));

--- a/templates/vue-vite-blank/src/App.vue
+++ b/templates/vue-vite-blank/src/App.vue
@@ -6,7 +6,9 @@ import { useSessionContext } from "@shopware/composables/dist";
 import Frontends from "./components/Frontends.vue";
 
 const { refreshSessionContext } = useSessionContext();
-refreshSessionContext();
+refreshSessionContext().catch((error) => {
+  console.error("[App][refreshSessionContext]", error);
+});
 </script>
 
 <template>


### PR DESCRIPTION
### Description

Propagates session context refresh failures so session-changing flows cannot silently continue after an unverifiable context switch. Adds guest checkout boundary guidance, updates refresh examples to await or handle failures, and includes focused tests plus a changeset for `@shopware/composables`.

### Type of change

Bug fix (non-breaking change that fixes an issue)

### ToDo's

- [x] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation)
- [x] Documentation added/updated
- [x] Unit-Tests added/updated
- [ ] E2E-Tests added/updated
- [ ] Related Issue updated

### Screenshots (if applicable)

Not applicable.

### Additional context

Validated with targeted composable tests, package typecheck, oxlint, and oxfmt checks.
