### PR TITLE
chore(deps): override nanoid to 3.3.18 to fix pnpm audit

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   editorconfig>minimatch: ^9.0.9
   '@vercel/blob>undici': ^6.28.0
   less: ^4.8.1
-  nanoid@<3.3.17: ^3.3.17
+  nanoid@<3.3.18: ^3.3.18
   esbuild: ^0.28.1
   vite: ^8.0.16
   '@vueuse/core': 14.4.0
@@ -9729,11 +9729,6 @@ packages:
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
-
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
 
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
@@ -20679,7 +20674,7 @@ snapshots:
     dependencies:
       '@sanity/eventsource': 5.0.4
       get-it: 8.8.2
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       rxjs: 7.8.2
 
   '@sanity/client@7.26.2':
@@ -26474,8 +26469,6 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.17: {}
-
   nanoid@3.3.18: {}
 
   nanotar@0.3.0: {}
@@ -30259,7 +30252,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,7 @@ overrides:
   "editorconfig>minimatch": "^9.0.9"
   "@vercel/blob>undici": "^6.28.0"
   less: ^4.8.1
-  "nanoid@<3.3.17": "^3.3.17"
+  "nanoid@<3.3.18": "^3.3.18"
   esbuild: ^0.28.1
   vite: ^8.0.16
   "@vueuse/core": 14.4.0


### PR DESCRIPTION
## Description

The scheduled `Audit check` workflow was failing on a **high** severity finding:

```
high  nanoid: custom generators can loop indefinitely when size is zero
Vulnerable versions  <3.3.18
Patched versions     >=3.3.18
```

[GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) was widened to cover `nanoid <3.3.18`. The repo already carried an override from #2626, but it was pinned at the previous patch level (`nanoid@<3.3.17: ^3.3.17`), so the selector no longer matched the newly-affected `3.3.17` and 100 transitive paths (mostly `postcss > nanoid`) stayed vulnerable.

## Changes

Bumped the existing override to `nanoid@<3.3.18: ^3.3.18` and refreshed the lockfile. `nanoid@3.3.17` is now fully gone — every consumer (`postcss@8.5.25`, `@sanity/client@7.26.0`) resolves to `3.3.18`, which stays within the `^3.3.x` range they ask for, so this is a patch-level move with no API change.

## Verification

- `pnpm audit` → `No known vulnerabilities found` (was 1 high)
- `pnpm install --frozen-lockfile --prefer-offline` succeeds, all 6 packages build
- `pnpm lint` → 31/31 packages pass