### PR TITLE
fix(vue-starter-template): make test ids reach the right element

### DIFF
--- a/templates/vue-starter-template/app/components/account/RegistrationForm.vue
+++ b/templates/vue-starter-template/app/components/account/RegistrationForm.vue
@@ -178,7 +178,7 @@ const invokeSubmit = async () => {
           v-if="!companyOnly"
           class="col-span-12"
           v-model="accountTypeModel"
-          dataTestId="registration-account-type-select"
+          data-testid="registration-account-type-select"
           id="accountType"
         />
 
@@ -190,7 +190,7 @@ const invokeSubmit = async () => {
           :label="$t('form.firstName')"
           :errorMessage="r$.firstName.$errors[0]"
           @blur="r$.firstName.$touch()"
-          dataTestId="registration-first-name-input"
+          data-testid="registration-first-name-input"
         />
 
         <FormInputField
@@ -201,7 +201,7 @@ const invokeSubmit = async () => {
           :label="$t('form.lastName')"
           :errorMessage="r$.lastName.$errors[0]"
           @blur="r$.lastName.$touch()"
-          dataTestId="registration-last-name-input"
+          data-testid="registration-last-name-input"
         />
 
         <FormInputField
@@ -212,7 +212,7 @@ const invokeSubmit = async () => {
           :label="$t('form.email')"
           :errorMessage="r$.email.$errors[0]"
           @blur="r$.email.$touch()"
-          dataTestId="registration-email-input"
+          data-testid="registration-email-input"
         />
 
         <FormInputField
@@ -224,7 +224,7 @@ const invokeSubmit = async () => {
           :label="$t('form.password')"
           :errorMessage="r$.password.$errors[0]"
           @blur="r$.password.$touch()"
-          dataTestId="registration-password-input"
+          data-testid="registration-password-input"
         />
 
         <FormInputField
@@ -234,7 +234,7 @@ const invokeSubmit = async () => {
           v-model="vatIdModel"
           :label="$t('form.vatId')"
           @blur="r$.vatIds?.$touch()"
-          dataTestId="registration-vatid-input"
+          data-testid="registration-vatid-input"
         />
       </div>
 
@@ -252,7 +252,7 @@ const invokeSubmit = async () => {
           v-model="companyModel"
           autocomplete="company"
           :label="$t('form.company')"
-          dataTestId="registration-company-input"
+          data-testid="registration-company-input"
           @blur="r$.billingAddress.company.$touch()"
           :errorMessage="r$.billingAddress.company.$errors[0]"
         />
@@ -263,7 +263,7 @@ const invokeSubmit = async () => {
           v-model="state.billingAddress.street"
           autocomplete="street-address"
           :label="$t('form.streetAddress')"
-          dataTestId="registration-street-input"
+          data-testid="registration-street-input"
           @blur="r$.billingAddress.street.$touch()"
           :errorMessage="r$.billingAddress.street.$errors[0]"
         />
@@ -274,7 +274,7 @@ const invokeSubmit = async () => {
           id="zipcode"
           v-model="zipcodeModel"
           autocomplete="postal-code"
-          dataTestId="registration-zipcode-input"
+          data-testid="registration-zipcode-input"
           @blur="r$.billingAddress.zipcode.$touch()"
           :errorMessage="r$.billingAddress.zipcode.$errors[0]"
         />
@@ -285,7 +285,7 @@ const invokeSubmit = async () => {
           id="city"
           v-model="state.billingAddress.city"
           autocomplete="address-level2"
-          dataTestId="registration-city-input"
+          data-testid="registration-city-input"
           @blur="r$.billingAddress.city.$touch()"
           :errorMessage="r$.billingAddress.city.$errors[0]"
         />

--- a/templates/vue-starter-template/app/components/account/RegistrationForm.vue
+++ b/templates/vue-starter-template/app/components/account/RegistrationForm.vue
@@ -190,7 +190,7 @@ const invokeSubmit = async () => {
           :label="$t('form.firstName')"
           :errorMessage="r$.firstName.$errors[0]"
           @blur="r$.firstName.$touch()"
-          data-testid="registration-first-name-input"
+          dataTestId="registration-first-name-input"
         />
 
         <FormInputField
@@ -201,7 +201,7 @@ const invokeSubmit = async () => {
           :label="$t('form.lastName')"
           :errorMessage="r$.lastName.$errors[0]"
           @blur="r$.lastName.$touch()"
-          data-testid="registration-last-name-input"
+          dataTestId="registration-last-name-input"
         />
 
         <FormInputField
@@ -212,7 +212,7 @@ const invokeSubmit = async () => {
           :label="$t('form.email')"
           :errorMessage="r$.email.$errors[0]"
           @blur="r$.email.$touch()"
-          data-testid="registration-email-input"
+          dataTestId="registration-email-input"
         />
 
         <FormInputField
@@ -224,7 +224,7 @@ const invokeSubmit = async () => {
           :label="$t('form.password')"
           :errorMessage="r$.password.$errors[0]"
           @blur="r$.password.$touch()"
-          data-testid="registration-password-input"
+          dataTestId="registration-password-input"
         />
 
         <FormInputField
@@ -234,7 +234,7 @@ const invokeSubmit = async () => {
           v-model="vatIdModel"
           :label="$t('form.vatId')"
           @blur="r$.vatIds?.$touch()"
-          data-testid="registration-vatid-input"
+          dataTestId="registration-vatid-input"
         />
       </div>
 
@@ -252,7 +252,7 @@ const invokeSubmit = async () => {
           v-model="companyModel"
           autocomplete="company"
           :label="$t('form.company')"
-          data-testid="registration-company-input"
+          dataTestId="registration-company-input"
           @blur="r$.billingAddress.company.$touch()"
           :errorMessage="r$.billingAddress.company.$errors[0]"
         />
@@ -263,7 +263,7 @@ const invokeSubmit = async () => {
           v-model="state.billingAddress.street"
           autocomplete="street-address"
           :label="$t('form.streetAddress')"
-          data-testid="registration-street-input"
+          dataTestId="registration-street-input"
           @blur="r$.billingAddress.street.$touch()"
           :errorMessage="r$.billingAddress.street.$errors[0]"
         />
@@ -274,7 +274,7 @@ const invokeSubmit = async () => {
           id="zipcode"
           v-model="zipcodeModel"
           autocomplete="postal-code"
-          data-testid="registration-zipcode-input"
+          dataTestId="registration-zipcode-input"
           @blur="r$.billingAddress.zipcode.$touch()"
           :errorMessage="r$.billingAddress.zipcode.$errors[0]"
         />
@@ -285,7 +285,7 @@ const invokeSubmit = async () => {
           id="city"
           v-model="state.billingAddress.city"
           autocomplete="address-level2"
-          data-testid="registration-city-input"
+          dataTestId="registration-city-input"
           @blur="r$.billingAddress.city.$touch()"
           :errorMessage="r$.billingAddress.city.$errors[0]"
         />

--- a/templates/vue-starter-template/app/components/checkout/SummaryBox.vue
+++ b/templates/vue-starter-template/app/components/checkout/SummaryBox.vue
@@ -86,7 +86,7 @@ function handleUpdateQuantity(id: string, quantity: number) {
         <SharedPrice
           :value="totalPrice"
           class="text-right justify-start text-surface-on-surface text-base font-normal leading-normal"
-          data-testid="cart-subtotal"
+          data-testid="cart-total"
         />
       </div>
     </div>

--- a/templates/vue-starter-template/app/components/form/AccountTypeSelect.vue
+++ b/templates/vue-starter-template/app/components/form/AccountTypeSelect.vue
@@ -7,11 +7,7 @@ const model = defineModel<string>({
   required: true,
 });
 
-const {
-  dataTestId = "",
-  id = "",
-  errorMessage = undefined,
-} = defineProps<{
+const { id = "", errorMessage = undefined } = defineProps<{
   dataTestId?: string;
   id?: string;
   errorMessage?: MaybeRef<string>;
@@ -36,7 +32,7 @@ const accountTypeOptions = [
     v-model="model"
     :label="$t('form.accountType.title')"
     :options="accountTypeOptions"
-    :data-testid="dataTestId"
+    :dataTestId="dataTestId"
     :errorMessage="errorMessage"
   />
 </template>

--- a/templates/vue-starter-template/app/components/form/AccountTypeSelect.vue
+++ b/templates/vue-starter-template/app/components/form/AccountTypeSelect.vue
@@ -8,7 +8,6 @@ const model = defineModel<string>({
 });
 
 const { id = "", errorMessage = undefined } = defineProps<{
-  dataTestId?: string;
   id?: string;
   errorMessage?: MaybeRef<string>;
 }>();
@@ -32,7 +31,6 @@ const accountTypeOptions = [
     v-model="model"
     :label="$t('form.accountType.title')"
     :options="accountTypeOptions"
-    :dataTestId="dataTestId"
     :errorMessage="errorMessage"
   />
 </template>

--- a/templates/vue-starter-template/app/components/form/BaseDropdown.vue
+++ b/templates/vue-starter-template/app/components/form/BaseDropdown.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+defineOptions({ inheritAttrs: false });
+
 const { variant = "default" } = defineProps<{
   placeholder?: string;
   options: {
@@ -10,8 +12,6 @@ const { variant = "default" } = defineProps<{
   loading?: boolean;
   autocomplete?: string;
   variant?: "default" | "control";
-  /** Lands on the <select>. A plain data-testid attribute would fall through to the root element. */
-  dataTestId?: string;
 }>();
 
 const model = defineModel<string>({
@@ -27,9 +27,12 @@ const fieldClass = computed(() =>
     ? "border border-outline-outline-variant bg-white text-surface-on-surface"
     : "text-surface-on-surface-variant",
 );
+
+const { wrapperAttrs, controlAttrs } = useControlAttrs();
 </script>
 <template>
   <div
+    v-bind="wrapperAttrs"
     :class="rounded"
     class="focus-within:outline-2 focus-within:outline-outline-outline-focus focus-within:outline focus-within:outline-offset-[2px]"
   >
@@ -44,7 +47,7 @@ const fieldClass = computed(() =>
         :id="id"
         :disabled="loading"
         :autocomplete
-        :data-testid="dataTestId"
+        v-bind="controlAttrs"
       >
         <option v-if="loading" value="" selected disabled>
           {{ $t("form.loading") }}

--- a/templates/vue-starter-template/app/components/form/BaseDropdown.vue
+++ b/templates/vue-starter-template/app/components/form/BaseDropdown.vue
@@ -10,6 +10,8 @@ const { variant = "default" } = defineProps<{
   loading?: boolean;
   autocomplete?: string;
   variant?: "default" | "control";
+  /** Lands on the <select>. A plain data-testid attribute would fall through to the root element. */
+  dataTestId?: string;
 }>();
 
 const model = defineModel<string>({
@@ -42,6 +44,7 @@ const fieldClass = computed(() =>
         :id="id"
         :disabled="loading"
         :autocomplete
+        :data-testid="dataTestId"
       >
         <option v-if="loading" value="" selected disabled>
           {{ $t("form.loading") }}

--- a/templates/vue-starter-template/app/components/form/BaseInput.vue
+++ b/templates/vue-starter-template/app/components/form/BaseInput.vue
@@ -18,6 +18,8 @@ const {
   invalid?: boolean;
   autocomplete?: string;
   id?: string;
+  /** Lands on the <input>. A plain data-testid attribute would fall through to the root element. */
+  dataTestId?: string;
 }>();
 
 const model = defineModel<string>({
@@ -51,6 +53,7 @@ const emit = defineEmits<{
         :placeholder="placeholder"
         :type="type"
         :autocomplete="autocomplete"
+        :data-testid="dataTestId"
         @focus="emit('focus')"
       />
       <slot name="rightIcon" />

--- a/templates/vue-starter-template/app/components/form/BaseInput.vue
+++ b/templates/vue-starter-template/app/components/form/BaseInput.vue
@@ -8,6 +8,8 @@ type InputTypeAttribute =
   | "time"
   | "url";
 
+defineOptions({ inheritAttrs: false });
+
 const {
   placeholder,
   type = "text",
@@ -18,8 +20,6 @@ const {
   invalid?: boolean;
   autocomplete?: string;
   id?: string;
-  /** Lands on the <input>. A plain data-testid attribute would fall through to the root element. */
-  dataTestId?: string;
 }>();
 
 const model = defineModel<string>({
@@ -34,9 +34,12 @@ const slots = defineSlots<{
 const emit = defineEmits<{
   focus: [];
 }>();
+
+const { wrapperAttrs, controlAttrs } = useControlAttrs();
 </script>
 <template>
   <div
+    v-bind="wrapperAttrs"
     class="focus-within:outline-2 focus-within:outline-outline-outline-focus focus-within:outline focus-within:outline-offset-[2px] rounded-lg"
   >
     <div
@@ -53,7 +56,7 @@ const emit = defineEmits<{
         :placeholder="placeholder"
         :type="type"
         :autocomplete="autocomplete"
-        :data-testid="dataTestId"
+        v-bind="controlAttrs"
         @focus="emit('focus')"
       />
       <slot name="rightIcon" />

--- a/templates/vue-starter-template/app/components/form/DropdownField.vue
+++ b/templates/vue-starter-template/app/components/form/DropdownField.vue
@@ -13,6 +13,7 @@ const { errorMessage } = defineProps<{
   loading?: boolean;
   autocomplete?: string;
   variant?: "default" | "control";
+  dataTestId?: string;
 }>();
 
 const model = defineModel<string>({
@@ -41,6 +42,7 @@ const errorText = computed(() => unref(errorMessage));
       :loading
       :autocomplete
       :variant="variant"
+      :dataTestId="dataTestId"
     />
     <span v-if="errorText" class="text-states-error text-xs block mt-1">{{
       errorText

--- a/templates/vue-starter-template/app/components/form/DropdownField.vue
+++ b/templates/vue-starter-template/app/components/form/DropdownField.vue
@@ -1,6 +1,8 @@
 <script lang="ts" setup>
 import type { MaybeRef } from "vue";
 
+defineOptions({ inheritAttrs: false });
+
 const { errorMessage } = defineProps<{
   placeholder?: string;
   label?: string;
@@ -13,7 +15,6 @@ const { errorMessage } = defineProps<{
   loading?: boolean;
   autocomplete?: string;
   variant?: "default" | "control";
-  dataTestId?: string;
 }>();
 
 const model = defineModel<string>({
@@ -21,9 +22,11 @@ const model = defineModel<string>({
 });
 
 const errorText = computed(() => unref(errorMessage));
+
+const { wrapperAttrs, controlAttrs } = useControlAttrs();
 </script>
 <template>
-  <div>
+  <div v-bind="wrapperAttrs">
     <label
       class="text-surface-on-surface text-sm mb-1 block"
       v-if="label"
@@ -42,7 +45,7 @@ const errorText = computed(() => unref(errorMessage));
       :loading
       :autocomplete
       :variant="variant"
-      :dataTestId="dataTestId"
+      v-bind="controlAttrs"
     />
     <span v-if="errorText" class="text-states-error text-xs block mt-1">{{
       errorText

--- a/templates/vue-starter-template/app/components/form/InputField.vue
+++ b/templates/vue-starter-template/app/components/form/InputField.vue
@@ -14,6 +14,7 @@ const {
   type?: "text" | "password" | "email";
   errorMessage?: MaybeRef<string>;
   autocomplete?: string;
+  dataTestId?: string;
 }>();
 
 const model = defineModel<string>({
@@ -40,6 +41,7 @@ const errorText = computed(() => unref(errorMessage));
       :id="id"
       :invalid="!!errorText"
       :autocomplete="autocomplete"
+      :dataTestId="dataTestId"
     />
     <span v-if="errorText" class="text-states-error text-xs block mt-1">{{
       errorText

--- a/templates/vue-starter-template/app/components/form/InputField.vue
+++ b/templates/vue-starter-template/app/components/form/InputField.vue
@@ -1,6 +1,8 @@
 <script lang="ts" setup>
 import type { MaybeRef } from "vue";
 
+defineOptions({ inheritAttrs: false });
+
 const {
   placeholder,
   label = "",
@@ -14,7 +16,6 @@ const {
   type?: "text" | "password" | "email";
   errorMessage?: MaybeRef<string>;
   autocomplete?: string;
-  dataTestId?: string;
 }>();
 
 const model = defineModel<string>({
@@ -22,9 +23,11 @@ const model = defineModel<string>({
 });
 
 const errorText = computed(() => unref(errorMessage));
+
+const { wrapperAttrs, controlAttrs } = useControlAttrs();
 </script>
 <template>
-  <div class="relative">
+  <div v-bind="wrapperAttrs" class="relative">
     <label
       class="text-surface-on-surface text-sm mb-1 block"
       v-if="label"
@@ -41,7 +44,7 @@ const errorText = computed(() => unref(errorMessage));
       :id="id"
       :invalid="!!errorText"
       :autocomplete="autocomplete"
-      :dataTestId="dataTestId"
+      v-bind="controlAttrs"
     />
     <span v-if="errorText" class="text-states-error text-xs block mt-1">{{
       errorText

--- a/templates/vue-starter-template/app/components/form/SalutationSelect.vue
+++ b/templates/vue-starter-template/app/components/form/SalutationSelect.vue
@@ -7,7 +7,6 @@ const model = defineModel<string>({
 
 const { id = "", errorMessage = undefined } = defineProps<{
   id?: string;
-  dataTestId?: string;
   errorMessage?: MaybeRef<string>;
 }>();
 
@@ -63,7 +62,6 @@ const errorMessageText = computed(() => (error ? error : errorMessage));
     v-model="model"
     :label="$t('form.salutation')"
     :options="salutationData?.options ?? []"
-    :dataTestId="dataTestId"
     :loading="isLoading"
   />
   <small v-if="errorMessageText" class="text-states-error">{{

--- a/templates/vue-starter-template/app/components/form/SalutationSelect.vue
+++ b/templates/vue-starter-template/app/components/form/SalutationSelect.vue
@@ -5,11 +5,7 @@ const model = defineModel<string>({
   required: true,
 });
 
-const {
-  id = "",
-  dataTestId = "",
-  errorMessage = undefined,
-} = defineProps<{
+const { id = "", errorMessage = undefined } = defineProps<{
   id?: string;
   dataTestId?: string;
   errorMessage?: MaybeRef<string>;
@@ -67,7 +63,7 @@ const errorMessageText = computed(() => (error ? error : errorMessage));
     v-model="model"
     :label="$t('form.salutation')"
     :options="salutationData?.options ?? []"
-    :data-testid="dataTestId"
+    :dataTestId="dataTestId"
     :loading="isLoading"
   />
   <small v-if="errorMessageText" class="text-states-error">{{

--- a/templates/vue-starter-template/app/components/layout/header/Search.vue
+++ b/templates/vue-starter-template/app/components/layout/header/Search.vue
@@ -85,21 +85,22 @@ const handleEnterKey = () => {
 
 <template>
   <div ref="searchBox">
-    <FormBaseInput
-      id="search-input"
-      v-model="model"
-      :placeholder="$t('search.placeholder')"
-      @click="suggestIsActive = true"
-      @focus="suggestIsActive = true"
-      @keydown.enter="handleEnterKey"
-    >
-      <template #rightIcon>
-        <Icon
-          name="shopware:search-s"
-          class="color-surface-on-surface-variant rotate-90 ml-2"
-        />
-      </template>
-    </FormBaseInput>
+    <div @click="suggestIsActive = true">
+      <FormBaseInput
+        id="search-input"
+        v-model="model"
+        :placeholder="$t('search.placeholder')"
+        @focus="suggestIsActive = true"
+        @keydown.enter="handleEnterKey"
+      >
+        <template #rightIcon>
+          <Icon
+            name="shopware:search-s"
+            class="color-surface-on-surface-variant rotate-90 ml-2"
+          />
+        </template>
+      </FormBaseInput>
+    </div>
 
     <div
       v-if="showSuggest"

--- a/templates/vue-starter-template/app/components/shared/CountryStateInput.vue
+++ b/templates/vue-starter-template/app/components/shared/CountryStateInput.vue
@@ -63,7 +63,7 @@ watch(countryId, (newValue, oldValue) => {
       :placeholder="$t('form.chooseState')"
       :label="$t('form.state')"
       :options="stateOptions"
-      dataTestId="checkout-pi-state-input"
+      data-testid="checkout-pi-state-input"
       :errorMessage="stateIdValidation?.$errors[0]"
     />
   </div>

--- a/templates/vue-starter-template/app/components/shared/CountryStateInput.vue
+++ b/templates/vue-starter-template/app/components/shared/CountryStateInput.vue
@@ -49,7 +49,7 @@ watch(countryId, (newValue, oldValue) => {
       v-model="countryId"
       :label="$t('form.country')"
       :placeholder="$t('form.chooseCountry')"
-      data-testid="country-select"
+      dataTestId="country-select"
       :errorMessage="countryIdValidation?.$errors[0]"
       @states-change="handleStatesChange"
     />
@@ -63,7 +63,7 @@ watch(countryId, (newValue, oldValue) => {
       :placeholder="$t('form.chooseState')"
       :label="$t('form.state')"
       :options="stateOptions"
-      data-testid="checkout-pi-state-input"
+      dataTestId="checkout-pi-state-input"
       :errorMessage="stateIdValidation?.$errors[0]"
     />
   </div>

--- a/templates/vue-starter-template/app/composables/useControlAttrs.ts
+++ b/templates/vue-starter-template/app/composables/useControlAttrs.ts
@@ -1,0 +1,22 @@
+/**
+ * Splits fallthrough attributes for form components that wrap a real control.
+ *
+ * `class` and `style` stay on the wrapper, everything else (`data-*`, `name`,
+ * `required`, `aria-*`, listeners) goes to the `<input>` or `<select>`.
+ * Use it together with `defineOptions({ inheritAttrs: false })`.
+ */
+export function useControlAttrs() {
+  const attrs = useAttrs();
+
+  const wrapperAttrs = computed(() => ({
+    class: attrs.class,
+    style: attrs.style,
+  }));
+
+  const controlAttrs = computed(() => {
+    const { class: _class, style: _style, ...rest } = attrs;
+    return rest;
+  });
+
+  return { wrapperAttrs, controlAttrs };
+}

--- a/templates/vue-starter-template/app/pages/checkout/success/[id]/index.vue
+++ b/templates/vue-starter-template/app/pages/checkout/success/[id]/index.vue
@@ -117,7 +117,7 @@ const formatDate = (date: string) =>
                   v-if="order?.amountTotal"
                   :value="order.amountTotal"
                   class="text-surface-on-surface font-normal"
-                  data-testid="order-subtotal"
+                  data-testid="order-summary-total"
                 />
               </div>
               <div v-if="order?.orderDate" class="text-surface-on-surface">


### PR DESCRIPTION
### Description

Part of #2650.

Every `registration-*-input` test id in `vue-starter-template` selects a `<div>`. `FormInputField` and `FormDropdownField` have a root `<div>`, so a plain `data-testid` attribute falls through to that root and never reaches the `<input>` or `<select>` inside `BaseInput` / `BaseDropdown`.

`country-select` was set twice, on the wrapper in `CountryStateInput` and on the inner input by `CountrySearchSelect`'s own default, so Playwright strict mode throws on it.

Measured in a real browser against a local dev server, before and after.

Before:

```
registration-first-name-input      div
registration-account-type-select   div
country-select                     div, input   <-- 2 matches, strict mode throws
fill() on first-name FAILED: Element is not an <input>, <textarea>, <select> ...
```

After:

```
registration-first-name-input      input
registration-account-type-select   select
country-select                     input
fill() on first-name -> "Ada"
```

### Type of change

Bug fix (non-breaking change that fixes an issue)

### What changed

- `BaseInput` and `BaseDropdown` take a `dataTestId` prop, bound on the `<input>` and the `<select>`
- `InputField` and `DropdownField` forward it
- `SalutationSelect` and `AccountTypeSelect` forward it as a prop instead of as a `data-testid` attribute, and no longer default it to `""`
- `CountryStateInput` uses the prop, which removes the duplicate `country-select`
- The 9 `registration-*-input` attributes in `RegistrationForm` become `dataTestId`

`registration-form` sits on a real `<form>` and `registration-submit-button` on `BaseButton`, whose root is a `<button>`. Both already worked and are untouched.

No new test ids are added here. That is the rest of #2650.

### Second commit: two duplicate test ids

Playwright runs `getByTestId` in strict mode, so a test id that matches twice throws instead of picking one. Two cases were mislabelled rather than merely duplicated:

- `SummaryBox.vue` used `cart-subtotal` on both the subtotal and the total. The total is now `cart-total`.
- The order success page used `order-subtotal` on `order.amountTotal` in the summary header, and again on the real subtotal further down. Both render under the same `v-if`. The header one is now `order-summary-total`.

Neither old id is selected by any spec, so nothing breaks.

Checked and deliberately left alone:

- `order-item-unitprice` and `order-item-totalprice` repeat per line item. They are meant to be multi-match and need `.nth()`.
- The success page skeleton reuses `order-subtotal` and `order-total`, but it lives in `<template #placeholder>` so it never renders beside the real content.
- `PriceSummary` shares those ids but only renders on the account order pages, never on checkout success.
- `CountrySearchSelect` defaults `dataTestId` to `country-select`, so every instance emits it. All three call sites render once per page today. A page with billing and shipping forms would produce two. The default is load-bearing: `CheckoutPage.ts` and `RegisterPage.ts` both select it and checkout's `CustomerAddress` relies on it, so it should not simply be removed.
- `CountryStateInput` hardcodes `id="country"` and `id="state"`. Two instances would give duplicate DOM ids and break `<label for>`. No page renders two today.

### ToDo's

- [ ] Related Issue updated

No changeset. `vue-starter-template` is private and unpublished.

### Additional context

`registration-vatid-input`, `registration-company-input` and `checkout-pi-state-input` do not render on load. They are conditional on a business account type and on a country that has states. They go through the same components, so the same fix covers them.

This gives #2650, #2651 and #2652 a one-line-per-field pattern. Without it every test id those issues add is dead on arrival.
