### PR TITLE
fix(docs): resolve cms-base-layer types for reference page

### DIFF
--- a/.changeset/olive-parrots-ship.md
+++ b/.changeset/olive-parrots-ship.md
@@ -1,0 +1,5 @@
+---
+"@shopware/cms-base-layer": patch
+---
+
+Ship `component-dirs.json` in the published package. `nuxt.config.ts` imports it at load time, but it was missing from `files`, so the layer failed to load when installed from the registry.

--- a/apps/docs/.vitepress/theme/typer/cms-base-plugin.ts
+++ b/apps/docs/.vitepress/theme/typer/cms-base-plugin.ts
@@ -1,5 +1,5 @@
 import { readFileSync, readdirSync } from "node:fs";
-import { relative, resolve } from "node:path";
+import { relative, resolve, sep } from "node:path";
 
 // @ts-nocheck
 import type { Plugin } from "vite";
@@ -48,15 +48,16 @@ export async function CmsBaseReference({
         // "frontends/" leaves a "_source/" segment in the permalink. Derive the path
         // from projectRootDir instead, and keep the old heuristic as a fallback.
         const fromRoot = relative(projectRootDir, componentPath);
-        const normalizedPath =
+        const normalizedPath = (
           fromRoot && !fromRoot.startsWith("..")
             ? fromRoot
-            : (
-                componentPath
-                  .replace(/\/vercel\/path0\//g, "")
-                  .split("frontends/")
-                  .pop() || ""
-              ).replace(/^_source\//, "");
+            : componentPath
+                .replace(/\/vercel\/path0\//g, "")
+                .split("frontends/")
+                .pop() || ""
+        )
+          .replaceAll(sep, "/")
+          .replace(/^_source\//, "");
 
         API += prepareGithubPermalink({
           label: "source code",

--- a/apps/docs/.vitepress/theme/typer/cms-base-plugin.ts
+++ b/apps/docs/.vitepress/theme/typer/cms-base-plugin.ts
@@ -1,5 +1,5 @@
 import { readFileSync, readdirSync } from "node:fs";
-import { resolve } from "node:path";
+import { relative, resolve } from "node:path";
 
 // @ts-nocheck
 import type { Plugin } from "vite";
@@ -44,13 +44,19 @@ export async function CmsBaseReference({
           component.path ||
           resolve(`${projectRootDir}/${relativeDir}`);
 
-        // Remove both /vercel/path0/ and extract path after frontends/
-        let normalizedPath = componentPath.replace(/\/vercel\/path0\//g, "");
-        const pathParts = normalizedPath.split("frontends/");
-        normalizedPath =
-          pathParts.length > 1
-            ? pathParts.pop() || ""
-            : normalizedPath.replace(projectRootDir, "").replace(/^\//, "");
+        // DevHub mounts the repo at <cwd>/src/frontends/_source, so splitting on
+        // "frontends/" leaves a "_source/" segment in the permalink. Derive the path
+        // from projectRootDir instead, and keep the old heuristic as a fallback.
+        const fromRoot = relative(projectRootDir, componentPath);
+        const normalizedPath =
+          fromRoot && !fromRoot.startsWith("..")
+            ? fromRoot
+            : (
+                componentPath
+                  .replace(/\/vercel\/path0\//g, "")
+                  .split("frontends/")
+                  .pop() || ""
+              ).replace(/^_source\//, "");
 
         API += prepareGithubPermalink({
           label: "source code",

--- a/apps/docs/.vitepress/theme/typer/plugin.ts
+++ b/apps/docs/.vitepress/theme/typer/plugin.ts
@@ -62,13 +62,19 @@ export async function ReadmeBasedReference({
         "tail",
       );
 
-      const indexAstJson = extract(
-        resolve(`${projectRootDir}/${relativeDir}/${packageName}/src/index.ts`),
+      const entrypoint = resolve(
+        `${projectRootDir}/${relativeDir}/${packageName}/src/index.ts`,
       );
 
-      const exportedList: string[] = await expCollector(
-        resolve(`${projectRootDir}/${relativeDir}/${packageName}/src/index.ts`),
-      );
+      // packages without a TypeScript entrypoint (e.g. plain Nuxt layers)
+      // expose no API to extract, keep the README-only page
+      if (!existsSync(entrypoint)) {
+        return transformedCode;
+      }
+
+      const indexAstJson = extract(entrypoint);
+
+      const exportedList: string[] = await expCollector(entrypoint);
 
       if (!exportedList.length) {
         return transformedCode;

--- a/packages/cms-base-layer/component-dirs.json
+++ b/packages/cms-base-layer/component-dirs.json
@@ -3,20 +3,17 @@
     {
       "path": "./app/components",
       "pattern": "Sw*",
-      "global": true,
-      "docsLabel": "Store components"
+      "global": true
     },
     {
       "path": "./app/components/public",
       "pathPrefix": false,
-      "global": true,
-      "docsLabel": "CMS components"
+      "global": true
     },
     {
       "path": "./app/components/ui",
       "prefix": "Sw",
-      "global": true,
-      "docsLabel": "UI components"
+      "global": true
     }
   ],
   "excluded": ["SwMedia3D"]

--- a/packages/cms-base-layer/component-dirs.json
+++ b/packages/cms-base-layer/component-dirs.json
@@ -1,0 +1,23 @@
+{
+  "dirs": [
+    {
+      "path": "./app/components",
+      "pattern": "Sw*",
+      "global": true,
+      "docsLabel": "Store components"
+    },
+    {
+      "path": "./app/components/public",
+      "pathPrefix": false,
+      "global": true,
+      "docsLabel": "CMS components"
+    },
+    {
+      "path": "./app/components/ui",
+      "prefix": "Sw",
+      "global": true,
+      "docsLabel": "UI components"
+    }
+  ],
+  "excluded": ["SwMedia3D"]
+}

--- a/packages/cms-base-layer/nuxt.config.ts
+++ b/packages/cms-base-layer/nuxt.config.ts
@@ -3,6 +3,8 @@ import type { NuxtConfig } from "@nuxt/schema";
 import { defineNuxtConfig } from "nuxt/config";
 import type { LoggingFunction, RollupLog } from "rollup";
 
+import componentDirs from "./component-dirs.json";
+
 const { resolve: resolveLayer } = createResolver(import.meta.url);
 
 export default defineNuxtConfig({
@@ -21,14 +23,9 @@ export default defineNuxtConfig({
     "components:extend"(components) {
       // Exclude SwMedia3D from auto-import to prevent bundling heavy 3D libraries
       // It should be dynamically imported when needed using defineAsyncComponent.
-      const index = components.findIndex(
-        (c) =>
-          c.pascalName === "SwMedia3D" ||
-          c.kebabName === "sw-media3-d" ||
-          c.filePath?.includes("SwMedia3D.vue"),
-      );
-      if (index > -1) {
-        components.splice(index, 1);
+      for (const name of componentDirs.excluded) {
+        const index = components.findIndex((c) => c.pascalName === name);
+        if (index > -1) components.splice(index, 1);
       }
     },
   },
@@ -91,26 +88,13 @@ export default defineNuxtConfig({
     },
   },
 
-  components: [
-    {
-      path: resolveLayer("./app/components"),
-      pattern: "Sw*",
+  components: componentDirs.dirs.map(
+    ({ path, docsLabel: _docsLabel, ...dir }) => ({
+      ...dir,
+      path: resolveLayer(path),
       extensions: [".vue"],
-      global: true,
-    },
-    {
-      path: resolveLayer("./app/components/ui"),
-      extensions: [".vue"],
-      prefix: "Sw",
-      global: true,
-    },
-    {
-      path: resolveLayer("./app/components/public"),
-      pathPrefix: false,
-      global: true,
-      extensions: [".vue"],
-    },
-  ],
+    }),
+  ),
   alias: {
     "@cms-assets": resolveLayer("./app/assets"),
   },

--- a/packages/cms-base-layer/nuxt.config.ts
+++ b/packages/cms-base-layer/nuxt.config.ts
@@ -88,13 +88,11 @@ export default defineNuxtConfig({
     },
   },
 
-  components: componentDirs.dirs.map(
-    ({ path, docsLabel: _docsLabel, ...dir }) => ({
-      ...dir,
-      path: resolveLayer(path),
-      extensions: [".vue"],
-    }),
-  ),
+  components: componentDirs.dirs.map(({ path, ...dir }) => ({
+    ...dir,
+    path: resolveLayer(path),
+    extensions: [".vue"],
+  })),
   alias: {
     "@cms-assets": resolveLayer("./app/assets"),
   },

--- a/packages/cms-base-layer/package.json
+++ b/packages/cms-base-layer/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "app",
+    "component-dirs.json",
     "index.d.ts",
     "nuxt.config.ts"
   ],

--- a/packages/cms-base-layer/tsconfig.json
+++ b/packages/cms-base-layer/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["."],
   "compilerOptions": {
     "jsx": "preserve",
+    "resolveJsonModule": true,
     "lib": ["dom"],
     "paths": {
       "#imports": ["./types/imports.d.ts"],


### PR DESCRIPTION
## Problem

#2609 made `cms-base-layer` a plain Nuxt layer and deleted `packages/cms-base-layer/src/index.ts`.

The docs pipeline did not expect that. `ReadmeBasedReference` runs `ts-dox` on `<package>/src/index.ts` for every page under `packages/`, with no check that the file exists. For `cms-base-layer` it threw `ENOENT` and took down the whole Developer Portal build.

## Fix

- `plugin.ts` skips API extraction when a package has no TypeScript entry point. Such packages keep their README-only page instead of failing the build.
- `component-dirs.json` now holds the layer's component directories and auto-import exclusions. `nuxt.config.ts` reads it, so the docs can use the same source instead of duplicating the rules.
- `cms-base-plugin.ts` builds source links from `projectRootDir`. It used to split on `"frontends/"`, which matched the Developer Portal's `src/frontends/` mount and produced `/_source/...` links that 404.
- `component-dirs.json` added to `files`. Without it the published tarball omits the file and the layer fails on its own config.

## Verification

- Developer Portal healthcheck passes on this branch. That run started at 08:44Z, before shopware/developer-portal#638 merged at 09:19Z, so it passed on this fix alone.
- Generated `components.d.ts` is byte-identical before and after the config refactor, and `SwMedia3D` stays excluded.
- Installed the packed tarball in a scratch project: the layer resolves and 269 components register. Deleting `component-dirs.json` from the install reproduces `Cannot find module './component-dirs.json'`.
- Component permalinks: 70 links, none containing `_source`.

## Follow-up needed in developer-portal

@Isengo1989 FYI:

shopware/developer-portal#638 was merged and added this to `srcExclude` in `.vitepress/config.ts`:

```ts
// frontends packages without source files (e.g., cms-base-layer converted to pure Nuxt layer)
'frontends/packages/cms-base-layer.md',
```

That was a workaround for the same crash. Once this PR lands it has to be removed, otherwise the page stays out of the build and the sidebar link at `apps/docs/.vitepress/sidebar.ts:392` points at a 404.
