### PR TITLE
fix(unocss-design-tokens-layer): keep oxc-parser out of the client bundle

### DIFF
--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,20 @@
+---
+"@shopware/unocss-design-tokens-layer": patch
+---
+
+Load `presetWind3` from `@unocss/preset-wind3` instead of the `unocss` barrel in
+`uno.runtime.config.ts`.
+
+That file is imported by a client plugin, and the barrel statically re-exports
+`@unocss/transformer-attributify-jsx`. That transformer depends on `oxc-parser`, whose
+browser entry imports `@oxc-parser/binding-wasm32-wasi`. The binding is not present in a
+production install, so the client bundle failed to build:
+
+```
+[vite]: Rolldown failed to resolve import "@oxc-parser/binding-wasm32-wasi"
+from "oxc-parser/src-js/wasm.js"
+```
+
+The parser never runs in the browser. Importing the preset directly keeps it out of the
+client graph and also stops a 1.4 MB `.wasm` file and its worker from being emitted into
+the public bundle.

--- a/packages/unocss-design-tokens-layer/uno.runtime.config.ts
+++ b/packages/unocss-design-tokens-layer/uno.runtime.config.ts
@@ -1,5 +1,9 @@
 import type { ConfigBase } from "@unocss/core";
-import { presetWind3 } from "unocss";
+// Import the preset from its own package, not the `unocss` barrel. This config is
+// loaded by a client plugin, and the barrel statically re-exports
+// `@unocss/transformer-attributify-jsx`, which pulls `oxc-parser` and its wasm
+// binding into the client bundle.
+import { presetWind3 } from "@unocss/preset-wind3";
 
 import { designTokenTheme } from "./theme";
 


### PR DESCRIPTION
uno.runtime.config.ts is imported by app/plugins/unocss-runtime.client.ts, so it is part of the client graph. It loaded presetWind3 from the `unocss` barrel, and that barrel statically re-exports @unocss/transformer-attributify-jsx. The transformer depends on oxc-parser, whose browser entry is src-js/wasm.js, which imports @oxc-parser/binding-wasm32-wasi.

That binding is not present in a production install, so the client bundle failed to build:

  [vite]: Rolldown failed to resolve import "@oxc-parser/binding-wasm32-wasi"
  from "oxc-parser/src-js/wasm.js"

This is why the vue-starter-template and starter-template-extended Vercel deployments fail on main. It stayed hidden for a while because turbo replayed vue-starter-template#build from cache instead of running it.

Load the preset from @unocss/preset-wind3, which is already a dependency of this package. The parser never runs in the browser, so nothing else changes, and a 1.4 MB parser.wasm32-wasi.wasm plus its worker stop being emitted into the public bundle.

### Description

<!-- Describe the changes you did and which issue you're closing -->

<!-- example: closes #007 -->

### Type of change

<!-- Comment out the type of change your PR is making -->

<!-- Bug fix (non-breaking change that fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

### ToDo's

<!-- Add the todo's that need to be done before merge -->
<!-- Remember to run `pnpm run changeset` and describe your change (plus potential migration guide/important notes) to your pull request. -->

<!-- - [ ] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation) -->
<!-- - [ ] Documentation added/updated -->
<!-- - [ ] Unit-Tests added/updated -->
<!-- - [ ] E2E-Tests added/updated -->
<!-- - [ ] Related Issue updated -->

### Screenshots (if applicable)

<!-- Please attach any relevant screenshots or images to help explain your changes. -->

### Additional context

<!-- Add any other context about the pull request here. -->
