### PR TITLE
chore: align Dependabot cooldown with pnpm supply-chain policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,11 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 2
     versioning-strategy: "increase"
+    # Match pnpm-workspace.yaml minimumReleaseAge (4320 min = 3 days). Do not set
+    # this higher: Dependabot injects the longer gate, lockfile verification can
+    # fail, and it retries ungated. Security updates are exempt.
     cooldown:
-      default-days: 4
+      default-days: 3
       exclude:
         - "@shopware/*"
     ignore:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,8 @@ packages:
   - "templates/*"
   - "examples/*"
 
-# Reduciing the risk of installing fresh compromised packages before detected
+# Reducing the risk of installing fresh compromised packages before detected.
+# Keep .github/dependabot.yml cooldown.default-days in lockstep (4320 min = 3 days).
 minimumReleaseAge: 4320 ## 3 days
 minimumReleaseAgeExclude:
   - "@shopware/*"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Set Dependabot `cooldown.default-days` to **3** so it matches `pnpm-workspace.yaml` `minimumReleaseAge: 4320` (3 days) instead of the previous 4-day buffer.

This only delays **version-update PRs for the direct dependency being bumped**. `@shopware/*` stays excluded, matching `minimumReleaseAgeExclude`. Security updates remain exempt (GitHub’s rule).

It does **not** stop PRs like [#2715](https://github.com/shopware/frontends/pull/2715). That bump was `sharp` 0.35.3 → 0.35.4, already 13 days old — well past both the 3- and 4-day windows — so cooldown would still have opened it. CI failed because Dependabot also rewrote `pnpm-lock.yaml` with unrelated transitives published hours earlier (`nypm@0.6.10`, `@inquirer/*`, `@types/node@26.5.0`). That lockfile path is outside `cooldown.default-days`; Dependabot already had a 4-day cooldown when #2715 opened.

### Type of change

Chore / maintenance (repository automation only)

### ToDo's

No changeset — this does not change a published package.

### Additional context

A longer Dependabot cooldown than pnpm’s gate can make Dependabot inject `--config.minimumReleaseAge` above 4320 minutes, fail lockfile verification, and retry ungated. Matching 3 days avoids that mismatch for direct version updates. It is not a fix for lockfile-transitive policy violations.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2051bc5a-9dcc-4900-996e-3d2aa31340ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2051bc5a-9dcc-4900-996e-3d2aa31340ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

