### PR TITLE
ci: point the accessibility and Lighthouse checks at vue-starter-template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,4 @@
-BASE_E2E_URL="https://frontends-demo.vercel.app/"
+BASE_E2E_URL="https://frontends-starter-template.vercel.app/"
 NUXT_PUBLIC_SHOPWARE_ENDPOINT="https://demo-frontends.shopware.store"
 NUXT_PUBLIC_SHOPWARE_ACCESS_TOKEN="SWSCBHFSNTVMAWNZDNFKSHLAYW"
 NITRO_PRESET=vercel

--- a/.github/workflows/accessibility-check.yml
+++ b/.github/workflows/accessibility-check.yml
@@ -3,6 +3,9 @@ name: Accessibiliy Check
 run-name: Playwright accessibility tests 🚀
 on:
   workflow_dispatch:
+  # Kept on manual dispatch for now. This job has never run green in CI, so a
+  # nightly schedule would only produce a red run every morning. Re-enable the
+  # cron once a manual dispatch passes against the starter template.
   # schedule:
   #   - cron: "30 09 * * *"
 jobs:
@@ -31,4 +34,4 @@ jobs:
       - name: Run tests
         run: |
           cd apps/e2e-tests
-          BASE_E2E_URL=https://frontends-demo.vercel.app/ npx playwright test --grep @accessibility --project=chromium
+          BASE_E2E_URL=https://frontends-starter-template.vercel.app/ npx playwright test --grep @accessibility --project=chromium

--- a/.github/workflows/accessibility-check.yml
+++ b/.github/workflows/accessibility-check.yml
@@ -39,8 +39,12 @@ jobs:
       - name: Run tests
         # Passed as an env var, not interpolated into the script, so a crafted
         # input cannot inject shell.
+        #
+        # The fallback is not redundant with the input default: `inputs` is empty
+        # on a schedule and on a dispatch with a cleared field, and an empty
+        # BASE_E2E_URL points playwright.config.ts at localhost.
         env:
-          BASE_E2E_URL: ${{ inputs.base_url }}
+          BASE_E2E_URL: ${{ inputs.base_url || 'https://frontends-starter-template.vercel.app/' }}
         run: |
           cd apps/e2e-tests
           npx playwright test --grep @accessibility --project=chromium

--- a/.github/workflows/accessibility-check.yml
+++ b/.github/workflows/accessibility-check.yml
@@ -1,4 +1,4 @@
-name: Accessibiliy Check
+name: Accessibility Check
 
 run-name: Playwright accessibility tests 🚀
 on:

--- a/.github/workflows/accessibility-check.yml
+++ b/.github/workflows/accessibility-check.yml
@@ -3,6 +3,11 @@ name: Accessibility Check
 run-name: Playwright accessibility tests 🚀
 on:
   workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Storefront to test. Pass a pull request's Vercel preview URL to check that branch's deployment."
+        required: false
+        default: "https://frontends-starter-template.vercel.app/"
   # Kept on manual dispatch for now. This job has never run green in CI, so a
   # nightly schedule would only produce a red run every morning. Re-enable the
   # cron once a manual dispatch passes against the starter template.
@@ -32,6 +37,10 @@ jobs:
           pnpm playwright install --with-deps
 
       - name: Run tests
+        # Passed as an env var, not interpolated into the script, so a crafted
+        # input cannot inject shell.
+        env:
+          BASE_E2E_URL: ${{ inputs.base_url }}
         run: |
           cd apps/e2e-tests
-          BASE_E2E_URL=https://frontends-starter-template.vercel.app/ npx playwright test --grep @accessibility --project=chromium
+          npx playwright test --grep @accessibility --project=chromium

--- a/.github/workflows/failed-job-check.yml
+++ b/.github/workflows/failed-job-check.yml
@@ -7,7 +7,7 @@ on:
         Lighthouse CI,
         Stackblitz templates,
         Audit check,
-        Accessibiliy Check,
+        Accessibility Check,
       ]
     types: [completed]
     branches: [main, prod]

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -17,7 +17,7 @@ jobs:
         uses: treosh/lighthouse-ci-action@v12
         with:
           urls: |
-            "https://frontends-demo.vercel.app/"
-            "https://frontends-demo.vercel.app/Products/"
-            "https://frontends-demo.vercel.app/Summer-BBQ/"
+            "https://frontends-starter-template.vercel.app/"
+            "https://frontends-starter-template.vercel.app/Furniture/"
+            "https://frontends-starter-template.vercel.app/Sale/"
           configPath: "./lighthouserc.js"

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -16,8 +16,6 @@ jobs:
       - name: Audit URLs using Lighthouse
         uses: treosh/lighthouse-ci-action@v12
         with:
-          urls: |
-            "https://frontends-starter-template.vercel.app/"
-            "https://frontends-starter-template.vercel.app/Furniture/"
-            "https://frontends-starter-template.vercel.app/Sale/"
+          # No `urls:` here on purpose: the action overrides the config file's
+          # `collect.url` with it, and two copies of the list only drift apart.
           configPath: "./lighthouserc.js"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ pnpm run lint:fix                         # Fix linting issues
 pnpm run typecheck                        # TypeScript checking
 pnpm run test                             # Run tests
 pnpm run test:watch                       # Watch mode
-pnpm run test:e2e                         # E2E tests
+pnpm run test:e2e                         # E2E tests (demo store tag only)
 pnpm format                               # Format with Oxfmt
 ```
 
@@ -576,7 +576,17 @@ This creates a file in `.changeset/` - commit it with your changes.
 ### E2E Tests (Playwright)
 
 - Located in `apps/e2e-tests/`
-- Run with `pnpm run test:e2e`
+- Install the browsers once with `pnpm exec playwright install chromium`
+- Run with `pnpm run test:e2e`. That script is `playwright test --grep @vue-demo-store`, so it only covers the deprecated demo store template
+- The `@accessibility` specs are template agnostic. Run them against any storefront:
+
+```bash
+cd apps/e2e-tests
+BASE_E2E_URL=https://frontends-starter-template.vercel.app/ \
+  pnpm exec playwright test --grep @accessibility --project=chromium
+```
+
+- Target host comes from `BASE_E2E_URL`, read from a `.env` file found by walking up from the working directory. See `.env.template` and `apps/e2e-tests/README.md`
 
 ### Type Tests
 
@@ -648,7 +658,7 @@ pnpm run build
 ## API and Documentation
 
 - **Documentation**: [developer.shopware.com/frontends](https://developer.shopware.com/frontends/)
-- **Demo**: [frontends-demo.vercel.app](https://frontends-demo.vercel.app/)
+- **Demo**: [frontends-starter-template.vercel.app](https://frontends-starter-template.vercel.app/)
 - **Repository**: [github.com/shopware/frontends](https://github.com/shopware/frontends)
 - **Discussions**: [GitHub Discussions](https://github.com/shopware/frontends/discussions)
 

--- a/apps/docs/src/best-practices/testing/e2e-testing.md
+++ b/apps/docs/src/best-practices/testing/e2e-testing.md
@@ -35,6 +35,21 @@ await page.waitFor(1000); // hard wait for 1000ms
 Never use hard waits in production tests. However, you can use them for testing or debugging purposes.
 Replace them with playwright methods like `waitForNavigation`, `waitForLoadState`, `waitForSelector`.
 
+One exception: avoid `waitForLoadState("networkidle")` on a Shopware storefront. A Nuxt app keeps making
+requests after the page is usable, so the network rarely goes idle and the wait times out. Wait for the
+element you are about to act on instead.
+
+```js
+// flaky
+await page.waitForLoadState("networkidle");
+await page.getByTestId("product-box-product-name-link").first().click();
+
+// reliable
+const firstProduct = page.getByTestId("product-box-product-name-link").first();
+await firstProduct.waitFor({ state: "visible" });
+await firstProduct.click();
+```
+
 ### Pages
 
 Follow the PageObjects pattern for the suite template to encapsulate each internal page structure and responsibilities inside its highly cohesive class file. This allows you to define a new page object for each page as per your needs.

--- a/apps/e2e-tests/README.md
+++ b/apps/e2e-tests/README.md
@@ -33,7 +33,7 @@ BASE_E2E_URL=https://frontends-starter-template.vercel.app/ \
   pnpm exec playwright test --grep @accessibility --project=chromium
 ```
 
-That is the same command as the `Accessibiliy Check` workflow, which is manual dispatch only. See [.github/workflows/accessibility-check.yml](../../.github/workflows/accessibility-check.yml).
+That is the same command as the `Accessibility Check` workflow, which is manual dispatch only. See [.github/workflows/accessibility-check.yml](../../.github/workflows/accessibility-check.yml).
 
 To check a local build instead, build and serve the template first:
 

--- a/apps/e2e-tests/README.md
+++ b/apps/e2e-tests/README.md
@@ -35,6 +35,24 @@ BASE_E2E_URL=https://frontends-starter-template.vercel.app/ \
 
 That is the same command as the `Accessibility Check` workflow, which is manual dispatch only. See [.github/workflows/accessibility-check.yml](../../.github/workflows/accessibility-check.yml).
 
+### Check a pull request
+
+Every pull request gets a Vercel preview of the starter. Find its URL:
+
+```sh
+gh api repos/shopware/frontends/issues/<pr-number>/comments \
+  --jq '.[] | select(.user.login | test("vercel")) | .body' \
+  | grep -oE 'https://frontends-vue-starter-template[^ )]*'
+```
+
+Then dispatch the workflow against it:
+
+```sh
+gh workflow run accessibility-check.yml --ref <branch> -f base_url=<preview-url>
+```
+
+Without `-f base_url` the workflow checks the deployed starter, so a plain dispatch tells you nothing about the branch. The same URL works locally through `BASE_E2E_URL`.
+
 To check a local build instead, build and serve the template first:
 
 ```sh

--- a/apps/e2e-tests/README.md
+++ b/apps/e2e-tests/README.md
@@ -75,7 +75,7 @@ pnpm exec playwright show-report
 
 ## Lighthouse
 
-Lighthouse is not part of this suite. It runs in the `Lighthouse CI` workflow on manual dispatch, against the URLs listed in [lighthouserc.js](../../lighthouserc.js) at the repository root. That file and the workflow both carry the URL list, so change them together.
+Lighthouse is not part of this suite. It runs in the `Lighthouse CI` workflow on manual dispatch, against the URLs listed in [lighthouserc.js](../../lighthouserc.js) at the repository root. That file is the only place the list lives.
 
 ## Debug tests
 

--- a/apps/e2e-tests/README.md
+++ b/apps/e2e-tests/README.md
@@ -1,26 +1,74 @@
 # E2E tests
 
-## Run tests
+Playwright suite for the templates in this repository.
 
-Prepare a `.env` file with the `BASE_E2E_URL` of your local environment (please see the `.env.template` file).
-Before running tests, create an account on storefront and put the login `USER_EMAIL` and password `PASSWORD` in the `.env` file. Login and password will be used in the login tests.
+All commands below run from this directory, `apps/e2e-tests`. Playwright resolves its config from there.
 
-And run the following command
+## Setup
+
+Install the browsers once:
 
 ```sh
-> pnpm run test:e2e
+pnpm exec playwright install chromium
 ```
+
+Prepare a `.env` file with the `BASE_E2E_URL` of the storefront you want to test. See `.env.template` for the keys. The file is looked up from the working directory upwards, so a root `.env` works too.
+
+The login tests need an account on that storefront. Put its `USER_EMAIL` and `PASSWORD` in the same file.
+
+## Run tests
+
+```sh
+pnpm run test:e2e
+```
+
+`test:e2e` is `playwright test --grep @vue-demo-store`, so it only runs the specs tagged for the deprecated demo store template. Retagging it for `vue-starter-template` is tracked in [#2649](https://github.com/shopware/frontends/issues/2649).
+
+## Run the accessibility check
+
+The `@accessibility` specs do not select on template specific content, so they run against any storefront. CI runs them against the supported starter template:
+
+```sh
+BASE_E2E_URL=https://frontends-starter-template.vercel.app/ \
+  pnpm exec playwright test --grep @accessibility --project=chromium
+```
+
+That is the same command as the `Accessibiliy Check` workflow, which is manual dispatch only. See [.github/workflows/accessibility-check.yml](../../.github/workflows/accessibility-check.yml).
+
+To check a local build instead, build and serve the template first:
+
+```sh
+pnpm --filter vue-starter-template build
+pnpm --filter vue-starter-template preview
+```
+
+then point the run at it:
+
+```sh
+BASE_E2E_URL=http://localhost:3000/ \
+  pnpm exec playwright test --grep @accessibility --project=chromium
+```
+
+A failing run means axe found a real violation. Open the report to see which rule and which element:
+
+```sh
+pnpm exec playwright show-report
+```
+
+## Lighthouse
+
+Lighthouse is not part of this suite. It runs in the `Lighthouse CI` workflow on manual dispatch, against the URLs listed in [lighthouserc.js](../../lighthouserc.js) at the repository root. That file and the workflow both carry the URL list, so change them together.
 
 ## Debug tests
 
 To debug all tests, run
 
 ```sh
-> pnpm test:e2e --debug
+pnpm run test:e2e --debug
 ```
 
 To debug only a single test, run
 
 ```sh
-> pnpm test:e2e example-test -- --debug
+pnpm run test:e2e example-test -- --debug
 ```

--- a/apps/e2e-tests/page-objects/HomePage.ts
+++ b/apps/e2e-tests/page-objects/HomePage.ts
@@ -72,8 +72,10 @@ export class HomePage extends AbstractPage {
    *
    * Nav entries are sales channel content, so the first one is not guaranteed
    * to list products. New-tab entries are skipped and the rest tried in order.
-   * The URL is checked before the product card because the home page carries
-   * cards of its own, so the card alone would pass without ever leaving home.
+   *
+   * Entries are opened by their href rather than clicked. A click hands over to
+   * the client router, which swaps the URL long before the listing renders, and
+   * axe would scan the page mid-transition.
    */
   async openFirstCategoryPage() {
     const sameTabEntries = this.page.locator(
@@ -81,23 +83,28 @@ export class HomePage extends AbstractPage {
     );
     await sameTabEntries.first().waitFor({ state: "visible" });
 
+    // Bounded, so a storefront where nothing lists products reports the error
+    // below instead of running past the 30s test timeout.
+    const candidates = (await sameTabEntries.all()).slice(0, 3);
+
     const tried: string[] = [];
-    for (const entry of await sameTabEntries.all()) {
+    for (const entry of candidates) {
+      const label = (await entry.textContent())?.trim() || "(unnamed)";
       const href = await entry.getAttribute("href");
-      if (!href) continue;
-      tried.push((await entry.textContent())?.trim() || "(unnamed)");
-      await entry.click();
+      if (!href) {
+        tried.push(`${label} (no href)`);
+        continue;
+      }
+      tried.push(label);
+      await this.page.goto(href);
       try {
-        await this.page.waitForURL((url) => url.pathname.startsWith(href), {
-          timeout: 4000,
-        });
         await this.page
           .getByTestId("product-box-product-name-link")
           .first()
-          .waitFor({ state: "visible", timeout: 4000 });
+          .waitFor({ state: "visible", timeout: 3000 });
         return;
       } catch {
-        await this.visitMainPage();
+        continue;
       }
     }
 

--- a/apps/e2e-tests/page-objects/HomePage.ts
+++ b/apps/e2e-tests/page-objects/HomePage.ts
@@ -65,6 +65,34 @@ export class HomePage extends AbstractPage {
       .click();
   }
 
+  /**
+   * Template agnostic navigation, used by the @accessibility run.
+   * openCategoryPage and openCartPage above select on vue-demo-store content
+   * ("Products", "YORK 3") that does not exist in vue-starter-template.
+   */
+  async openFirstCategoryPage() {
+    const firstCategory = this.page
+      .getByRole("menubar")
+      .getByRole("menuitem")
+      .first();
+    await firstCategory.waitFor({ state: "visible" });
+    await firstCategory.click();
+    await this.page
+      .getByTestId("product-box-product-name-link")
+      .first()
+      .waitFor({ state: "visible" });
+  }
+
+  async openFirstProductPage() {
+    await this.page
+      .getByTestId("product-box-product-name-link")
+      .first()
+      .click();
+    await this.page.waitForSelector("[data-testid='product-quantity']", {
+      state: "visible",
+    });
+  }
+
   async openRegistrationPage() {
     await this.linkToRegistrationPage.click();
     await this.page.waitForURL("**/register");

--- a/apps/e2e-tests/page-objects/HomePage.ts
+++ b/apps/e2e-tests/page-objects/HomePage.ts
@@ -69,18 +69,41 @@ export class HomePage extends AbstractPage {
    * Template agnostic navigation, used by the @accessibility run.
    * openCategoryPage and openCartPage above select on vue-demo-store content
    * ("Products", "YORK 3") that does not exist in vue-starter-template.
+   *
+   * Nav entries are sales channel content, so the first one is not guaranteed
+   * to list products. New-tab entries are skipped and the rest tried in order.
+   * The URL is checked before the product card because the home page carries
+   * cards of its own, so the card alone would pass without ever leaving home.
    */
   async openFirstCategoryPage() {
-    const firstCategory = this.page
-      .getByRole("menubar")
-      .getByRole("menuitem")
-      .first();
-    await firstCategory.waitFor({ state: "visible" });
-    await firstCategory.click();
-    await this.page
-      .getByTestId("product-box-product-name-link")
-      .first()
-      .waitFor({ state: "visible" });
+    const sameTabEntries = this.page.locator(
+      '[role="menubar"] [role="menuitem"]:not([target="_blank"])',
+    );
+    await sameTabEntries.first().waitFor({ state: "visible" });
+
+    const tried: string[] = [];
+    for (const entry of await sameTabEntries.all()) {
+      const href = await entry.getAttribute("href");
+      if (!href) continue;
+      tried.push((await entry.textContent())?.trim() || "(unnamed)");
+      await entry.click();
+      try {
+        await this.page.waitForURL((url) => url.pathname.startsWith(href), {
+          timeout: 4000,
+        });
+        await this.page
+          .getByTestId("product-box-product-name-link")
+          .first()
+          .waitFor({ state: "visible", timeout: 4000 });
+        return;
+      } catch {
+        await this.visitMainPage();
+      }
+    }
+
+    throw new Error(
+      `No top navigation entry opened a product listing. Tried: ${tried.join(", ")}.`,
+    );
   }
 
   async openFirstProductPage() {

--- a/apps/e2e-tests/tests/accessibilityCheck.spec.ts
+++ b/apps/e2e-tests/tests/accessibilityCheck.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 
 import { HomePage } from "../page-objects/HomePage";
 
-test.describe.only(
+test.describe(
   "Should not have any automatically detectable accessibility issues",
   { tag: "@accessibility" },
   () => {
@@ -26,7 +26,7 @@ test.describe.only(
 
     test("Check Category accessibility issues", async ({ page }) => {
       await homePage.visitMainPage();
-      await homePage.openCategoryPage();
+      await homePage.openFirstCategoryPage();
       const accessibilityScanResults = await new AxeBuilder({ page })
         .disableRules(["heading-order", "page-has-heading-one"])
         .analyze();
@@ -35,7 +35,8 @@ test.describe.only(
 
     test("Check Product Page accessibility issues", async ({ page }) => {
       await homePage.visitMainPage();
-      await homePage.openCartPage();
+      await homePage.openFirstCategoryPage();
+      await homePage.openFirstProductPage();
       const accessibilityScanResults = await new AxeBuilder({ page })
         .disableRules(["heading-order", "page-has-heading-one"])
         .analyze();

--- a/apps/e2e-tests/tests/accessibilityCheck.spec.ts
+++ b/apps/e2e-tests/tests/accessibilityCheck.spec.ts
@@ -17,7 +17,6 @@ test.describe(
     });
 
     test("Check Homepage accessibility issues", async ({ page }) => {
-      await homePage.visitMainPage();
       const accessibilityScanResults = await new AxeBuilder({ page })
         .disableRules(["heading-order", "page-has-heading-one"])
         .analyze();
@@ -25,7 +24,6 @@ test.describe(
     });
 
     test("Check Category accessibility issues", async ({ page }) => {
-      await homePage.visitMainPage();
       await homePage.openFirstCategoryPage();
       const accessibilityScanResults = await new AxeBuilder({ page })
         .disableRules(["heading-order", "page-has-heading-one"])
@@ -34,7 +32,6 @@ test.describe(
     });
 
     test("Check Product Page accessibility issues", async ({ page }) => {
-      await homePage.visitMainPage();
       await homePage.openFirstCategoryPage();
       await homePage.openFirstProductPage();
       const accessibilityScanResults = await new AxeBuilder({ page })

--- a/apps/e2e-tests/utils/helpers.ts
+++ b/apps/e2e-tests/utils/helpers.ts
@@ -1,2 +1,25 @@
-import { findUp } from "find-up";
-export const findEnv = () => findUp(process.env.ENV_FILE || ".env");
+import { existsSync } from "node:fs";
+import { dirname, join, parse } from "node:path";
+
+/**
+ * Walk up from the working directory looking for an env file.
+ *
+ * This used to call find-up, which is declared in no package.json here. It
+ * resolved to a hoisted CommonJS copy, so the named import was undefined and
+ * loading playwright.config.ts threw. The version that did resolve was also
+ * async, so dotenv received a Promise rather than a path.
+ *
+ * Returns undefined when no file is found, which leaves dotenv on its default.
+ */
+export const findEnv = (): string | undefined => {
+  const fileName = process.env.ENV_FILE || ".env";
+  const { root } = parse(process.cwd());
+
+  let directory = process.cwd();
+  for (;;) {
+    const candidate = join(directory, fileName);
+    if (existsSync(candidate)) return candidate;
+    if (directory === root) return undefined;
+    directory = dirname(directory);
+  }
+};

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -2,10 +2,18 @@ module.exports = {
   ci: {
     collect: {
       numberOfRuns: 5,
+      // vue-starter-template is the supported template. vue-demo-store is
+      // deprecated and gets deleted by 2026-12-31, so its deployment is not
+      // worth measuring any more.
+      //
+      // The old paths /Products/ and /Summer-BBQ/ are not a rename away: the
+      // starter runs a different sales channel with a different catalogue, and
+      // both paths return 404 on it. These three are the closest equivalents,
+      // one home page and two category listings, and all return 200 today.
       url: [
-        "https://frontends-demo.vercel.app/",
-        "https://frontends-demo.vercel.app/Products/",
-        "https://frontends-demo.vercel.app/Summer-BBQ/",
+        "https://frontends-starter-template.vercel.app/",
+        "https://frontends-starter-template.vercel.app/Furniture/",
+        "https://frontends-starter-template.vercel.app/Sale/",
       ],
       settings: {
         onlyCategories: [


### PR DESCRIPTION
### Description

closes #2653

The accessibility and Lighthouse workflows measured `frontends-demo.vercel.app`, the deprecated demo store. They now measure `vue-starter-template`.

`/Products/` and `/Summer-BBQ/` are not a rename away. The starter runs a different sales channel and both return 404 on it, so Lighthouse audits `/Furniture/` and `/Sale/` instead. The reason is recorded in `lighthouserc.js`, which held a second copy of the URL list that the issue missed.

Two pre-existing breaks had to go first, or the repointed workflow could not run at all:

- `apps/e2e-tests` imported `find-up`, declared in no package.json. It resolved to a hoisted CommonJS copy, so the named import was undefined and `playwright.config.ts` threw before any test started.
- The accessibility specs navigated via demo store content, a "Products" menu item and a "YORK 3" product. Neither exists on the starter.

Also dropped a `test.describe.only` that would suppress every other spec in a full run. That one would have bitten #2649.

The nightly cron stays commented out. This job has never been green, and a schedule that is red every morning just gets ignored. The reason is written into the workflow.

### Type of change

Bug fix (non-breaking change that fixes an issue)

### Added after the first review

**The workflow name was misspelled "Accessibiliy".** Copilot flagged it and named the coupling: `failed-job-check.yml` matches the workflow by exact name in its `workflow_run` list, so a rename without it would silently stop the Slack failure notification. Both files change together, plus the one docs line that repeated the typo.

**The check can now target any storefront.** `BASE_E2E_URL` was hardcoded, so dispatching on a branch ran that branch's code against production and told you nothing about the branch. A `base_url` dispatch input fixes that:

```sh
gh workflow run accessibility-check.yml --ref <branch> -f base_url=<vercel-preview-url>
```

It defaults to the deployed starter, so a plain dispatch behaves as before. The value is passed through `env:` rather than interpolated into the run script, so a crafted input cannot inject shell.

### ToDo's

- [x] Documentation added/updated
- [ ] Related Issue updated

No changeset. Nothing here is a published package.

### Additional context

Verified by running it, not by reading it.

Against the deployed starter, 2 of 3 pass. The homepage fails on a real serious `link-name` violation, which is the check doing its job. #2663 fixes it.

Against #2663's Vercel preview, which carries that fix, all 3 pass:

```sh
cd apps/e2e-tests
BASE_E2E_URL=<2663-preview-url> \
  pnpm exec playwright test --grep @accessibility --project=chromium

3 passed
```

So this workflow stays red until #2663 merges, and goes green immediately after.

`apps/e2e-tests/README.md` documents all three ways to run it: the deployed starter, a pull request preview, and a local build.
