### PR TITLE
fix(templates): skip checkout method icons without media

### DIFF
--- a/templates/vue-starter-template/app/components/checkout/PaymentMethods.vue
+++ b/templates/vue-starter-template/app/components/checkout/PaymentMethods.vue
@@ -52,7 +52,7 @@ function handleChange(id: string) {
             {{ paymentMethod.description }}
           </div>
         </div>
-        <div class="ml-auto">
+        <div v-if="getPaymentMethodIcon(paymentMethod)" class="ml-auto">
           <NuxtImg
             :src="getPaymentMethodIcon(paymentMethod)"
             height="32"

--- a/templates/vue-starter-template/app/components/checkout/ShippingMethods.vue
+++ b/templates/vue-starter-template/app/components/checkout/ShippingMethods.vue
@@ -54,7 +54,7 @@ function handleChange(id: string) {
             {{ getShippingMethodDeliveryTime(shippingMethod) }}
           </div>
         </div>
-        <div class="ml-auto">
+        <div v-if="getShippingMethodIcon(shippingMethod)" class="ml-auto">
           <NuxtImg
             :src="getShippingMethodIcon(shippingMethod)"
             height="32"


### PR DESCRIPTION
### Description

Shipping and payment methods without an assigned icon rendered a broken image in the checkout.

`getShippingMethodIcon()` and `getPaymentMethodIcon()` return an empty string when the method has no media. That empty string was passed straight to `NuxtImg`, which still built its density srcset from it. The result was `<img srcset="1x, 2x" src="">`. A browser resolves an empty `src` against the current document, so it requested the checkout page itself as an image and showed the broken image placeholder.

The fix renders the icon only when the method actually has media. This matches how `vue-demo-store` already handles it in `app/pages/checkout/index.vue`.

This is not a missing association. Shopware core adds the media association server side in both `ShippingMethodRoute` and `PaymentMethodRoute`, so the data is already requested correctly. The demo store's "Standard" shipping method simply has `mediaId: null`. Any merchant can leave a method icon empty, so the frontend has to handle it.

Changed files:

- `templates/vue-starter-template/app/components/checkout/ShippingMethods.vue`
- `templates/vue-starter-template/app/components/checkout/PaymentMethods.vue`

`vue-starter-template-extended` needs no change. It extends `vue-starter-template` as a Nuxt layer and uses these same components, so it picks up the fix automatically.

### Type of change

Bug fix (non-breaking change that fixes an issue)


### Screenshots (if applicable)

<img width="664" height="255" alt="image" src="https://github.com/user-attachments/assets/261004fc-32d5-46d1-89c1-b0f079fe20be" />


Before: the shipping method row shows a broken image placeholder. DevTools shows `srcset="1x, 2x"` with an empty `src`.

After: no image element is rendered when the method has no icon. Methods that do have an icon are unchanged.

### Additional context

Verified against both demo sales channels with and without an explicit `media` association:

| endpoint | request body | `mediaId` | `media` |
| --- | --- | --- | --- |
| `/payment-method` | `{}` | `b5da4638...` | full object with `url` |
| `/payment-method` | `{"associations":{"media":{}}}` | `b5da4638...` | full object with `url` |
| `/shipping-method` | `{}` | `null` | `null` |
| `/shipping-method` | `{"associations":{"media":{}}}` | `null` | `null` |

Payment method media arrives fully loaded with no associations requested. Adding the association to the shipping request changes nothing.

The public helpers keep returning an empty string. That is their documented and unit tested contract in `@shopware/helpers`, so changing it to `undefined` would be a breaking change for a problem the call sites can handle.

`oxlint` and `oxfmt --check` pass on both changed files.
