### PR TITLE
ci: serialize Nuxt build and typecheck for examples

### DIFF
--- a/.github/scripts/ci-turbo.sh
+++ b/.github/scripts/ci-turbo.sh
@@ -31,5 +31,11 @@ else
   use_full_packages_and_templates
 fi
 
-echo "turbo run $* ${filters[*]}" >&2
-exec pnpm exec turbo run "$@" "${filters[@]}"
+# Run tasks one at a time. `turbo run build typecheck` would schedule a Nuxt
+# app's `nuxt build` and `nuxi typecheck` together; both write `.nuxt/` and
+# race (TS6053: nuxt.node.d.ts not found).
+echo "turbo filters: ${filters[*]}" >&2
+for task in "$@"; do
+  echo "turbo run ${task} ${filters[*]}" >&2
+  pnpm exec turbo run "${task}" "${filters[@]}"
+done

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -6,6 +6,10 @@ on:
     paths-ignore:
       - "apps/**"
       - "**.md"
+  pull_request:
+    paths:
+      - "examples/**"
+      - ".github/workflows/examples.yml"
   workflow_dispatch:
 
 concurrency:
@@ -29,5 +33,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - uses: ./.github/actions/setup
-      - name: Build and typecheck examples
-        run: pnpm exec turbo run build typecheck --filter='./examples/*'
+      # Sequential: build and typecheck both write `.nuxt/` in each example.
+      # Running them in one turbo graph races (TS6053: nuxt.node.d.ts not found).
+      - name: Build examples
+        run: pnpm exec turbo run build --filter='./examples/*'
+      - name: Typecheck examples
+        run: pnpm exec turbo run typecheck --filter='./examples/*'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The new **Examples** workflow on `main` failed: `example-sanity-cms#typecheck` with

```
error TS6053: File '.../examples/sanity-cms/.nuxt/nuxt.node.d.ts' not found.
```

Cause: `turbo run build typecheck` schedules a Nuxt app’s `nuxt prepare && nuxt build` and `nuxt prepare && nuxi typecheck` at the same time. Both write `.nuxt/`. Typecheck then sees a torn `tsconfig.node.json` / missing `nuxt.node.d.ts`.

`example-sanity-cms` typecheck passes in isolation.

## Fix

- Run **build**, then **typecheck**, as separate Turbo invocations (examples workflow and `ci-turbo.sh` used by PR CI).
- Also run Examples on PRs that touch `examples/**` or this workflow, so this race is caught before merge.

Failed run: https://github.com/shopware/frontends/actions/runs/34198940299

## Type of change

CI / maintenance

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a9f6edf-39fb-413d-96a4-61782e3ec898?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a9f6edf-39fb-413d-96a4-61782e3ec898&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

