### PR TITLE
test(api-client): stop live Store-API e2e specs from flaking

### DIFF
--- a/packages/api-client/src/invocations.e2e.test.ts
+++ b/packages/api-client/src/invocations.e2e.test.ts
@@ -6,7 +6,8 @@ import { createAPIClient } from "./createAPIClient";
 const baseURL = "https://demo-frontends.shopware.store/store-api";
 const accessToken = "SWSCBHFSNTVMAWNZDNFKSHLAYW";
 
-describe("Test real API invocations", () => {
+// hits the live demo instance, so the 5s default timeout flakes in CI
+describe("Test real API invocations", { retry: 2, timeout: 30_000 }, () => {
   it("should fail on unprovided access token", async () => {
     const apiInstance = createAPIClient<operations>({
       baseURL,

--- a/packages/api-client/src/tests/updateSessionContext.e2e.test.ts
+++ b/packages/api-client/src/tests/updateSessionContext.e2e.test.ts
@@ -6,7 +6,8 @@ import { createAPIClient } from "../createAPIClient";
 const baseURL = "https://demo-frontends.shopware.store/store-api";
 const accessToken = "SWSCBHFSNTVMAWNZDNFKSHLAYW";
 
-describe("updateSessionContext", () => {
+// hits the live demo instance, so the 5s default timeout flakes in CI
+describe("updateSessionContext", { retry: 2, timeout: 30_000 }, () => {
   describe("update session currency", () => {
     it("should update session currency", async () => {
       const apiInstance = createAPIClient<operations>({


### PR DESCRIPTION
The two `*.e2e.test.ts` suites in `packages/api-client` call the live demo instance (`demo-frontends.shopware.store`) and hit vitest's 5s default timeout, failing `Test` on unrelated PRs — e.g. #2644 (`should fail on unprovided access token`, `should update session currency`).

Gives both suites a 30s timeout and 2 retries at the `describe` level, so unit specs keep the strict default.