### PR TITLE
feat: support seo url route names of headless sales channels

### DIFF
--- a/.changeset/headless-seo-route-names.md
+++ b/.changeset/headless-seo-route-names.md
@@ -1,0 +1,6 @@
+---
+"@shopware/helpers": minor
+"@shopware/composables": minor
+---
+
+Support SEO URLs of headless (API type) sales channels. Since shopware/shopware#17991 headless sales channels persist their SEO URLs against the `store-api.*` route family (`store-api.product.detail`, `store-api.category.detail`, `store-api.landing-page.detail`). `useNavigationSearch().resolvePath()` now maps those route names to their `frontend.*` equivalents, so page resolution works unchanged on a headless sales channel. The new `getFrontendRouteName` helper in `@shopware/helpers` exposes the same mapping for custom resolvers.

--- a/apps/docs/src/guides/routing.md
+++ b/apps/docs/src/guides/routing.md
@@ -56,6 +56,10 @@ There are three different type of routes that Shopware natively supports. When t
 - `frontend.navigation.page` - A category page
 - `frontend.landing.page` - A landing page
 
+:::info Headless sales channels
+Headless (API type) sales channels store their SEO URLs with `store-api.*` route names instead (`store-api.product.detail`, `store-api.category.detail`, `store-api.landing-page.detail`). The `resolvePath` function of `useNavigationSearch` maps them to the `frontend.*` equivalents listed above, so your page resolution logic works the same for both sales channel types. If you resolve SEO URLs yourself, use the `getFrontendRouteName` helper from `@shopware/helpers` to apply the same mapping.
+:::
+
 Depending on which type of route you have, the way of fetching the page data is different - because routes don't point to pages. They point to entities that are used to render pages.
 
 Possibly, the easiest approach is to set up a catch-all component, that resolves the route and then renders the correct page component. This is how it could look like:

--- a/packages/composables/src/useNavigationSearch/useNavigationSearch.test.ts
+++ b/packages/composables/src/useNavigationSearch/useNavigationSearch.test.ts
@@ -58,6 +58,27 @@ describe("useNavigationSearch", () => {
       }),
     );
   });
+  it("should map headless sales channel route names to storefront route names", async () => {
+    const { vm, injections } = useSetup(useNavigationSearch);
+    injections.apiClient.invoke.mockResolvedValue({
+      data: {
+        elements: [
+          {
+            ...mockedResponse,
+            routeName: "store-api.product.detail",
+            pathInfo: "/store-api/product/e05e9340aff4484f9009646dfd572df9",
+          },
+        ],
+      },
+    });
+
+    await expect(
+      vm.resolvePath("/Fred-3-Burner-Gas-Grill/941044"),
+    ).resolves.toMatchObject({
+      routeName: "frontend.detail.page",
+      foreignKey: "e05e9340aff4484f9009646dfd572df9",
+    });
+  });
   it("should resolve technical url", async () => {
     const { vm, injections } = useSetup(useNavigationSearch);
     injections.apiClient.invoke.mockResolvedValue({ data: { elements: [] } });

--- a/packages/composables/src/useNavigationSearch/useNavigationSearch.ts
+++ b/packages/composables/src/useNavigationSearch/useNavigationSearch.ts
@@ -1,5 +1,6 @@
 import { encodeForQuery } from "@shopware/api-client/helpers";
 import {
+  getFrontendRouteName,
   getRouteFromPathInfo,
   isTechnicalPath,
   normalizePath,
@@ -63,7 +64,13 @@ export function useNavigationSearch(): UseNavigationSearchReturn {
 
     const element = seoResult.data.elements?.[0];
     if (element) {
-      return element;
+      // headless (API type) sales channels persist SEO URLs against the
+      // store-api.* route family - map them to the frontend.* names the
+      // page resolvers work with
+      return {
+        ...element,
+        routeName: getFrontendRouteName(element.routeName),
+      } as Schemas["SeoUrl"];
     }
 
     const fallback = getRouteFromPathInfo(path);

--- a/packages/helpers/src/getFrontendRouteName.test.ts
+++ b/packages/helpers/src/getFrontendRouteName.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { getFrontendRouteName } from "./getFrontendRouteName";
+
+describe("getFrontendRouteName", () => {
+  it("maps headless product route to the storefront detail page", () => {
+    expect(getFrontendRouteName("store-api.product.detail")).toBe(
+      "frontend.detail.page",
+    );
+  });
+
+  it("maps headless category route to the storefront navigation page", () => {
+    expect(getFrontendRouteName("store-api.category.detail")).toBe(
+      "frontend.navigation.page",
+    );
+  });
+
+  it("maps headless landing page route to the storefront landing page", () => {
+    expect(getFrontendRouteName("store-api.landing-page.detail")).toBe(
+      "frontend.landing.page",
+    );
+  });
+
+  it("keeps storefront route names unchanged", () => {
+    expect(getFrontendRouteName("frontend.detail.page")).toBe(
+      "frontend.detail.page",
+    );
+  });
+
+  it("keeps unknown route names unchanged", () => {
+    expect(getFrontendRouteName("frontend.custom.page")).toBe(
+      "frontend.custom.page",
+    );
+  });
+
+  it("passes undefined through", () => {
+    expect(getFrontendRouteName(undefined)).toBeUndefined();
+  });
+});

--- a/packages/helpers/src/getFrontendRouteName.ts
+++ b/packages/helpers/src/getFrontendRouteName.ts
@@ -1,0 +1,30 @@
+const HEADLESS_ROUTE_NAME_MAP = {
+  "store-api.product.detail": "frontend.detail.page",
+  "store-api.category.detail": "frontend.navigation.page",
+  "store-api.landing-page.detail": "frontend.landing.page",
+} as const;
+
+export type HeadlessRouteName = keyof typeof HEADLESS_ROUTE_NAME_MAP;
+
+/**
+ * Map the SEO URL route name of a headless (API type) sales channel to its
+ * storefront equivalent used for page resolution. Any other route name is
+ * returned unchanged.
+ *
+ * Headless sales channels persist their SEO URLs against the `store-api.*`
+ * route family (see shopware/shopware#17991), while all routing helpers and
+ * page resolvers work with the `frontend.*` names.
+ *
+ * @public
+ * @category Routing
+ */
+export function getFrontendRouteName(routeName: string): string;
+export function getFrontendRouteName(
+  routeName: string | undefined,
+): string | undefined;
+export function getFrontendRouteName(
+  routeName: string | undefined,
+): string | undefined {
+  if (!routeName) return routeName;
+  return HEADLESS_ROUTE_NAME_MAP[routeName as HeadlessRouteName] ?? routeName;
+}

--- a/packages/helpers/src/index.test.ts
+++ b/packages/helpers/src/index.test.ts
@@ -30,6 +30,7 @@ describe("helpers - test global API", () => {
         "getCmsLayoutConfiguration": [Function],
         "getCmsTranslate": [Function],
         "getFormattedPrice": [Function],
+        "getFrontendRouteName": [Function],
         "getLanguageName": [Function],
         "getListingFilters": [Function],
         "getMainImageUrl": [Function],

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -2,6 +2,7 @@ export * from "./product";
 export * from "./category";
 export * from "./ui-interfaces";
 export * from "./cms";
+export * from "./getFrontendRouteName";
 export * from "./getRouteFromPathInfo";
 export * from "./getTranslatedProperty";
 export * from "./listing";


### PR DESCRIPTION
### Description

Since shopware/shopware#17991 (upcoming 6.7.14), headless (API type) sales channels persist their SEO URLs against the `store-api.*` route family: `store-api.product.detail`, `store-api.category.detail` and `store-api.landing-page.detail`. The `/store-api/seo-url` endpoint returns those rows as-is, so on a headless sales channel `resolvePath()` hands a `store-api.*` route name to the page resolver, `pascalCase()` turns it into `StoreApiProductDetail`, and the catch-all page fails with `Problem resolving component: StoreApiProductDetail`.

This PR maps the headless route names to their storefront equivalents at the resolution boundary:

- new `getFrontendRouteName` helper in `@shopware/helpers` (`store-api.product.detail` → `frontend.detail.page` etc.; any other route name passes through unchanged),
- `useNavigationSearch().resolvePath()` normalizes the route name of the resolved `SeoUrl` entity,
- a note in the routing guide.

Everything downstream — the catch-all page resolver, `useNavigationContext`, CMS page rendering, history-state navigation — keeps working unchanged for both sales channel types.

This is part of finishing headless sales channel support for Composable Frontends: relates to shopware/shopware#19685 (core-side PRs: shopware/shopware#19686, shopware/shopware#19688). The end goal is dropping the ["use the Storefront type" workaround](https://developer.shopware.com/frontends/resources/troubleshooting.html#which-saleschannel-type-to-use-for-composable-frontends) from the troubleshooting guide.

### Type of change

New feature (non-breaking change which adds functionality)

### ToDo's

- [x] Changeset file provided [read more](https://github.com/shopware/frontends/blob/main/CONTRIBUTION.md#changelog-preparation)
- [x] Documentation added/updated
- [x] Unit-Tests added/updated
- [ ] Update the sales-channel-type troubleshooting entry once the core-side PRs are merged and released

### Additional context

The mapping is inert on Storefront-type channels and on Shopware < 6.7.14 (no `store-api.*` rows exist there), so the change is safe to merge independently of the core PRs — opening as a draft anyway until the core side settles.

Two things intentionally left out to keep this minimal, happy to follow up if wanted:

- Technical-path entry URLs (`/detail/{id}`) don't get a canonical 301 redirect on headless channels, because the persisted `pathInfo` is `/store-api/product/{id}` and the `pathInfo` lookup misses. The synthetic fallback still renders the page correctly.
- The generated `SeoUrl.routeName` type union in `storeApiTypes.d.ts` doesn't include the `store-api.*` values; that mirrors the core OpenAPI schema, so it likely deserves a core-side schema fix rather than a hand edit here.

**Open question on the mapping direction.** Mapping `store-api.*` onto `frontend.*` is a deliberate compatibility choice, not a statement that the storefront names are the "right" ones: `frontend.*` is what the page-resolver component names (`FrontendDetailPage` & co.), the routing guide's switch examples, and `getProductRoute`/`getCategoryRoute` history state are all built on, in this repo and in every downstream project. Long term — once headless sales channels are the recommended setup — it may be worth flipping the canonical vocabulary: treat `store-api.*` (or better, an abstract page type like `product`/`category`/`landing`, as already hinted at in `composables/src/types/index.ts`) as the primary identifier and keep `frontend.*` as the legacy alias for Storefront-type channels. That's a breaking, major-version decision that affects template component naming, so this PR only introduces the boundary normalization that would make such a flip a one-map change later. Happy to draft that follow-up if the team wants to go there.
