### PR TITLE
chore(ci): raise the code-check job timeout to 25 minutes

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     name: Build
-    timeout-minutes: 15
+    timeout-minutes: 25
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
@@ -52,7 +52,7 @@ jobs:
 
   test:
     name: Test
-    timeout-minutes: 15
+    timeout-minutes: 25
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
### Description

`Build` timed out four times on #2693, and not because of the code.

`pnpm/action-setup` has been stalling on its `npm install` since 2026-09-04 (`added 1 package in 7m`, versus 13s on main). Cold PR builds already need 8-11m, so a 15m cap leaves no slack and `Typecheck` gets killed mid-step.

25m absorbs it. `Test` raised too: same cap, same exposure.

### Type of change

Bug fix (non-breaking change that fixes an issue)

### Additional context

CI config only, no changeset. Does not fix the npm stall itself, just stops it failing unrelated PRs.
